### PR TITLE
Add fig provider before Build is called

### DIFF
--- a/doc/fig-documentation/docs/client-configuration.md
+++ b/doc/fig-documentation/docs/client-configuration.md
@@ -15,7 +15,7 @@ var configuration = new ConfigurationBuilder()
     .AddFig<Settings>(o =>
     {
         o.ClientName = "<YOUR CLIENT NAME>";
-    }).Build();
+    });
 ```
 
 :::tip My tip
@@ -55,7 +55,7 @@ You can disable Fig by removing the FIG_API_URI environment variable. This is us
     {
         o.ClientName = "AspNetApi";
         o.ClientSecretOverride = "d4b0b76dfb5943f3b0ab6a7f70b6ffa0";
-    }).Build();
+    });
    ```
 
 7. It is recommended that you validate the settings when they are changed. To add this functionality, add the following in `program.cs`:
@@ -71,7 +71,7 @@ You can disable Fig by removing the FIG_API_URI environment variable. This is us
     {
         o.ClientName = "AspNetApi";
         o.SupportsRestart = true;
-    }).Build();
+    });
    
    builder.Host.UseFigRestart<Settings>();
    ```

--- a/doc/fig-documentation/docs/features/client-management.md
+++ b/doc/fig-documentation/docs/features/client-management.md
@@ -19,7 +19,7 @@ var configuration = new ConfigurationBuilder()
         o.ClientName = "AspNetApi";
         o.SupportsRestart = true;
         o.VersionType = VersionType.File;
-    }).Build();
+    });
 ```
 
 The version can also be overridden in the fig configuration. For example:
@@ -31,7 +31,7 @@ var configuration = new ConfigurationBuilder()
         o.ClientName = "AspNetApi";
         o.SupportsRestart = true;
         o.VersionOverride = "v6";
-    }).Build();
+    });
 ```
 
 It is possible to restart clients if the restart requested event is subscribed to. To add this functionally, add the following in your `program.cs` file:

--- a/doc/fig-documentation/docs/features/live-reload.md
+++ b/doc/fig-documentation/docs/features/live-reload.md
@@ -14,7 +14,7 @@ var configuration = new ConfigurationBuilder()
     {
         o.ClientName = "AspNetApi";
         o.LiveReload = false;
-    }).Build();
+    });
 ```
 
 Note that this will only change the 'default' value for the client. It might be overridden by the Fig web application if the setting is changed there.

--- a/doc/fig-documentation/docs/features/offline-settings.md
+++ b/doc/fig-documentation/docs/features/offline-settings.md
@@ -16,6 +16,6 @@ var configuration = new ConfigurationBuilder()
     {
         o.ClientName = "AspNetApi";
         o.AllowOfflineSettings = false;
-    }).Build();
+    });
 ```
 

--- a/doc/fig-documentation/docs/guides/integration-testing.md
+++ b/doc/fig-documentation/docs/guides/integration-testing.md
@@ -24,8 +24,7 @@ To get started, do the following.
        {
            options.ClientName = "AspNetApi";
            options.CommandLineArgs = args;
-       })
-       .Build();
+       });
    ```
 
    Then, in your integration test, add the following line into your WebApplicationFactory setup:

--- a/doc/fig-documentation/docs/intro.md
+++ b/doc/fig-documentation/docs/intro.md
@@ -67,7 +67,7 @@ In this guide, we'll create an ASP.NET project from scratch and integrate the Fi
     .AddFig<Settings>(o =>
     {
         o.ClientName = "AspNetApi";
-    }).Build();
+    });
    ```
 
 6. Access the settings via the IOptions or IOptionsMonitor interface. E.g.

--- a/examples/Fig.Examples.AspNetApi/Program.cs
+++ b/examples/Fig.Examples.AspNetApi/Program.cs
@@ -28,8 +28,7 @@ builder.Configuration.SetBasePath(GetBasePath())
         options.ClientName = "AspNetApi";
         options.LoggerFactory = loggerFactory;
         options.CommandLineArgs = args;
-    })
-    .Build();
+    });
 
 builder.Host.UseSerilog(serilogLogger);
 

--- a/src/client/Fig.Client/ConfigurationProvider/FigConfigurationBuilder.cs
+++ b/src/client/Fig.Client/ConfigurationProvider/FigConfigurationBuilder.cs
@@ -26,15 +26,7 @@ public class FigConfigurationBuilder : IConfigurationBuilder
         _figOptions = figOptions ?? throw new ArgumentNullException(nameof(figOptions));
         _settingsType = settingsType;
         ValidateClientName();
-    }
-
-    public IConfigurationBuilder Add(IConfigurationSource source)
-    {
-        return _configurationBuilder.Add(source);
-    }
-
-    public IConfigurationRoot Build()
-    {
+ 
         var source = new FigConfigurationSource
         {
             LoggerFactory = _figOptions.LoggerFactory ?? new NullLoggerFactory(),
@@ -66,8 +58,6 @@ public class FigConfigurationBuilder : IConfigurationBuilder
         {
             Add(source);
         }
-
-        return _configurationBuilder.Build();
 
         bool IsFigApiUriValid(List<string>? uris)
         {
@@ -104,6 +94,16 @@ public class FigConfigurationBuilder : IConfigurationBuilder
 
             return null;
         }
+    }
+
+    public IConfigurationBuilder Add(IConfigurationSource source)
+    {
+        return _configurationBuilder.Add(source);
+    }
+
+    public IConfigurationRoot Build()
+    {
+        return _configurationBuilder.Build();
     }
 
     private void ValidateClientName()

--- a/src/integrations/Fig.Integration.SqlLookupTableService/Program.cs
+++ b/src/integrations/Fig.Integration.SqlLookupTableService/Program.cs
@@ -29,8 +29,7 @@ builder.Configuration.SetBasePath(GetBasePath())
         options.ClientName = "SqlLookupTableService";
         options.LoggerFactory = loggerFactory;
         options.CommandLineArgs = args;
-    })
-    .Build();
+    });
 
 builder.Host.UseSerilog(serilogLogger);
 


### PR DESCRIPTION
Eliminates the need to manually build the
configuration object when bootstrapping the app