### PR TITLE
Add tls support to fig

### DIFF
--- a/doc/fig-documentation/docs/guides/configuring-tls.md
+++ b/doc/fig-documentation/docs/guides/configuring-tls.md
@@ -1,0 +1,86 @@
+---
+sidebar_position: 5
+
+
+
+---
+# Configuring TLS
+
+Fig is able to run both its api and web instances with TLS enabled, provided the required environment variables and pem encoded certificate files are made available. This is aimed at use within docker containers, but equivalent configuration on host environments such as windows will also work for the api, but not the web instance.
+
+## Fig-Api
+
+To enable this within the Fig-Api docker container:
+
+1. Define the SSL_CERT_PATH, SSL_KEY_PATH, and FIG_API_SSL_PORT environment variables:
+   - SSL_CERT_PATH: The path to the full chain pem encoded certificate
+   - SSL_KEY_PATH: The path to the pem encoded private key
+   - FIG_API_SSL_PORT: The port that the api will listen on for https requests
+
+2. Mount the pem encoded certificate and key at the paths defined in the corresponding path variables
+3. Update the port mapping and health check to match the https port that Fig-Api is now listening at. Below is an example docker-compose file snippet representing the required configuration.
+
+```
+fig-api:
+  image: mzbrau/fig-api:latest
+  container_name: fig-api
+  ports:
+    - "7281:7148"
+  depends_on:
+    fig-setup:
+      condition: service_completed_successfully
+  environment:
+    - ApiSettings:DbConnectionString=Server=${fqdn};User Id=${FIG_USER_NAME};Password=${FIG_DB_PWD};Initial Catalog=${FIG_DB_NAME}
+    - SSL_CERT_PATH=/usr/bin/certs/fig.pem
+    - SSL_KEY_PATH=/usr/bin/certs/fig.key
+    - FIG_API_SSL_PORT=7148
+  volumes:
+    - ./fig.pem:/usr/bin/certs/fig.pem
+    - ./fig.key:/usr/bin/certs/fig.key
+  healthcheck:
+    test: ["CMD", "curl", "-f", "https://localhost:7148/_health"]
+    start_period: 30s
+    interval: 5s
+    timeout: 10s
+    retries: 3
+```
+
+## Fig-Web
+
+To enable this within the Fig-Web docker container:
+
+1. Define the SSL_CERT_PATH, SSL_KEY_PATH, FIG_API_SSL_PORT, and optionally SSL_TRUSTED_CERT_PATH environment variables:
+   - SSL_CERT_PATH: The path to the full chain pem encoded certificate
+   - SSL_KEY_PATH: The path to the pem encoded private key
+   - FIG_API_SSL_PORT: The port that the web instance will run on
+   - SSL_TRUSTED_CERT_PATH: The path to a pem encoded trusted certificate.
+
+2. Mount the pem encoded certificate, key, and optionally trusted certificate at the paths defined in the corresponding path variables
+3. Update the port mapping and health check to match the https port that Fig-Web is now listening at. Below is an example docker-compose file snippet representing the required configuration.
+
+```
+fig-web:
+  image: mzbrau/fig-web:latest
+  container_name: fig-web
+  ports:
+    - "7148:443"
+  depends_on:
+    fig-api:
+      condition: service_healthy
+  environment:
+    - FIG_API_URI=https://localhost:7281
+    - SSL_CERT_PATH=/usr/local/nginx/certs/fig.pem
+    - SSL_KEY_PATH=/usr/local/nginx/certs/fig.key
+    - SSL_TRUSTED_CERT_PATH=/usr/local/nginx/certs/ca.pem
+    - FIG_WEB_SSL_PORT=443
+  volumes:
+    - ./fig.key:/usr/local/nginx/certs/fig.key
+    - ./fig.pem:/usr/local/nginx/certs/fig.pem
+    - ./ca.pem:/usr/local/nginx/certs/ca.pem
+  healthcheck:
+    test: ["CMD", "curl", "-f", "https://localhost:443"]
+    start_period: 30s      
+    interval: 5s
+    timeout: 10s
+    retries: 3
+```

--- a/doc/fig-documentation/docs/security.md
+++ b/doc/fig-documentation/docs/security.md
@@ -39,3 +39,4 @@ The following recommendations will ensure your application settings are as safe 
 1. **Protect client secrets** - Client secrets protect the values for that client and as a result, they should be kept secret. Fig supports 4 ways of reading client secrets. For windows installations, the DPAPI is the recommended way to store secrets. It will protect them for the user. For other installations, a secret store pushing to an environment variable or appsettings.json file is recommended.
 1. **Web Hook Alerts** - Setting up web hook alerts will ensure you are kept informed if settings are changed.
 1. **Disable Client Overrides** - If client overrides are not being used, disable this feature or at least limit it to the clients that should have access. This can avoid unwanted consequences.
+1. **Enable TLS** - Fig supports TLS for both the Web and Api instances. See [the guide](http://www.figsettings.com/docs/guides/configuring-tls) for steps and example config.

--- a/src/api/Fig.Api/Program.cs
+++ b/src/api/Fig.Api/Program.cs
@@ -15,6 +15,7 @@ using Fig.Api.SettingVerification.Converters;
 using Fig.Api.SettingVerification.ExtensionMethods;
 using Fig.Api.Utils;
 using Fig.Api.Validators;
+using Fig.Api.WebHost;
 using Fig.Common;
 using Fig.Common.NetStandard.Cryptography;
 using Fig.Common.NetStandard.Diag;
@@ -164,6 +165,8 @@ builder.Services.AddSwaggerGen();
 
 builder.Services.AddHealthChecks()
     .AddCheck<DatabaseHealthCheck>("Database");
+
+builder.WebHost.ConfigureHttpsListener();
 
 var app = builder.Build();
 

--- a/src/api/Fig.Api/Program.cs
+++ b/src/api/Fig.Api/Program.cs
@@ -166,7 +166,7 @@ builder.Services.AddSwaggerGen();
 builder.Services.AddHealthChecks()
     .AddCheck<DatabaseHealthCheck>("Database");
 
-builder.WebHost.ConfigureHttpsListener();
+builder.WebHost.ConfigureHttpsListener(logger);
 
 var app = builder.Build();
 

--- a/src/api/Fig.Api/WebHost/ConfigureHttps.cs
+++ b/src/api/Fig.Api/WebHost/ConfigureHttps.cs
@@ -1,0 +1,25 @@
+﻿using System.Security.Cryptography.X509Certificates;
+
+namespace Fig.Api.WebHost
+{
+    public static class ConfigureHttps
+    {
+        public static void ConfigureHttpsListener(this ConfigureWebHostBuilder builder)
+        {
+            var certPath = Environment.GetEnvironmentVariable("SSL_CERT_PATH");
+            var keyPath = Environment.GetEnvironmentVariable("SSL_KEY_PATH");
+            if (certPath != null && keyPath != null && int.TryParse(Environment.GetEnvironmentVariable("FIG_API_SSL_PORT"), out int sslPort))
+            {
+                builder.ConfigureKestrel((context, serverOptions) =>
+                {
+                    var exportableCert = new X509Certificate2(X509Certificate2.CreateFromPemFile(certPath, keyPath).Export(X509ContentType.Pfx, ""), "", X509KeyStorageFlags.Exportable);
+                    serverOptions.Configure()
+                    .AnyIPEndpoint(sslPort, listenOptions =>
+                    {
+                        listenOptions.UseHttps(exportableCert);
+                    });
+                });
+            }
+        }
+    }
+}

--- a/src/web/Fig.Web/Dockerfile
+++ b/src/web/Fig.Web/Dockerfile
@@ -19,6 +19,8 @@ FROM nginx:alpine AS final
 WORKDIR /usr/share/nginx/html
 COPY --from=publish /app/publish/wwwroot .
 COPY ["web/Fig.Web/nginx.conf", "/etc/nginx/nginx.conf"]
+COPY ["web/Fig.Web/ssl.conf.template", "/etc/templates/ssl.conf.template"]
+COPY ["web/Fig.Web/ssl_ca.conf.template", "/etc/templates/ssl_ca.conf.template"]
 COPY ["web/Fig.Web/entrypoint.sh", "/entrypoint.sh"]
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT [ "/entrypoint.sh"]

--- a/src/web/Fig.Web/entrypoint.sh
+++ b/src/web/Fig.Web/entrypoint.sh
@@ -2,11 +2,21 @@
 
 sed -i "s|https:\/\/localhost:7281|$FIG_API_URI|g" /usr/share/nginx/html/appsettings.json
 
-if [ -n "$FIG_WEB_SSL_PORT" ]; then
+if [ -n "$FIG_WEB_SSL_PORT" ] && [ -n "$SSL_CERT_PATH" ] && [ -n "$SSL_KEY_PATH" ]; then
   if [ -n "$SSL_TRUSTED_CERT_PATH" ]; then
     envsubst '\$FIG_WEB_SSL_PORT \$SSL_CERT_PATH \$SSL_KEY_PATH \$SSL_TRUSTED_CERT_PATH' < /etc/templates/ssl_ca.conf.template > /etc/nginx/conf.d/ssl_ca.conf
   else
     envsubst '\$FIG_WEB_SSL_PORT \$SSL_CERT_PATH \$SSL_KEY_PATH' < /etc/templates/ssl.conf.template > /etc/nginx/conf.d/ssl.conf
+  fi
+else
+  if [ -z "$FIG_WEB_SSL_PORT" ]; then
+    echo "[wrn] Environment variable FIG_WEB_SSL_PORT is not set. Unable to configure fig for https."
+  fi
+  if [ -z "$SSL_CERT_PATH" ]; then
+    echo "[wrn] Environment variable SSL_CERT_PATH is not set. Unable to configure fig for https."
+  fi
+  if [ -z "$SSL_KEY_PATH" ]; then
+    echo "[wrn] Environment variable SSL_KEY_PATH is not set. Unable to configure fig for https."
   fi
 fi
 

--- a/src/web/Fig.Web/entrypoint.sh
+++ b/src/web/Fig.Web/entrypoint.sh
@@ -1,5 +1,14 @@
 #!/bin/sh
 
 sed -i "s|https:\/\/localhost:7281|$FIG_API_URI|g" /usr/share/nginx/html/appsettings.json
+
+if [ -n "$FIG_WEB_SSL_PORT" ]; then
+  if [ -n "$SSL_TRUSTED_CERT_PATH" ]; then
+    envsubst '\$FIG_WEB_SSL_PORT \$SSL_CERT_PATH \$SSL_KEY_PATH \$SSL_TRUSTED_CERT_PATH' < /etc/templates/ssl_ca.conf.template > /etc/nginx/conf.d/ssl_ca.conf
+  else
+    envsubst '\$FIG_WEB_SSL_PORT \$SSL_CERT_PATH \$SSL_KEY_PATH' < /etc/templates/ssl.conf.template > /etc/nginx/conf.d/ssl.conf
+  fi
+fi
+
 sh -c "/docker-entrypoint.sh"
 nginx -g "daemon off;"

--- a/src/web/Fig.Web/nginx.conf
+++ b/src/web/Fig.Web/nginx.conf
@@ -1,6 +1,7 @@
 events { }
 http {
     include mime.types;
+    include /etc/nginx/conf.d/ssl*.conf;
 
     server {
         listen 80;

--- a/src/web/Fig.Web/ssl.conf.template
+++ b/src/web/Fig.Web/ssl.conf.template
@@ -1,0 +1,11 @@
+server {
+    listen               $FIG_WEB_SSL_PORT ssl;
+    ssl_certificate      $SSL_CERT_PATH;
+    ssl_certificate_key  $SSL_KEY_PATH;
+    ssl_protocols        TLSv1.3;
+
+    location / {
+        root /usr/share/nginx/html;
+        try_files $uri $uri/ /index.html =404;
+    }
+}

--- a/src/web/Fig.Web/ssl_ca.conf.template
+++ b/src/web/Fig.Web/ssl_ca.conf.template
@@ -1,0 +1,12 @@
+server {
+    listen                  $FIG_WEB_SSL_PORT ssl;
+    ssl_certificate         $SSL_CERT_PATH;
+    ssl_certificate_key     $SSL_KEY_PATH;
+    ssl_protocols           TLSv1.3;
+    ssl_trusted_certificate $SSL_TRUSTED_CERT_PATH;
+
+    location / {
+        root /usr/share/nginx/html;
+        try_files $uri $uri/ /index.html =404;
+    }
+}


### PR DESCRIPTION
Changes Add TLS support to Fig, when environment variables and files are provided in the host environment running fig (mainly with docker containers in mind). This is only added conditionally though, requiring all the appropriate environment variables to be correctly defined and PEM style certificate files to be made available.

I tested the changes for Fig.Api by locally building a new instance of the docker image, however I found that for the latest code on main Fig.Web was not working as expected (regardless of whether my changes were involved), with nothing but the initial landing page with the large Favicon icon being displayed, so have tested this by mounting the new nginx config files and entrypoint script to the latest available image of Fig.Web which worked as expected.

I need to add documentation relating to the process of enabling TLS, but I'm not sure where would be best to add that. Is there an existing .md file that you think would suit, or should I add a new one specifically for this @mzbrau?