### PR TITLE
Add support for custom predefined categories for example: [Category<T…

### DIFF
--- a/doc/fig-documentation/docs/features/settings-management/2-category.md
+++ b/doc/fig-documentation/docs/features/settings-management/2-category.md
@@ -32,6 +32,73 @@ public string? ServiceUsername { get; set; }
 
 This will automatically select the color and name leading to a more consistent experience when applications are developed across teams.
 
+## Custom Predefined Categories
+
+While Fig includes built-in predefined categories (like `Authentication`, `Database`, `Logging`, etc.), you can also create your own custom predefined categories that can be shared across multiple applications in your solution.
+
+Custom predefined categories allow multiple applications to use the same names and colors for categories, making a full solution appear more consistent and coherent.
+
+### Creating Custom Categories
+
+To create custom categories, define an enum with `CategoryName` and `ColorHex` attributes:
+
+```csharp
+public enum MyCustomCategories
+{
+    [CategoryName("Payment Processing")]
+    [ColorHex("#FF5733")]
+    PaymentProcessing,
+
+    [CategoryName("User Management")]
+    [ColorHex("#33FF57")]
+    UserManagement,
+
+    [CategoryName("Audit & Compliance")]
+    [ColorHex("#3357FF")]
+    AuditCompliance
+}
+```
+
+### Using Custom Categories
+
+Once defined, you can use your custom categories in settings:
+
+```csharp
+[Setting("Payment gateway API key")]
+[Category<MyCustomCategories>(MyCustomCategories.PaymentProcessing)]
+[Secret]
+public string? PaymentApiKey { get; set; }
+
+[Setting("User session timeout in minutes")]
+[Category<MyCustomCategories>(MyCustomCategories.UserManagement)]
+public int SessionTimeoutMinutes { get; set; } = 30;
+```
+
+### Benefits of Custom Predefined Categories
+
+- **Consistency**: All applications in your solution use the same category names and colors
+- **Maintainability**: Category definitions are centralized and can be shared via a common library
+- **Team Collaboration**: Developers across teams use consistent categorization
+- **Visual Cohesion**: Settings across different applications have a unified appearance
+
+### Built-in Categories
+
+Fig includes the following built-in predefined categories:
+
+- Authentication
+- Database  
+- Elasticsearch
+- File Handling
+- Map
+- Message Bus
+- API Integration
+- Logging
+- Business Logic
+- Testing
+- Property Mapping
+- REST API
+- Security
+
 ## Appearance
 
 The category name appears as a tooltip.

--- a/src/client/Fig.Client.Abstractions/Attributes/CategoryAttribute.cs
+++ b/src/client/Fig.Client.Abstractions/Attributes/CategoryAttribute.cs
@@ -55,3 +55,17 @@ public class CategoryAttribute : Attribute
         return attribute?.HexValue;
     }
 }
+
+[AttributeUsage(AttributeTargets.Property)]
+public class CategoryAttribute<TEnum> : Attribute where TEnum : struct, Enum
+{
+    public CategoryAttribute(TEnum enumValue)
+    {
+        Name = CategoryHelper.GetName(enumValue);
+        ColorHex = CategoryHelper.GetColorHex(enumValue);
+    }
+
+    public string? Name { get; }
+
+    public string? ColorHex { get; }
+}

--- a/src/client/Fig.Client.Abstractions/Attributes/CategoryHelper.cs
+++ b/src/client/Fig.Client.Abstractions/Attributes/CategoryHelper.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Reflection;
+
+namespace Fig.Client.Abstractions.Attributes;
+
+public static class CategoryHelper
+{
+    /// <summary>
+    /// Extracts the category name from a custom enum value decorated with CategoryNameAttribute.
+    /// </summary>
+    /// <param name="enumValue">The enum value to extract the name from.</param>
+    /// <returns>The category name if found, otherwise null.</returns>
+    public static string? GetName(Enum enumValue)
+    {
+        FieldInfo fieldInfo = enumValue.GetType().GetField(enumValue.ToString());
+        var attribute = fieldInfo?.GetCustomAttribute<CategoryNameAttribute>();
+        return attribute?.Name;
+    }
+
+    /// <summary>
+    /// Extracts the category color hex value from a custom enum value decorated with ColorHexAttribute.
+    /// </summary>
+    /// <param name="enumValue">The enum value to extract the color from.</param>
+    /// <returns>The color hex value if found, otherwise null.</returns>
+    public static string? GetColorHex(Enum enumValue)
+    {
+        FieldInfo fieldInfo = enumValue.GetType().GetField(enumValue.ToString());
+        var attribute = fieldInfo?.GetCustomAttribute<ColorHexAttribute>();
+        return attribute?.HexValue;
+    }
+
+    /// <summary>
+    /// Creates a CategoryAttribute instance from a custom enum value.
+    /// The enum value must be decorated with CategoryNameAttribute and/or ColorHexAttribute.
+    /// </summary>
+    /// <param name="enumValue">The enum value to create the category from.</param>
+    /// <returns>A new CategoryAttribute with the name and color extracted from the enum.</returns>
+    public static CategoryAttribute FromEnum(Enum enumValue)
+    {
+        var name = GetName(enumValue);
+        var colorHex = GetColorHex(enumValue);
+        return new CategoryAttribute(name ?? enumValue.ToString(), colorHex ?? "#000000");
+    }
+}

--- a/src/tests/Fig.Unit.Test/Client/CustomCategoryAttributeTests.cs
+++ b/src/tests/Fig.Unit.Test/Client/CustomCategoryAttributeTests.cs
@@ -1,0 +1,201 @@
+using System.Linq;
+using Fig.Client.Abstractions.Attributes;
+using Fig.Client.Abstractions.Enums;
+using NUnit.Framework;
+
+namespace Fig.Unit.Test.Client;
+
+public class CustomCategoryAttributeTests
+{
+    [Test]
+    public void CategoryHelper_GetName_ExtractsCorrectName()
+    {
+        // Arrange
+        var customCategory = TestCustomCategory.CustomCategory1;
+
+        // Act
+        var name = CategoryHelper.GetName(customCategory);
+
+        // Assert
+        Assert.That(name, Is.EqualTo("My Custom Category"));
+    }
+
+    [Test]
+    public void CategoryHelper_GetColorHex_ExtractsCorrectColor()
+    {
+        // Arrange
+        var customCategory = TestCustomCategory.CustomCategory1;
+
+        // Act
+        var colorHex = CategoryHelper.GetColorHex(customCategory);
+
+        // Assert
+        Assert.That(colorHex, Is.EqualTo("#FF5733"));
+    }
+
+    [Test]
+    public void CategoryHelper_GetName_WithoutAttribute_ReturnsNull()
+    {
+        // Arrange
+        var customCategory = TestCustomCategory.CategoryWithoutAttributes;
+
+        // Act
+        var name = CategoryHelper.GetName(customCategory);
+
+        // Assert
+        Assert.That(name, Is.Null);
+    }
+
+    [Test]
+    public void CategoryHelper_GetColorHex_WithoutAttribute_ReturnsNull()
+    {
+        // Arrange
+        var customCategory = TestCustomCategory.CategoryWithoutAttributes;
+
+        // Act
+        var colorHex = CategoryHelper.GetColorHex(customCategory);
+
+        // Assert
+        Assert.That(colorHex, Is.Null);
+    }
+
+    [Test]
+    public void CategoryHelper_FromEnum_CreatesCorrectCategoryAttribute()
+    {
+        // Arrange
+        var customCategory = TestCustomCategory.CustomCategory1;
+
+        // Act
+        var categoryAttribute = CategoryHelper.FromEnum(customCategory);
+
+        // Assert
+        Assert.That(categoryAttribute.Name, Is.EqualTo("My Custom Category"));
+        Assert.That(categoryAttribute.ColorHex, Is.EqualTo("#FF5733"));
+    }
+
+    [Test]
+    public void CategoryHelper_FromEnum_WithoutAttributes_UsesDefaults()
+    {
+        // Arrange
+        var customCategory = TestCustomCategory.CategoryWithoutAttributes;
+
+        // Act
+        var categoryAttribute = CategoryHelper.FromEnum(customCategory);
+
+        // Assert
+        Assert.That(categoryAttribute.Name, Is.EqualTo("CategoryWithoutAttributes"));
+        Assert.That(categoryAttribute.ColorHex, Is.EqualTo("#000000"));
+    }
+
+    [Test]
+    public void CategoryAttribute_WithPredefinedEnum_StillWorks()
+    {
+        // Arrange
+        var predefinedCategory = Category.Database;
+
+        // Act
+        var categoryAttribute = new Fig.Client.Abstractions.Attributes.CategoryAttribute(predefinedCategory);
+
+        // Assert
+        Assert.That(categoryAttribute.Name, Is.EqualTo("Database"));
+        Assert.That(categoryAttribute.ColorHex, Is.EqualTo("#4f51c9"));
+    }
+
+    [Test]
+    public void CategoryAttribute_WithCustomNameAndColor_Works()
+    {
+        // Arrange & Act
+        var categoryAttribute = new Fig.Client.Abstractions.Attributes.CategoryAttribute("My Custom Category", "#FF5733");
+
+        // Assert
+        Assert.That(categoryAttribute.Name, Is.EqualTo("My Custom Category"));
+        Assert.That(categoryAttribute.ColorHex, Is.EqualTo("#FF5733"));
+    }
+
+    [Test]
+    public void CategoryAttribute_WithCustomEnumInSettingsClass_ExtractsCorrectly()
+    {
+        // Arrange
+        var settings = new TestSettingsWithCustomCategory();
+
+        // Act
+        var dataContract = settings.CreateDataContract("TestClient");
+
+        // Assert
+        var setting = dataContract.Settings.First(s => s.Name == nameof(TestSettingsWithCustomCategory.TestSetting));
+        Assert.That(setting.CategoryName, Is.EqualTo("My Custom Category"));
+        Assert.That(setting.CategoryColor, Is.EqualTo("#FF5733"));
+    }
+
+    [Test]
+    public void CategoryAttribute_WithCustomEnumDirectly_WorksCorrectly()
+    {
+        // Arrange & Act
+        var categoryAttribute = new CategoryAttribute<TestCustomCategory>(TestCustomCategory.CustomCategory1);
+
+        // Assert
+        Assert.That(categoryAttribute.Name, Is.EqualTo("My Custom Category"));
+        Assert.That(categoryAttribute.ColorHex, Is.EqualTo("#FF5733"));
+    }
+
+    [Test]
+    public void CategoryAttribute_WithCustomEnumDirectlyInSettingsClass_ExtractsCorrectly()
+    {
+        // Arrange
+        var settings = new TestSettingsWithDirectCustomCategory();
+
+        // Act
+        var dataContract = settings.CreateDataContract("TestClient");
+
+        // Assert
+        var setting = dataContract.Settings.First(s => s.Name == nameof(TestSettingsWithDirectCustomCategory.TestSetting));
+        Assert.That(setting.CategoryName, Is.EqualTo("My Custom Category"));
+        Assert.That(setting.CategoryColor, Is.EqualTo("#FF5733"));
+    }
+
+    [Test]
+    public void CategoryAttribute_WithPredefinedCategoryEnumStillWorks()
+    {
+        // Arrange & Act
+        var categoryAttribute = new Fig.Client.Abstractions.Attributes.CategoryAttribute(Category.Database);
+
+        // Assert
+        Assert.That(categoryAttribute.Name, Is.EqualTo("Database"));
+        Assert.That(categoryAttribute.ColorHex, Is.EqualTo("#4f51c9"));
+    }
+}
+
+public enum TestCustomCategory
+{
+    [CategoryName("My Custom Category")]
+    [ColorHex("#FF5733")]
+    CustomCategory1,
+
+    [CategoryName("Another Custom Category")]
+    [ColorHex("#33FF57")]
+    CustomCategory2,
+
+    CategoryWithoutAttributes
+}
+
+public class TestSettingsWithCustomCategory : Fig.Client.SettingsBase
+{
+    public override string ClientDescription => "Test settings with custom category";
+
+    [Fig.Client.Abstractions.Attributes.Category("My Custom Category", "#FF5733")]
+    [Setting("Test Setting")]
+    public string TestSetting { get; set; } = "Default Value";
+
+    public override System.Collections.Generic.IEnumerable<string> GetValidationErrors() => [];
+}
+
+public class TestSettingsWithDirectCustomCategory : Fig.Client.SettingsBase
+{
+    public override string ClientDescription => "Test settings with direct custom category enum";
+
+    [Category<TestCustomCategory>(TestCustomCategory.CustomCategory1)]
+    [Setting("Test Setting")]
+    public string TestSetting { get; set; } = "Default Value";
+
+    public override System.Collections.Generic.IEnumerable<string> GetValidationErrors() => [];
+}


### PR DESCRIPTION
…estCustomCategory>(TestCustomCategory.CustomCategory1)]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enum-based predefined categories: define and reuse named categories with colors; color formats are validated and applied across settings.

- **Documentation**
  - Added “Custom Predefined Categories” guidance with examples, benefits, built-in categories list, and note that category names appear as tooltips.

- **Tests**
  - Added unit tests covering enum-based categories, name/color extraction, validation, and settings integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->