### PR TITLE
Fix null ref problems when closing dialogs with [X] button

### DIFF
--- a/src/web/Fig.Web/Pages/Setting/Settings.razor
+++ b/src/web/Fig.Web/Pages/Setting/Settings.razor
@@ -239,7 +239,7 @@ else
                         <RadzenButton Text="Yes" Click="() => ds.Close(true)" Class="mr-1" Style="width: 80px;"/>
         </div>
         </div>
-        </div>);
+        </div>) ?? false;
     }
 
     async Task ShowDescription(string? clientName, string? description)
@@ -273,7 +273,7 @@ else
                         <RadzenButton Text="Cancel" Click="() => ds.Close(false)" ButtonStyle="ButtonStyle.Secondary" Class="mr-1"/>
         </div>
         </div>
-        </div>);
+        </div>) ?? false;
     }
 
     async Task<bool?> AskUserForChangeMessage(List<ChangeModel> changeModels)


### PR DESCRIPTION
When closing any of the two dialogs, Delete Confirmation and Get Instance Name, in Fig UI using the [X] button, `DialogService.OpenAsync` returns null and conversion to a bool fails, leaving the client in an Oops'ed state.