### PR TITLE
Add support for 2 new properties in SettingsBase LastFigUpdateUtc and FigSettingsLoadType. These enable applications to understand if settings have been successfully loaded or not.

### DIFF
--- a/doc/fig-documentation/docs/features/29-metadata-properties.md
+++ b/doc/fig-documentation/docs/features/29-metadata-properties.md
@@ -1,0 +1,211 @@
+---
+sidebar_position: 29
+sidebar_label: Metadata Properties
+---
+
+# Metadata Properties
+
+Fig automatically tracks when your settings are loaded and updated, providing you with metadata about the state of your configuration. This feature is particularly useful for monitoring, debugging, and implementing health checks in your applications.
+
+## Available Properties
+
+All settings classes that inherit from `SettingsBase` automatically include two properties that provide information about the last update:
+
+### LastFigUpdateUtc
+
+A `DateTime?` property that indicates when the settings were last successfully loaded or updated.
+
+```csharp
+public class MySettings : SettingsBase
+{
+    public string DatabaseConnection { get; set; }
+    public int RetryCount { get; set; }
+    
+    // Inherited from SettingsBase
+    // public DateTime? LastFigUpdateUtc { get; }
+}
+
+// Usage
+var settings = serviceProvider.GetRequiredService<IOptionsMonitor<MySettings>>();
+var lastUpdate = settings.CurrentValue.LastFigUpdateUtc;
+
+if (lastUpdate.HasValue)
+{
+    Console.WriteLine($"Settings last updated: {lastUpdate.Value:yyyy-MM-dd HH:mm:ss} UTC");
+}
+else
+{
+    Console.WriteLine("Settings have not been successfully loaded");
+}
+```
+
+### FigSettingLoadType
+
+An enum property that indicates how the settings were loaded. This helps you understand whether your application is running with the latest server configuration or fallback values.
+
+```csharp
+public enum LoadType
+{
+    None,    // Settings failed to load completely
+    Server,  // Settings loaded from Fig API
+    Offline  // Settings loaded from offline cache
+}
+
+// Usage
+var settings = serviceProvider.GetRequiredService<IOptionsMonitor<MySettings>>();
+var loadType = settings.CurrentValue.FigSettingLoadType;
+
+switch (loadType)
+{
+    case LoadType.Server:
+        Console.WriteLine("✓ Running with latest settings from Fig API");
+        break;
+    case LoadType.Offline:
+        Console.WriteLine("⚠ Running with cached settings (API unavailable)");
+        break;
+    case LoadType.None:
+        Console.WriteLine("❌ Running with default values (no settings loaded)");
+        break;
+}
+```
+
+## Common Use Cases
+
+### Health Checks
+
+Use these properties to implement health checks that verify your application has successfully loaded recent settings:
+
+```csharp
+public class SettingsHealthCheck : IHealthCheck
+{
+    private readonly IOptionsMonitor<MySettings> _settings;
+    private readonly TimeSpan _maxAge;
+
+    public SettingsHealthCheck(IOptionsMonitor<MySettings> settings)
+    {
+        _settings = settings;
+        _maxAge = TimeSpan.FromMinutes(30); // Consider settings stale after 30 minutes
+    }
+
+    public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, 
+        CancellationToken cancellationToken = default)
+    {
+        var currentSettings = _settings.CurrentValue;
+        
+        // Check if settings loaded successfully
+        if (currentSettings.FigSettingLoadType == LoadType.None)
+        {
+            return Task.FromResult(HealthCheckResult.Unhealthy(
+                "Fig settings failed to load"));
+        }
+        
+        // Check if settings are recent
+        if (currentSettings.LastFigUpdateUtc.HasValue)
+        {
+            var age = DateTime.UtcNow - currentSettings.LastFigUpdateUtc.Value;
+            if (age > _maxAge)
+            {
+                return Task.FromResult(HealthCheckResult.Degraded(
+                    $"Fig settings are {age.TotalMinutes:F1} minutes old"));
+            }
+        }
+        
+        var message = currentSettings.FigSettingLoadType == LoadType.Server 
+            ? "Fig settings loaded from server" 
+            : "Fig settings loaded from offline cache";
+            
+        return Task.FromResult(HealthCheckResult.Healthy(message));
+    }
+}
+```
+
+### Monitoring and Alerting
+
+Monitor your application's configuration state:
+
+```csharp
+public class SettingsMonitor
+{
+    private readonly IOptionsMonitor<MySettings> _settings;
+    private readonly ILogger<SettingsMonitor> _logger;
+
+    public SettingsMonitor(IOptionsMonitor<MySettings> settings, ILogger<SettingsMonitor> logger)
+    {
+        _settings = settings;
+        _logger = logger;
+        
+        // Monitor for settings changes
+        _settings.OnChange(OnSettingsChanged);
+    }
+
+    private void OnSettingsChanged(MySettings settings)
+    {
+        var loadType = settings.FigSettingLoadType;
+        var lastUpdate = settings.LastFigUpdateUtc;
+        
+        _logger.LogInformation("Settings updated - LoadType: {LoadType}, LastUpdate: {LastUpdate}", 
+            loadType, lastUpdate);
+            
+        // Send metrics to your monitoring system
+        if (loadType == LoadType.Offline)
+        {
+            _logger.LogWarning("Application running with offline settings cache");
+        }
+    }
+}
+```
+
+### Conditional Logic Based on Settings Age
+
+Implement different behavior based on how recently settings were updated:
+
+```csharp
+public class DataService
+{
+    private readonly IOptionsMonitor<MySettings> _settings;
+
+    public async Task ProcessDataAsync()
+    {
+        var currentSettings = _settings.CurrentValue;
+        
+        // Use more conservative timeouts if settings are old or offline
+        var timeout = GetTimeoutBasedOnSettingsAge(currentSettings);
+        
+        using var httpClient = new HttpClient { Timeout = timeout };
+        // ... rest of implementation
+    }
+
+    private TimeSpan GetTimeoutBasedOnSettingsAge(MySettings settings)
+    {
+        // If settings failed to load, use conservative defaults
+        if (settings.FigSettingLoadType == LoadType.None)
+        {
+            return TimeSpan.FromSeconds(30);
+        }
+        
+        // If using offline settings, be more conservative
+        if (settings.FigSettingLoadType == LoadType.Offline)
+        {
+            return TimeSpan.FromSeconds(settings.TimeoutSeconds + 10);
+        }
+        
+        // If settings are very recent, use configured value
+        if (settings.LastFigUpdateUtc.HasValue && 
+            DateTime.UtcNow - settings.LastFigUpdateUtc.Value < TimeSpan.FromMinutes(5))
+        {
+            return TimeSpan.FromSeconds(settings.TimeoutSeconds);
+        }
+        
+        // Default to slightly more conservative timeout
+        return TimeSpan.FromSeconds(settings.TimeoutSeconds + 5);
+    }
+}
+```
+
+## Important Notes
+
+- **UTC Timestamps**: `LastFigUpdateUtc` is always in UTC to avoid timezone confusion
+- **Null Values**: `LastFigUpdateUtc` will be `null` if settings have never been successfully loaded
+- **Automatic Updates**: These properties are automatically updated whenever Fig reloads your settings
+- **Thread Safety**: These properties are updated atomically when settings change
+- **Default Values**: When `LoadType.None`, your application runs with the default values defined in your settings class

--- a/doc/fig-documentation/versioned_docs/version-2.0/features/29-metadata-properties.md
+++ b/doc/fig-documentation/versioned_docs/version-2.0/features/29-metadata-properties.md
@@ -1,0 +1,211 @@
+---
+sidebar_position: 29
+sidebar_label: Metadata Properties
+---
+
+# Metadata Properties
+
+Fig automatically tracks when your settings are loaded and updated, providing you with metadata about the state of your configuration. This feature is particularly useful for monitoring, debugging, and implementing health checks in your applications.
+
+## Available Properties
+
+All settings classes that inherit from `SettingsBase` automatically include two properties that provide information about the last update:
+
+### LastFigUpdateUtc
+
+A `DateTime?` property that indicates when the settings were last successfully loaded or updated.
+
+```csharp
+public class MySettings : SettingsBase
+{
+    public string DatabaseConnection { get; set; }
+    public int RetryCount { get; set; }
+    
+    // Inherited from SettingsBase
+    // public DateTime? LastFigUpdateUtc { get; }
+}
+
+// Usage
+var settings = serviceProvider.GetRequiredService<IOptionsMonitor<MySettings>>();
+var lastUpdate = settings.CurrentValue.LastFigUpdateUtc;
+
+if (lastUpdate.HasValue)
+{
+    Console.WriteLine($"Settings last updated: {lastUpdate.Value:yyyy-MM-dd HH:mm:ss} UTC");
+}
+else
+{
+    Console.WriteLine("Settings have not been successfully loaded");
+}
+```
+
+### FigSettingLoadType
+
+An enum property that indicates how the settings were loaded. This helps you understand whether your application is running with the latest server configuration or fallback values.
+
+```csharp
+public enum LoadType
+{
+    None,    // Settings failed to load completely
+    Server,  // Settings loaded from Fig API
+    Offline  // Settings loaded from offline cache
+}
+
+// Usage
+var settings = serviceProvider.GetRequiredService<IOptionsMonitor<MySettings>>();
+var loadType = settings.CurrentValue.FigSettingLoadType;
+
+switch (loadType)
+{
+    case LoadType.Server:
+        Console.WriteLine("✓ Running with latest settings from Fig API");
+        break;
+    case LoadType.Offline:
+        Console.WriteLine("⚠ Running with cached settings (API unavailable)");
+        break;
+    case LoadType.None:
+        Console.WriteLine("❌ Running with default values (no settings loaded)");
+        break;
+}
+```
+
+## Common Use Cases
+
+### Health Checks
+
+Use these properties to implement health checks that verify your application has successfully loaded recent settings:
+
+```csharp
+public class SettingsHealthCheck : IHealthCheck
+{
+    private readonly IOptionsMonitor<MySettings> _settings;
+    private readonly TimeSpan _maxAge;
+
+    public SettingsHealthCheck(IOptionsMonitor<MySettings> settings)
+    {
+        _settings = settings;
+        _maxAge = TimeSpan.FromMinutes(30); // Consider settings stale after 30 minutes
+    }
+
+    public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, 
+        CancellationToken cancellationToken = default)
+    {
+        var currentSettings = _settings.CurrentValue;
+        
+        // Check if settings loaded successfully
+        if (currentSettings.FigSettingLoadType == LoadType.None)
+        {
+            return Task.FromResult(HealthCheckResult.Unhealthy(
+                "Fig settings failed to load"));
+        }
+        
+        // Check if settings are recent
+        if (currentSettings.LastFigUpdateUtc.HasValue)
+        {
+            var age = DateTime.UtcNow - currentSettings.LastFigUpdateUtc.Value;
+            if (age > _maxAge)
+            {
+                return Task.FromResult(HealthCheckResult.Degraded(
+                    $"Fig settings are {age.TotalMinutes:F1} minutes old"));
+            }
+        }
+        
+        var message = currentSettings.FigSettingLoadType == LoadType.Server 
+            ? "Fig settings loaded from server" 
+            : "Fig settings loaded from offline cache";
+            
+        return Task.FromResult(HealthCheckResult.Healthy(message));
+    }
+}
+```
+
+### Monitoring and Alerting
+
+Monitor your application's configuration state:
+
+```csharp
+public class SettingsMonitor
+{
+    private readonly IOptionsMonitor<MySettings> _settings;
+    private readonly ILogger<SettingsMonitor> _logger;
+
+    public SettingsMonitor(IOptionsMonitor<MySettings> settings, ILogger<SettingsMonitor> logger)
+    {
+        _settings = settings;
+        _logger = logger;
+        
+        // Monitor for settings changes
+        _settings.OnChange(OnSettingsChanged);
+    }
+
+    private void OnSettingsChanged(MySettings settings)
+    {
+        var loadType = settings.FigSettingLoadType;
+        var lastUpdate = settings.LastFigUpdateUtc;
+        
+        _logger.LogInformation("Settings updated - LoadType: {LoadType}, LastUpdate: {LastUpdate}", 
+            loadType, lastUpdate);
+            
+        // Send metrics to your monitoring system
+        if (loadType == LoadType.Offline)
+        {
+            _logger.LogWarning("Application running with offline settings cache");
+        }
+    }
+}
+```
+
+### Conditional Logic Based on Settings Age
+
+Implement different behavior based on how recently settings were updated:
+
+```csharp
+public class DataService
+{
+    private readonly IOptionsMonitor<MySettings> _settings;
+
+    public async Task ProcessDataAsync()
+    {
+        var currentSettings = _settings.CurrentValue;
+        
+        // Use more conservative timeouts if settings are old or offline
+        var timeout = GetTimeoutBasedOnSettingsAge(currentSettings);
+        
+        using var httpClient = new HttpClient { Timeout = timeout };
+        // ... rest of implementation
+    }
+
+    private TimeSpan GetTimeoutBasedOnSettingsAge(MySettings settings)
+    {
+        // If settings failed to load, use conservative defaults
+        if (settings.FigSettingLoadType == LoadType.None)
+        {
+            return TimeSpan.FromSeconds(30);
+        }
+        
+        // If using offline settings, be more conservative
+        if (settings.FigSettingLoadType == LoadType.Offline)
+        {
+            return TimeSpan.FromSeconds(settings.TimeoutSeconds + 10);
+        }
+        
+        // If settings are very recent, use configured value
+        if (settings.LastFigUpdateUtc.HasValue && 
+            DateTime.UtcNow - settings.LastFigUpdateUtc.Value < TimeSpan.FromMinutes(5))
+        {
+            return TimeSpan.FromSeconds(settings.TimeoutSeconds);
+        }
+        
+        // Default to slightly more conservative timeout
+        return TimeSpan.FromSeconds(settings.TimeoutSeconds + 5);
+    }
+}
+```
+
+## Important Notes
+
+- **UTC Timestamps**: `LastFigUpdateUtc` is always in UTC to avoid timezone confusion
+- **Null Values**: `LastFigUpdateUtc` will be `null` if settings have never been successfully loaded
+- **Automatic Updates**: These properties are automatically updated whenever Fig reloads your settings
+- **Thread Safety**: These properties are updated atomically when settings change
+- **Default Values**: When `LoadType.None`, your application runs with the default values defined in your settings class

--- a/src/client/Fig.Client/Enums/LoadType.cs
+++ b/src/client/Fig.Client/Enums/LoadType.cs
@@ -1,0 +1,19 @@
+namespace Fig.Client.Enums;
+
+public enum LoadType
+{
+    /// <summary>
+    /// Settings were not loaded.
+    /// </summary>
+    None,
+    
+    /// <summary>
+    /// Settings were loaded from the server.
+    /// </summary>
+    Server,
+    
+    /// <summary>
+    /// Settings were loaded from a saved offline file.
+    /// </summary>
+    Offline
+}

--- a/src/client/Fig.Client/SettingsBase.cs
+++ b/src/client/Fig.Client/SettingsBase.cs
@@ -5,6 +5,7 @@ using Fig.Client.Attributes;
 using Fig.Client.Configuration;
 using Fig.Client.DefaultValue;
 using Fig.Client.Description;
+using Fig.Client.Enums;
 using Fig.Client.EnvironmentVariables;
 using Fig.Client.Exceptions;
 using Fig.Client.Validation;
@@ -47,6 +48,18 @@ public abstract class SettingsBase
     public abstract string ClientDescription { get; }
 
     public bool RestartRequested { get; set; }
+    
+    // Internal property to store ticks from configuration binding
+    public long? LastFigUpdateUtcTicks { get; set; }
+    
+    // Public property that converts ticks to UTC DateTime
+    public DateTime? LastFigUpdateUtc 
+    { 
+        get => LastFigUpdateUtcTicks.HasValue ? new DateTime(LastFigUpdateUtcTicks.Value, DateTimeKind.Utc) : null;
+        set => LastFigUpdateUtcTicks = value?.Ticks;
+    }
+    
+    public LoadType FigSettingLoadType { get; set; } = LoadType.None;
 
     public SettingsClientDefinitionDataContract CreateDataContract(string clientName)
     {

--- a/src/tests/Fig.Integration.Test/Client/SettingLoadTypeAndTimestampTests.cs
+++ b/src/tests/Fig.Integration.Test/Client/SettingLoadTypeAndTimestampTests.cs
@@ -1,0 +1,256 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Fig.Client.ExtensionMethods;
+using Fig.Client.Enums;
+using Fig.Contracts.Settings;
+using Fig.Test.Common;
+using Fig.Test.Common.TestSettings;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+
+namespace Fig.Integration.Test.Client;
+
+[TestFixture]
+public class SettingLoadTypeAndTimestampTests : IntegrationTestBase
+{
+    private string? _originalPollInterval;
+    private static readonly TimeSpan TimestampTolerance = TimeSpan.FromSeconds(30); // More generous tolerance for slow environments
+    
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        _originalPollInterval = Environment.GetEnvironmentVariable("FIG_POLL_INTERVAL_MS");
+        Environment.SetEnvironmentVariable("FIG_POLL_INTERVAL_MS", "1000"); // 1 second for tests
+    }
+    
+    [OneTimeTearDown]
+    public void OneTimeTearDown()
+    {
+        Environment.SetEnvironmentVariable("FIG_POLL_INTERVAL_MS", _originalPollInterval);
+    }
+    [Test]
+    public async Task ShallHaveValidTimestampAndServerLoadTypeWhenLoadingFromApi()
+    {
+        // Arrange
+        var secret = GetNewSecret();
+        await RegisterSettings<AllSettingsAndTypes>(secret);
+        var beforeLoadTime = DateTime.UtcNow;
+        
+        // Act
+        var (options, _) = InitializeConfigurationProvider<AllSettingsAndTypes>(secret);
+
+        // Assert
+        var currentSettings = options.CurrentValue;
+        Assert.That(currentSettings.FigSettingLoadType, Is.EqualTo(LoadType.Server), 
+            "LoadType should be Server when successfully loading from API");
+        
+        Assert.That(currentSettings.LastFigUpdateUtc, Is.Not.Null, 
+            "LastFigUpdateUtc should not be null when loading from API");
+        
+        var lastUpdateTime = currentSettings.LastFigUpdateUtc!.Value;
+        AssertTimestampIsRecent(lastUpdateTime, beforeLoadTime, "when loading from API");
+    }
+
+    [Test]
+    public void ShallHaveNoneLoadTypeAndNullTimestampWhenApiIsUnavailableAndNoOfflineSettings()
+    {
+        // Act
+        var (options, _) = InitializeConfigurationProviderWithInvalidEndpoint<AllSettingsAndTypes>(
+            clientSecret: GetNewSecret(), 
+            allowOfflineSettings: false);
+
+        // Assert
+        var currentSettings = options.CurrentValue;
+        Assert.That(currentSettings.FigSettingLoadType, Is.EqualTo(LoadType.None), 
+            "LoadType should be None when API is unavailable and offline settings are disabled");
+        
+        Assert.That(currentSettings.LastFigUpdateUtc, Is.Null, 
+            "LastFigUpdateUtc should be null when settings fail to load completely");
+    }
+
+    [Test]
+    public async Task ShallHaveOfflineLoadTypeAndValidTimestampWhenUsingOfflineSettings()
+    {
+        // Arrange - First, create valid settings and load them to create offline cache
+        var secret = GetNewSecret();
+        await RegisterSettings<AllSettingsAndTypes>(secret);
+        
+        // Load settings once to create offline cache
+        var (initialOptions, initialConfig) = InitializeConfigurationProvider<AllSettingsAndTypes>(secret);
+        await WaitForSettingsToLoad(initialOptions);
+        
+        // Dispose the initial configuration to clean up
+        (initialConfig as IDisposable)?.Dispose();
+        
+        var beforeOfflineLoadTime = DateTime.UtcNow;
+        
+        // Act - Configure with invalid endpoint but allow offline settings
+        var (offlineOptions, _) = InitializeConfigurationProviderWithInvalidEndpoint<AllSettingsAndTypes>(
+            clientSecret: secret, 
+            allowOfflineSettings: true);
+
+        // Assert
+        var currentSettings = offlineOptions.CurrentValue;
+        Assert.That(currentSettings.FigSettingLoadType, Is.EqualTo(LoadType.Offline), 
+            "LoadType should be Offline when API is unavailable but offline settings are available");
+        
+        Assert.That(currentSettings.LastFigUpdateUtc, Is.Not.Null, 
+            "LastFigUpdateUtc should not be null when loading from offline settings");
+        
+        var lastUpdateTime = currentSettings.LastFigUpdateUtc!.Value;
+        AssertTimestampIsRecent(lastUpdateTime, beforeOfflineLoadTime, "when loading from offline settings");
+    }
+
+    [Test]
+    public async Task ShallUpdateTimestampWhenSettingsReload()
+    {
+        // Arrange
+        var secret = GetNewSecret();
+        var settings = await RegisterSettings<AllSettingsAndTypes>(secret);
+        var (options, _) = InitializeConfigurationProvider<AllSettingsAndTypes>(secret);
+
+        // Get initial timestamp
+        var initialTimestamp = options.CurrentValue.LastFigUpdateUtc;
+        Assert.That(initialTimestamp, Is.Not.Null);
+
+        // Wait a small amount to ensure timestamp difference
+        await Task.Delay(100);
+
+        // Act - Update a setting to trigger a reload
+        await UpdateStringSetting(settings.ClientName, "UpdatedValue");
+        
+        // Wait for the reload to complete
+        await WaitForSettingsUpdate(options, initialTimestamp!.Value);
+
+        // Assert
+        var updatedSettings = options.CurrentValue;
+        Assert.That(updatedSettings.FigSettingLoadType, Is.EqualTo(LoadType.Server), 
+            "LoadType should remain Server after reload");
+        
+        Assert.That(updatedSettings.LastFigUpdateUtc, Is.Not.Null, 
+            "LastFigUpdateUtc should not be null after reload");
+        
+        Assert.That(updatedSettings.LastFigUpdateUtc!.Value, Is.GreaterThan(initialTimestamp.Value), 
+            "LastFigUpdateUtc should be updated after settings reload");
+        
+        AssertTimestampIsRecent(updatedSettings.LastFigUpdateUtc.Value, initialTimestamp.Value, "after settings reload");
+    }
+
+    [Test]
+    public async Task ShallMaintainLoadTypeConsistencyAcrossMultipleReloads()
+    {
+        // Arrange
+        var secret = GetNewSecret();
+        var settings = await RegisterSettings<AllSettingsAndTypes>(secret);
+        var (options, _) = InitializeConfigurationProvider<AllSettingsAndTypes>(secret);
+
+        // Act & Assert - Perform multiple updates
+        var previousTimestamp = options.CurrentValue.LastFigUpdateUtc!.Value;
+        
+        for (int i = 0; i < 3; i++)
+        {
+            await Task.Delay(100); // Ensure timestamp difference
+            
+            await UpdateStringSetting(settings.ClientName, $"UpdatedValue_{i}");
+            await WaitForSettingsUpdate(options, previousTimestamp);
+
+            var currentSettings = options.CurrentValue;
+            Assert.That(currentSettings.FigSettingLoadType, Is.EqualTo(LoadType.Server), 
+                $"LoadType should remain Server after reload {i + 1}");
+            
+            Assert.That(currentSettings.LastFigUpdateUtc, Is.Not.Null, 
+                $"LastFigUpdateUtc should not be null after reload {i + 1}");
+            
+            Assert.That(currentSettings.LastFigUpdateUtc!.Value, Is.GreaterThan(previousTimestamp), 
+                $"LastFigUpdateUtc should be updated after reload {i + 1}");
+            
+            AssertTimestampIsRecent(currentSettings.LastFigUpdateUtc.Value, previousTimestamp, $"after reload {i + 1}");
+
+            previousTimestamp = currentSettings.LastFigUpdateUtc.Value;
+        }
+    }
+
+    private (IOptionsMonitor<T>, IConfigurationRoot) InitializeConfigurationProviderWithInvalidEndpoint<T>(
+        string clientSecret, 
+        bool allowOfflineSettings = true) where T : TestSettingsBase
+    {
+        var builder = WebApplication.CreateBuilder();
+        var settings = Activator.CreateInstance<T>();
+
+        var configuration = new ConfigurationBuilder()
+            .AddFig<T>(o =>
+            {
+                o.ClientName = settings.ClientName;
+                o.HttpClient = new HttpClient()
+                {
+                    BaseAddress = new Uri("http://localhost:9999") // Invalid endpoint
+                };
+                o.ClientSecretOverride = clientSecret;
+                o.AllowOfflineSettings = allowOfflineSettings;
+            }).Build();
+
+        builder.Services.Configure<T>(configuration);
+        var app = builder.Build();
+
+        var options = app.Services.GetRequiredService<IOptionsMonitor<T>>();
+        ConfigProviderApps.Add(app);
+        ConfigRoots.Add(configuration);
+        return (options, configuration);
+    }
+
+    private async Task WaitForSettingsToLoad<T>(IOptionsMonitor<T> options, int timeoutMs = 5000) where T : TestSettingsBase
+    {
+        var startTime = DateTime.UtcNow;
+        while (DateTime.UtcNow.Subtract(startTime).TotalMilliseconds < timeoutMs)
+        {
+            if (options.CurrentValue.LastFigUpdateUtc != null)
+                return;
+            
+            await Task.Delay(50);
+        }
+        
+        throw new TimeoutException("Settings did not load within the expected time");
+    }
+
+    private async Task WaitForSettingsUpdate<T>(IOptionsMonitor<T> options, DateTime previousTimestamp, int timeoutMs = 5000) where T : TestSettingsBase
+    {
+        var startTime = DateTime.UtcNow;
+        while (DateTime.UtcNow.Subtract(startTime).TotalMilliseconds < timeoutMs)
+        {
+            var currentTimestamp = options.CurrentValue.LastFigUpdateUtc;
+            if (currentTimestamp != null && currentTimestamp.Value > previousTimestamp)
+                return;
+            
+            await Task.Delay(50);
+        }
+        
+        throw new TimeoutException("Settings were not updated within the expected time");
+    }
+
+    private static void AssertTimestampIsRecent(DateTime timestamp, DateTime earliestExpected, string context)
+    {
+        Assert.That(timestamp, Is.GreaterThanOrEqualTo(earliestExpected), 
+            $"LastFigUpdateUtc should be after the expected minimum time {context}");
+        
+        Assert.That(timestamp, Is.LessThanOrEqualTo(DateTime.UtcNow.Add(TimestampTolerance)), 
+            $"LastFigUpdateUtc should be within tolerance of current time {context} (tolerance: {TimestampTolerance})");
+        
+        Assert.That(timestamp.Kind, Is.EqualTo(DateTimeKind.Utc), 
+            $"LastFigUpdateUtc should be in UTC {context}");
+    }
+
+    private async Task UpdateStringSetting(string clientName, string newValue)
+    {
+        var settingsToUpdate = new List<SettingDataContract>
+        {
+            new(nameof(AllSettingsAndTypes.StringSetting), new StringSettingDataContract(newValue))
+        };
+
+        await SetSettings(clientName, settingsToUpdate);
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic metadata properties to all settings: last successful update time (UTC) and load type (None, Server, or Offline).
- **Documentation**
  - Introduced new documentation explaining how to use the metadata properties for health checks, monitoring, and conditional logic.
- **Tests**
  - Added integration tests to verify correct behavior of metadata properties in various loading scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->