### PR TITLE
Add support for data cleanup where old event logs, snapshots, setting…

### DIFF
--- a/doc/fig-documentation/docs/features/7-configuration.md
+++ b/doc/fig-documentation/docs/features/7-configuration.md
@@ -81,6 +81,28 @@ Fig clients poll every 30 seconds by default. This can be overridden via environ
 
 It is not recommended to set this value under 10000ms. Values under 2000ms are not allowed.
 
+### Data Cleanup
+
+Data Cleanup is a background process that runs on Fig API startup and every 8-12 hours therafter.
+
+In this section it is possible to configure the number of days that should pass before data should be deleted from various places. This prevents the database from becoming too large. Data cleanup can be disabled for each data type.
+
+#### Time Machine (Checkpoints)
+
+Time machine checkpoints are taken automatically if enabled and save a backup (export) of the settings in the database. They can grow very large if there are many settings and images embedded in the documentation and there is a lot of setting change activitiy in the system. It is recommended that data trimming be enabled for this data.
+
+#### Event Logs
+
+Event logs are a record of setting changes, client registrations, etc. They can be optionally cleaned up after a period of time but this is disabled by default as this data is usually quite small and may be important as a record of history.
+
+#### API Status
+
+API status entries are created when the Fig API is restarted. A running instance will update the same record. If you have a lot of restarts in your environment, you might want to enable cleanup here as the data is really runtime data and does not have any historical significance.
+
+#### Setting History
+
+The history for individual settings is held in a dedicated table, separate from the event logs. It can also be cleaned up if required but this feature is disabled by default.
+
 ## Appearance
 
 ![image-20220802231541473](./img/fig-configuration.png)

--- a/src/api/Fig.Api/Converters/FigConfigurationConverter.cs
+++ b/src/api/Fig.Api/Converters/FigConfigurationConverter.cs
@@ -21,7 +21,11 @@ public class FigConfigurationConverter : IFigConfigurationConverter
             PollIntervalOverride = configuration.PollIntervalOverride,
             AllowDisplayScripts = configuration.AllowDisplayScripts,
             EnableTimeMachine = configuration.EnableTimeMachine,
-            TimelineDurationDays = configuration.TimelineDurationDays
+            TimelineDurationDays = configuration.TimelineDurationDays,
+            TimeMachineCleanupDays = configuration.TimeMachineCleanupDays,
+            EventLogsCleanupDays = configuration.EventLogsCleanupDays,
+            ApiStatusCleanupDays = configuration.ApiStatusCleanupDays,
+            SettingHistoryCleanupDays = configuration.SettingHistoryCleanupDays
         };
     }
 }

--- a/src/api/Fig.Api/Datalayer/Repositories/ApiStatusRepository.cs
+++ b/src/api/Fig.Api/Datalayer/Repositories/ApiStatusRepository.cs
@@ -34,4 +34,16 @@ public class ApiStatusRepository : RepositoryBase<ApiStatusBusinessEntity>, IApi
         criteria.SetLockMode(LockMode.Upgrade);
         return await criteria.ListAsync<ApiStatusBusinessEntity>();
     }
+    
+    public async Task<int> DeleteOlderThan(DateTime cutoffDate)
+    {
+        using Activity? activity = ApiActivitySource.Instance.StartActivity();
+        var deleteCount = await Session.CreateQuery(
+                "delete from ApiStatusBusinessEntity where LastSeen < :cutoffDate and IsActive = false")
+            .SetParameter("cutoffDate", cutoffDate)
+            .ExecuteUpdateAsync();
+        
+        await Session.FlushAsync();
+        return deleteCount;
+    }
 }

--- a/src/api/Fig.Api/Datalayer/Repositories/CheckPointRepository.cs
+++ b/src/api/Fig.Api/Datalayer/Repositories/CheckPointRepository.cs
@@ -49,4 +49,16 @@ public class CheckPointRepository : RepositoryBase<CheckPointBusinessEntity>, IC
     {
         await Update(checkPoint);
     }
+    
+    public async Task<int> DeleteOlderThan(DateTime cutoffDate)
+    {
+        using Activity? activity = ApiActivitySource.Instance.StartActivity();
+        var deleteCount = await Session.CreateQuery(
+                "delete from CheckPointBusinessEntity where Timestamp < :cutoffDate")
+            .SetParameter("cutoffDate", cutoffDate)
+            .ExecuteUpdateAsync();
+        
+        await Session.FlushAsync();
+        return deleteCount;
+    }
 }

--- a/src/api/Fig.Api/Datalayer/Repositories/EventLogRepository.cs
+++ b/src/api/Fig.Api/Datalayer/Repositories/EventLogRepository.cs
@@ -134,4 +134,16 @@ public class EventLogRepository : RepositoryBase<EventLogBusinessEntity>, IEvent
 
         return count;
     }
+    
+    public async Task<int> DeleteOlderThan(DateTime cutoffDate)
+    {
+        using Activity? activity = ApiActivitySource.Instance.StartActivity();
+        var deleteCount = await Session.CreateQuery(
+                "delete from EventLogBusinessEntity where Timestamp < :cutoffDate")
+            .SetParameter("cutoffDate", cutoffDate)
+            .ExecuteUpdateAsync();
+        
+        await Session.FlushAsync();
+        return deleteCount;
+    }
 }

--- a/src/api/Fig.Api/Datalayer/Repositories/IApiStatusRepository.cs
+++ b/src/api/Fig.Api/Datalayer/Repositories/IApiStatusRepository.cs
@@ -7,4 +7,6 @@ public interface IApiStatusRepository
     Task AddOrUpdate(ApiStatusBusinessEntity status);
 
     Task<IList<ApiStatusBusinessEntity>> GetAllActive();
+    
+    Task<int> DeleteOlderThan(DateTime cutoffDate);
 }

--- a/src/api/Fig.Api/Datalayer/Repositories/ICheckPointDataRepository.cs
+++ b/src/api/Fig.Api/Datalayer/Repositories/ICheckPointDataRepository.cs
@@ -11,4 +11,6 @@ public interface ICheckPointDataRepository
     Task<IEnumerable<CheckPointDataBusinessEntity>> GetCheckPointsForEncryptionMigration(DateTime secretChangeDate);
 
     Task UpdateCheckPointsAfterEncryptionMigration(List<CheckPointDataBusinessEntity> updatedCheckPoints);
+    
+    Task<int> DeleteOlderThan(DateTime cutoffDate);
 }

--- a/src/api/Fig.Api/Datalayer/Repositories/ICheckPointRepository.cs
+++ b/src/api/Fig.Api/Datalayer/Repositories/ICheckPointRepository.cs
@@ -13,4 +13,6 @@ public interface ICheckPointRepository
     Task<CheckPointBusinessEntity?> GetCheckPoint(Guid id);
 
     Task UpdateCheckPoint(CheckPointBusinessEntity checkPoint);
+    
+    Task<int> DeleteOlderThan(DateTime cutoffDate);
 }

--- a/src/api/Fig.Api/Datalayer/Repositories/IEventLogRepository.cs
+++ b/src/api/Fig.Api/Datalayer/Repositories/IEventLogRepository.cs
@@ -25,4 +25,6 @@ public interface IEventLogRepository
     Task UpdateLogsAfterEncryptionMigration(List<EventLogBusinessEntity> updatedLogs);
     
     Task<long> GetEventLogCount();
+    
+    Task<int> DeleteOlderThan(DateTime cutoffDate);
 }

--- a/src/api/Fig.Api/Datalayer/Repositories/ISettingHistoryRepository.cs
+++ b/src/api/Fig.Api/Datalayer/Repositories/ISettingHistoryRepository.cs
@@ -11,4 +11,6 @@ public interface ISettingHistoryRepository
     Task<IList<SettingValueBusinessEntity>> GetValuesForEncryptionMigration(DateTime secretChangeDate);
 
     Task UpdateValuesAfterEncryptionMigration(List<SettingValueBusinessEntity> values);
+    
+    Task<int> DeleteOlderThan(DateTime cutoffDate);
 }

--- a/src/api/Fig.Api/Datalayer/Repositories/SettingHistoryRepository.cs
+++ b/src/api/Fig.Api/Datalayer/Repositories/SettingHistoryRepository.cs
@@ -65,4 +65,16 @@ public class SettingHistoryRepository : RepositoryBase<SettingValueBusinessEntit
         foreach (var value in values)
             await Session.EvictAsync(value);
     }
+    
+    public async Task<int> DeleteOlderThan(DateTime cutoffDate)
+    {
+        using Activity? activity = ApiActivitySource.Instance.StartActivity();
+        var deleteCount = await Session.CreateQuery(
+                "delete from SettingValueBusinessEntity where ChangedAt < :cutoffDate")
+            .SetParameter("cutoffDate", cutoffDate)
+            .ExecuteUpdateAsync();
+        
+        await Session.FlushAsync();
+        return deleteCount;
+    }
 }

--- a/src/api/Fig.Api/ExtensionMethods/ExceptionExtensionMethods.cs
+++ b/src/api/Fig.Api/ExtensionMethods/ExceptionExtensionMethods.cs
@@ -67,7 +67,7 @@ public static class ExceptionExtensionMethods
     public static bool IsLockContention(this Exception ex)
     {
         // Handle NHibernate's GenericADOException which wraps database-specific exceptions
-        if (ex is GenericADOException adoException && adoException.InnerException != null)
+        if (ex is GenericADOException { InnerException: not null } adoException)
         {
             return adoException.InnerException.IsLockContention();
         }

--- a/src/api/Fig.Api/ExtensionMethods/FigConfigurationBusinessEntityExtensionMethods.cs
+++ b/src/api/Fig.Api/ExtensionMethods/FigConfigurationBusinessEntityExtensionMethods.cs
@@ -20,5 +20,9 @@ public static class FigConfigurationBusinessEntityExtensionMethods
         businessEntity.AllowDisplayScripts = dataContract.AllowDisplayScripts;
         businessEntity.EnableTimeMachine = dataContract.EnableTimeMachine;
         businessEntity.TimelineDurationDays = dataContract.TimelineDurationDays;
+        businessEntity.TimeMachineCleanupDays = dataContract.TimeMachineCleanupDays;
+        businessEntity.EventLogsCleanupDays = dataContract.EventLogsCleanupDays;
+        businessEntity.ApiStatusCleanupDays = dataContract.ApiStatusCleanupDays;
+        businessEntity.SettingHistoryCleanupDays = dataContract.SettingHistoryCleanupDays;
     }
 }

--- a/src/api/Fig.Api/Program.cs
+++ b/src/api/Fig.Api/Program.cs
@@ -168,6 +168,7 @@ builder.Services.AddScoped<ISecretStore, AzureKeyVaultSecretStore>();
 builder.Services.AddScoped<ITimeMachineService, TimeMachineService>();
 builder.Services.AddScoped<ICustomActionService, CustomActionService>();
 builder.Services.AddScoped<IDatabaseMigrationService, DatabaseMigrationService>();
+builder.Services.AddScoped<IDataCleanupService, DataCleanupService>();
 
 builder.Services.AddHttpClient();
 
@@ -183,6 +184,7 @@ builder.Services.AddHostedService<CheckpointTriggerWorker>();
 builder.Services.AddHostedService<SchedulingWorker>();
 builder.Services.AddHostedService<TimeMachineWorker>();
 builder.Services.AddHostedService<WebHookProcessorWorker>();
+builder.Services.AddHostedService<DataCleanupWorker>();
 
 builder.Services.AddScoped<IAuthenticatedService>(a => a.GetService<IConfigurationService>()!);
 builder.Services.AddScoped<IAuthenticatedService>(a => a.GetService<IEventsService>()!);

--- a/src/api/Fig.Api/Services/DataCleanupService.cs
+++ b/src/api/Fig.Api/Services/DataCleanupService.cs
@@ -1,0 +1,143 @@
+using Fig.Api.Datalayer.Repositories;
+using Fig.Datalayer.BusinessEntities;
+
+namespace Fig.Api.Services;
+
+/// <summary>
+/// Service for performing data cleanup operations on old records in the database.
+/// Removes expired data based on configured retention periods.
+/// </summary>
+public class DataCleanupService : IDataCleanupService
+{
+    private readonly ILogger<DataCleanupService> _logger;
+    private readonly IConfigurationRepository _configurationRepository;
+    private readonly ICheckPointRepository _checkPointRepository;
+    private readonly ICheckPointDataRepository _checkPointDataRepository;
+    private readonly IEventLogRepository _eventLogRepository;
+    private readonly IApiStatusRepository _apiStatusRepository;
+    private readonly ISettingHistoryRepository _settingHistoryRepository;
+
+    public DataCleanupService(
+        ILogger<DataCleanupService> logger,
+        IConfigurationRepository configurationRepository,
+        ICheckPointRepository checkPointRepository,
+        ICheckPointDataRepository checkPointDataRepository,
+        IEventLogRepository eventLogRepository,
+        IApiStatusRepository apiStatusRepository,
+        ISettingHistoryRepository settingHistoryRepository)
+    {
+        _logger = logger;
+        _configurationRepository = configurationRepository;
+        _checkPointRepository = checkPointRepository;
+        _checkPointDataRepository = checkPointDataRepository;
+        _eventLogRepository = eventLogRepository;
+        _apiStatusRepository = apiStatusRepository;
+        _settingHistoryRepository = settingHistoryRepository;
+    }
+
+    public async Task<int> PerformCleanupAsync()
+    {
+        _logger.LogInformation("Starting data cleanup operation");
+        
+        var configuration = await _configurationRepository.GetConfiguration();
+
+        // Check if any cleanup is configured (any non-null cleanup days value)
+        var hasCleanupConfigured = configuration.TimeMachineCleanupDays.HasValue ||
+                                   configuration.EventLogsCleanupDays.HasValue ||
+                                   configuration.ApiStatusCleanupDays.HasValue ||
+                                   configuration.SettingHistoryCleanupDays.HasValue;
+        
+        if (!hasCleanupConfigured)
+        {
+            _logger.LogDebug("Data cleanup is disabled - no cleanup days configured");
+            return 0;
+        }
+
+        var now = DateTime.UtcNow;
+        var totalDeleted = 0;
+
+        totalDeleted += await CleanUpTimeMachineRecords(configuration, now);
+        totalDeleted += await CleanUpEventLogs(configuration, now);
+        totalDeleted += await CleanUpApiStatus(configuration, now);
+        totalDeleted += await CleanUpSettingHistory(configuration, now);
+
+        _logger.LogInformation("Data cleanup completed successfully. Total records deleted: {TotalDeleted}", totalDeleted);
+        
+        return totalDeleted;
+    }
+
+    private async Task<int> CleanUpTimeMachineRecords(FigConfigurationBusinessEntity configuration, DateTime now)
+    {
+        // Clean up time machine data (checkpoint and checkpoint_data)
+        if (configuration.TimeMachineCleanupDays is > 0)
+        {
+            var cutoffDate = now.AddDays(-configuration.TimeMachineCleanupDays.Value);
+            _logger.LogInformation("Cleaning up time machine data older than {CutoffDate}", cutoffDate);
+                    
+            // Delete checkpoint data first (child records)
+            var dataDeleted = await _checkPointDataRepository.DeleteOlderThan(cutoffDate);
+            // Then delete checkpoints (parent records)
+            var checkpointsDeleted = await _checkPointRepository.DeleteOlderThan(cutoffDate);
+            
+            _logger.LogInformation("Deleted {CheckpointsDeleted} checkpoints and {DataDeleted} checkpoint data records", 
+                checkpointsDeleted, dataDeleted);
+            
+            return dataDeleted + checkpointsDeleted;
+        }
+
+        return 0;
+    }
+
+    private async Task<int> CleanUpEventLogs(FigConfigurationBusinessEntity configuration, DateTime now)
+    {
+        // Clean up event logs
+        if (configuration.EventLogsCleanupDays is > 0)
+        {
+            var cutoffDate = now.AddDays(-configuration.EventLogsCleanupDays.Value);
+            _logger.LogInformation("Cleaning up event logs older than {CutoffDate}", cutoffDate);
+                    
+            var deleted = await _eventLogRepository.DeleteOlderThan(cutoffDate);
+
+            _logger.LogInformation("Deleted {Deleted} event log records", deleted);
+            return deleted;
+        }
+
+        return 0;
+    }
+    
+    private async Task<int> CleanUpApiStatus(FigConfigurationBusinessEntity configuration, DateTime now)
+    {
+        // Clean up API status
+        if (configuration.ApiStatusCleanupDays is > 0)
+        {
+            var cutoffDate = now.AddDays(-configuration.ApiStatusCleanupDays.Value);
+            _logger.LogInformation("Cleaning up API status records older than {CutoffDate}", cutoffDate);
+                    
+            var deleted = await _apiStatusRepository.DeleteOlderThan(cutoffDate);
+
+            _logger.LogInformation("Deleted {Deleted} API status records", deleted);
+
+            return deleted;
+        }
+
+        return 0;
+    }
+    
+    private async Task<int> CleanUpSettingHistory(FigConfigurationBusinessEntity configuration, DateTime now)
+    {
+        // Clean up setting history
+        if (configuration.SettingHistoryCleanupDays is > 0)
+        {
+            var cutoffDate = now.AddDays(-configuration.SettingHistoryCleanupDays.Value);
+            _logger.LogInformation("Cleaning up setting history older than {CutoffDate}", cutoffDate);
+                    
+            var deleted = await _settingHistoryRepository.DeleteOlderThan(cutoffDate);
+
+            _logger.LogInformation("Deleted {Deleted} setting history records", deleted);
+
+            return deleted;
+        }
+        
+        return 0;
+    }
+}

--- a/src/api/Fig.Api/Services/IDataCleanupService.cs
+++ b/src/api/Fig.Api/Services/IDataCleanupService.cs
@@ -1,0 +1,13 @@
+namespace Fig.Api.Services;
+
+/// <summary>
+/// Service for performing data cleanup operations on old records in the database.
+/// </summary>
+public interface IDataCleanupService
+{
+    /// <summary>
+    /// Performs cleanup of old data based on the configured cleanup settings.
+    /// </summary>
+    /// <returns>The total number of records deleted across all cleanup operations.</returns>
+    Task<int> PerformCleanupAsync();
+}

--- a/src/api/Fig.Api/Workers/DataCleanupWorker.cs
+++ b/src/api/Fig.Api/Workers/DataCleanupWorker.cs
@@ -1,0 +1,58 @@
+using Fig.Api.Services;
+using Fig.Common.Timer;
+
+namespace Fig.Api.Workers;
+
+/// <summary>
+/// Background service that performs scheduled cleanup of old data from the database.
+/// </summary>
+public class DataCleanupWorker : BackgroundService
+{
+    private readonly Random _random = new ();
+    private readonly ILogger<DataCleanupWorker> _logger;
+    private readonly IServiceScopeFactory _serviceScopeFactory;
+    private readonly IPeriodicTimer _timer;
+    
+
+    public DataCleanupWorker(
+        ILogger<DataCleanupWorker> logger,
+        ITimerFactory timerFactory,
+        IServiceScopeFactory serviceScopeFactory)
+    {
+        _logger = logger;
+        _serviceScopeFactory = serviceScopeFactory;
+        var cleanupInterval = TimeSpan.FromMinutes(_random.Next(480, 720)); // Random interval between 8-12 hours
+        _logger.LogInformation("Data cleanup worker will run every {Interval} minutes", cleanupInterval.TotalMinutes);
+        _timer = timerFactory.Create(cleanupInterval); 
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("Data cleanup worker starting");
+        
+        // Run cleanup on startup after a short delay
+        await Task.Delay(TimeSpan.FromSeconds(_random.Next(30, 300)), stoppingToken); // Random delay between 30s and 5min
+        await PerformCleanup();
+
+        // Then run twice per day at midnight and noon UTC
+        while (await _timer.WaitForNextTickAsync(stoppingToken) && !stoppingToken.IsCancellationRequested)
+        {
+            await PerformCleanup();
+        }
+    }
+
+    private async Task PerformCleanup()
+    {
+        using var scope = _serviceScopeFactory.CreateScope();
+        
+        try
+        {
+            var cleanupService = scope.ServiceProvider.GetRequiredService<IDataCleanupService>();
+            await cleanupService.PerformCleanupAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error during data cleanup operation");
+        }
+    }
+}

--- a/src/api/Fig.Datalayer/BusinessEntities/FigConfigurationBusinessEntity.cs
+++ b/src/api/Fig.Datalayer/BusinessEntities/FigConfigurationBusinessEntity.cs
@@ -30,4 +30,12 @@ public class FigConfigurationBusinessEntity
     public virtual bool EnableTimeMachine { get; set; } = true;
 
     public virtual int TimelineDurationDays { get; set; } = 60;
+    
+    public virtual int? TimeMachineCleanupDays { get; set; } = 90;
+    
+    public virtual int? EventLogsCleanupDays { get; set; }
+    
+    public virtual int? ApiStatusCleanupDays { get; set; } = 90;
+    
+    public virtual int? SettingHistoryCleanupDays { get; set; }
 }

--- a/src/api/Fig.Datalayer/Mappings/FigConfigurationMapping.cs
+++ b/src/api/Fig.Datalayer/Mappings/FigConfigurationMapping.cs
@@ -24,5 +24,9 @@ public class FigConfigurationMapping : ClassMapping<FigConfigurationBusinessEnti
         Property(x => x.AllowDisplayScripts, x => x.Column("allow_display_scripts"));
         Property(x => x.EnableTimeMachine, x => x.Column("enable_time_machine"));
         Property(x => x.TimelineDurationDays, x => x.Column("timeline_duration_days"));
+        Property(x => x.TimeMachineCleanupDays, x => x.Column("time_machine_cleanup_days"));
+        Property(x => x.EventLogsCleanupDays, x => x.Column("event_logs_cleanup_days"));
+        Property(x => x.ApiStatusCleanupDays, x => x.Column("api_status_cleanup_days"));
+        Property(x => x.SettingHistoryCleanupDays, x => x.Column("setting_history_cleanup_days"));
     }
 }

--- a/src/common/Fig.Contracts/Configuration/FigConfigurationDataContract.cs
+++ b/src/common/Fig.Contracts/Configuration/FigConfigurationDataContract.cs
@@ -30,6 +30,14 @@ namespace Fig.Contracts.Configuration
         
         public int TimelineDurationDays { get; set; } = 30;
 
+        public int? TimeMachineCleanupDays { get; set; }
+        
+        public int? EventLogsCleanupDays { get; set; }
+        
+        public int? ApiStatusCleanupDays { get; set; }
+        
+        public int? SettingHistoryCleanupDays { get; set; }
+
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder();

--- a/src/tests/Fig.Integration.Test/Api/ApiStatusTests.cs
+++ b/src/tests/Fig.Integration.Test/Api/ApiStatusTests.cs
@@ -19,16 +19,4 @@ public class ApiStatusTests : IntegrationTestBase
         Assert.That(statuses.All(a => a.Hostname == Environment.MachineName), "Status should be from this api");
         Assert.That(statuses.All(a => a.LastSeen > (DateTime.UtcNow - TimeSpan.FromMinutes(2))), "Expired apis should have been removed");
     }
-    
-    private async Task<List<ApiStatusDataContract>> GetAllApiStatuses()
-    {
-        const string uri = "/apistatus";
-        var result = await ApiClient.Get<List<ApiStatusDataContract>>(uri);
-        
-        if (result == null)
-            throw new ApplicationException($"Expected non null result for get for URI {uri}");
-
-        return result;
-        
-    }
 }

--- a/src/tests/Fig.Integration.Test/Api/DataCleanupTests.cs
+++ b/src/tests/Fig.Integration.Test/Api/DataCleanupTests.cs
@@ -1,0 +1,458 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Fig.Api.Services;
+using Fig.Contracts.Settings;
+using Fig.Test.Common;
+using Fig.Test.Common.TestSettings;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+
+namespace Fig.Integration.Test.Api;
+
+[TestFixture]
+public class DataCleanupTests : IntegrationTestBase
+{
+    [Test]
+    public async Task ShallAcceptDataCleanupConfigurationWithAllOptionsEnabled()
+    {
+        // Arrange & Act
+        var configuration = CreateConfiguration(
+            timeMachineCleanupDays: 90,
+            eventLogsCleanupDays: 60,
+            apiStatusCleanupDays: 30,
+            settingHistoryCleanupDays: 120);
+        
+        var result = await SetConfiguration(configuration);
+        
+        // Assert
+        Assert.That(result.IsSuccessStatusCode, Is.True, 
+            "Should accept data cleanup configuration with all options enabled");
+    }
+
+    [Test]
+    public async Task ShallAcceptDataCleanupConfigurationWithSomeOptionsDisabled()
+    {
+        // Arrange & Act
+        var configuration = CreateConfiguration(
+            timeMachineCleanupDays: 90,
+            eventLogsCleanupDays: null,  // Disabled
+            apiStatusCleanupDays: 30,
+            settingHistoryCleanupDays: null);  // Disabled
+        
+        var result = await SetConfiguration(configuration);
+        
+        // Assert
+        Assert.That(result.IsSuccessStatusCode, Is.True, 
+            "Should accept data cleanup configuration with some options disabled");
+    }
+
+    [Test]
+    public async Task ShallAcceptDataCleanupConfigurationWhenAllDisabled()
+    {
+        // Arrange & Act - all cleanup types disabled (null values)
+        var configuration = CreateConfiguration(
+            timeMachineCleanupDays: null,
+            eventLogsCleanupDays: null,
+            apiStatusCleanupDays: null,
+            settingHistoryCleanupDays: null);
+        
+        var result = await SetConfiguration(configuration);
+        
+        // Assert
+        Assert.That(result.IsSuccessStatusCode, Is.True, 
+            "Should accept data cleanup configuration when all cleanup types are disabled");
+    }
+
+    [Test]
+    public async Task ShallAcceptDefaultDataCleanupConfiguration()
+    {
+        // Arrange & Act - use defaults (time machine and api status enabled at 90 days)
+        var configuration = CreateConfiguration();
+        
+        var result = await SetConfiguration(configuration);
+        
+        // Assert
+        Assert.That(result.IsSuccessStatusCode, Is.True, 
+            "Should accept default data cleanup configuration");
+    }
+
+    [Test]
+    public async Task ShallAllowDataCleanupConfigurationUpdates()
+    {
+        // Arrange - first set with cleanup disabled
+        await SetConfiguration(CreateConfiguration(
+            timeMachineCleanupDays: null,
+            eventLogsCleanupDays: null,
+            apiStatusCleanupDays: null,
+            settingHistoryCleanupDays: null));
+        
+        // Act - update to enable cleanup
+        var updatedConfig = CreateConfiguration(
+            timeMachineCleanupDays: 60,
+            eventLogsCleanupDays: 30);
+        
+        var result = await SetConfiguration(updatedConfig);
+        
+        // Assert
+        Assert.That(result.IsSuccessStatusCode, Is.True, 
+            "Should allow updating data cleanup configuration");
+    }
+    
+    [Test]
+    public async Task ShallNotDeleteRecentEventLogsWhenConfigured()
+    {
+        // Arrange - Configure cleanup for event logs older than 7 days
+        await SetConfiguration(CreateConfiguration(eventLogsCleanupDays: 7));
+        
+        var startTime = DateTime.UtcNow;
+        
+        // Create some test data by making setting changes
+        var settings = await RegisterSettings<ThreeSettings>();
+        
+        // Make several setting changes to generate event logs
+        for (int i = 0; i < 5; i++)
+        {
+            await SetSettings(settings.ClientName, new List<SettingDataContract>
+            {
+                new(nameof(settings.AStringSetting), new StringSettingDataContract($"Value{i}"))
+            });
+        }
+        
+        // Wait a moment for events to be saved
+        await Task.Delay(500);
+        
+        // Verify we have event logs
+        var eventsBefore = await GetEvents(startTime, DateTime.UtcNow);
+        var eventCountBefore = await GetEventCount();
+        Assert.That(eventsBefore.Events.Count(), Is.GreaterThan(0), "Should have created event logs");
+        
+        // Act - Run cleanup service (should not delete anything since events are recent)
+        using (var scope = GetServiceScope())
+        {
+            var cleanupService = scope.ServiceProvider.GetRequiredService<IDataCleanupService>();
+            var deletedRecent = await cleanupService.PerformCleanupAsync();
+            
+            // Assert - No recent events should be deleted
+            Assert.That(deletedRecent, Is.EqualTo(0), "Should not delete recent event logs");
+        }
+        
+        var eventCountAfterFirstCleanup = await GetEventCount();
+        Assert.That(eventCountAfterFirstCleanup, Is.EqualTo(eventCountBefore), 
+            "Event count should remain the same after cleaning recent data");
+    }
+    
+    [Test]
+    public async Task ShallNotDeleteRecentCheckpointsWhenConfigured()
+    {
+        // Arrange - Configure cleanup for checkpoints older than 7 days  
+        await SetConfiguration(CreateConfiguration(timeMachineCleanupDays: 7));
+        
+        var startTime = DateTime.UtcNow;
+        
+        // Register a client and wait for checkpoint to be created
+        await RegisterClientAndWaitForCheckpoint<ThreeSettings>();
+        
+        // Verify we have checkpoints
+        var checkpointsBefore = await GetCheckpoints(startTime, DateTime.UtcNow);
+        Assert.That(checkpointsBefore.CheckPoints.Count(), Is.GreaterThan(0), 
+            "Should have created checkpoints");
+        
+        // Act - Run cleanup service (should not delete anything since checkpoints are recent)
+        using (var scope = GetServiceScope())
+        {
+            var cleanupService = scope.ServiceProvider.GetRequiredService<IDataCleanupService>();
+            var deleted = await cleanupService.PerformCleanupAsync();
+            
+            // Assert - No recent checkpoints should be deleted
+            Assert.That(deleted, Is.EqualTo(0), "Should not delete recent checkpoints");
+        }
+        
+        var checkpointsAfter = await GetCheckpoints(startTime, DateTime.UtcNow);
+        Assert.That(checkpointsAfter.CheckPoints.Count(), Is.EqualTo(checkpointsBefore.CheckPoints.Count()), 
+            "Checkpoint count should remain the same");
+    }
+    
+    [Test]
+    public async Task ShallDeleteOldCheckpointsWhenConfigured()
+    {
+        // Arrange - Configure cleanup for checkpoints older than 7 days  
+        await SetConfiguration(CreateConfiguration(timeMachineCleanupDays: 7));
+        
+        var startTime = DateTime.UtcNow;
+        
+        // Register a client and wait for checkpoint to be created
+        await RegisterClientAndWaitForCheckpoint<ThreeSettings>();
+        
+        // Verify we have the recent checkpoint
+        var checkpointsBefore = await GetCheckpoints(startTime, DateTime.UtcNow);
+        Assert.That(checkpointsBefore.CheckPoints.Count(), Is.EqualTo(1), 
+            "Should have created one checkpoint");
+        
+        var recentCheckpoint = checkpointsBefore.CheckPoints.First();
+        
+        // Backdate the checkpoint to make it older than the retention period (8 days old)
+        var oldTimestamp = DateTime.UtcNow.AddDays(-8);
+        await BackdateCheckpoint(recentCheckpoint.Id, oldTimestamp);
+        
+        // Verify the checkpoint now appears in the old date range
+        var oldCheckpoints = await GetCheckpoints(oldTimestamp.AddMinutes(-1), oldTimestamp.AddMinutes(1));
+        Assert.That(oldCheckpoints.CheckPoints.Count(), Is.EqualTo(1), 
+            "Should have one backdated checkpoint");
+        
+        // Act - Run cleanup service (should delete the old checkpoint)
+        int deletedCount;
+        using (var scope = GetServiceScope())
+        {
+            var cleanupService = scope.ServiceProvider.GetRequiredService<IDataCleanupService>();
+            deletedCount = await cleanupService.PerformCleanupAsync();
+        }
+        
+        // Assert - The old checkpoint should be deleted
+        Assert.That(deletedCount, Is.GreaterThan(0), "Should have deleted old checkpoint");
+        
+        var checkpointsAfter = await GetCheckpoints(oldTimestamp.AddMinutes(-1), oldTimestamp.AddMinutes(1));
+        Assert.That(checkpointsAfter.CheckPoints.Count(), Is.EqualTo(0), 
+            "Old checkpoint should no longer exist");
+    }
+    
+    [Test]
+    public async Task ShallNotDeleteDataWhenCleanupDisabled()
+    {
+        // Arrange - Disable all cleanup
+        await SetConfiguration(CreateConfiguration(
+            timeMachineCleanupDays: null,
+            eventLogsCleanupDays: null,
+            apiStatusCleanupDays: null,
+            settingHistoryCleanupDays: null));
+        
+        var startTime = DateTime.UtcNow;
+        
+        // Create test data
+        var settings = await RegisterSettings<ThreeSettings>();
+        await SetSettings(settings.ClientName, new List<SettingDataContract>
+        {
+            new(nameof(settings.AStringSetting), new StringSettingDataContract("TestValue"))
+        });
+        
+        await Task.Delay(500);
+        
+        var eventsBefore = await GetEvents(startTime, DateTime.UtcNow);
+        var eventCountBefore = eventsBefore.Events.Count();
+        
+        // Act - Run cleanup service
+        using (var scope = GetServiceScope())
+        {
+            var cleanupService = scope.ServiceProvider.GetRequiredService<IDataCleanupService>();
+            var deleted = await cleanupService.PerformCleanupAsync();
+            
+            // Assert - Nothing should be deleted
+            Assert.That(deleted, Is.EqualTo(0), "Should not delete any data when cleanup is disabled");
+        }
+        
+        var eventsAfter = await GetEvents(startTime, DateTime.UtcNow);
+        Assert.That(eventsAfter.Events.Count(), Is.EqualTo(eventCountBefore), 
+            "Event count should remain unchanged");
+    }
+    
+    [Test]
+    public async Task ShallReturnZeroWhenNoOldDataExists()
+    {
+        // Arrange - Configure aggressive cleanup (1 day retention)
+        await SetConfiguration(CreateConfiguration(
+            timeMachineCleanupDays: 1,
+            eventLogsCleanupDays: 1,
+            apiStatusCleanupDays: 1,
+            settingHistoryCleanupDays: 1));
+        
+        // Clean database first
+        await DeleteAllClients();
+        await DeleteAllCheckPointTriggers();
+        
+        // Act - Run cleanup on empty/recent data
+        using (var scope = GetServiceScope())
+        {
+            var cleanupService = scope.ServiceProvider.GetRequiredService<IDataCleanupService>();
+            var deleted = await cleanupService.PerformCleanupAsync();
+            
+            // Assert
+            Assert.That(deleted, Is.EqualTo(0), 
+                "Should return 0 when no old data exists to delete");
+        }
+    }
+    
+    [Test]
+    public async Task ShallOnlyDeleteDataOlderThanConfiguredDays()
+    {
+        // Arrange - Configure cleanup for 30 days
+        await SetConfiguration(CreateConfiguration(eventLogsCleanupDays: 30));
+        
+        var startTime = DateTime.UtcNow;
+        
+        // Create recent test data
+        var settings = await RegisterSettings<ThreeSettings>();
+        await SetSettings(settings.ClientName, new List<SettingDataContract>
+        {
+            new(nameof(settings.AStringSetting), new StringSettingDataContract("RecentValue"))
+        });
+        
+        await Task.Delay(500);
+        
+        var eventsBefore = await GetEvents(startTime, DateTime.UtcNow);
+        var recentEventCount = eventsBefore.Events.Count();
+        
+        // Act - Run cleanup
+        using (var scope = GetServiceScope())
+        {
+            var cleanupService = scope.ServiceProvider.GetRequiredService<IDataCleanupService>();
+            var deleted = await cleanupService.PerformCleanupAsync();
+            
+            // Assert - No recent data (< 30 days) should be deleted
+            Assert.That(deleted, Is.EqualTo(0), "Should not delete data newer than 30 days");
+        }
+        
+        var eventsAfter = await GetEvents(startTime, DateTime.UtcNow);
+        Assert.That(eventsAfter.Events.Count(), Is.EqualTo(recentEventCount), 
+            "Recent events should still exist");
+    }
+    
+    [Test]
+    public async Task ShallDeleteOldEventLogs()
+    {
+        // Arrange - Configure cleanup for event logs older than 7 days
+        await SetConfiguration(CreateConfiguration(eventLogsCleanupDays: 7));
+        
+        var startTime = DateTime.UtcNow;
+        
+        // Create some test data by making setting changes
+        var settings = await RegisterSettings<ThreeSettings>();
+        
+        // Make several setting changes to generate event logs
+        for (int i = 0; i < 3; i++)
+        {
+            await SetSettings(settings.ClientName, new List<SettingDataContract>
+            {
+                new(nameof(settings.AStringSetting), new StringSettingDataContract($"Value{i}"))
+            });
+        }
+        
+        // Wait a moment for events to be saved
+        await Task.Delay(500);
+        
+        // Verify we have event logs
+        var eventsBefore = await GetEvents(startTime, DateTime.UtcNow);
+        var eventCountBefore = eventsBefore.Events.Count();
+        Assert.That(eventCountBefore, Is.GreaterThan(0), "Should have created event logs");
+        
+        // Backdate the event logs to make them older than the retention period (8 days old)
+        var oldTimestamp = DateTime.UtcNow.AddDays(-8);
+        await BackdateEventLogs(startTime, DateTime.UtcNow, oldTimestamp);
+        
+        // Verify the events now appear in the old date range
+        var oldEvents = await GetEvents(oldTimestamp.AddMinutes(-1), oldTimestamp.AddMinutes(1));
+        Assert.That(oldEvents.Events.Count(), Is.EqualTo(eventCountBefore), 
+            "Should have backdated event logs");
+        
+        // Act - Run cleanup service (should delete the old events)
+        int deletedCount;
+        using (var scope = GetServiceScope())
+        {
+            var cleanupService = scope.ServiceProvider.GetRequiredService<IDataCleanupService>();
+            deletedCount = await cleanupService.PerformCleanupAsync();
+        }
+        
+        // Assert - The old events should be deleted
+        Assert.That(deletedCount, Is.GreaterThan(0), "Should have deleted old event logs");
+        
+        var eventsAfter = await GetEvents(oldTimestamp.AddMinutes(-1), oldTimestamp.AddMinutes(1));
+        Assert.That(eventsAfter.Events.Count(), Is.EqualTo(0), 
+            "Old event logs should no longer exist");
+    }
+    
+    [Test]
+    public async Task ShallDeleteOldApiStatus()
+    {
+        // Arrange - Configure cleanup for API status older than 7 days
+        await SetConfiguration(CreateConfiguration(apiStatusCleanupDays: 7));
+        
+        // Get initial count before inserting old records
+        var initialStatuses = await GetAllApiStatuses();
+        var initialCount = initialStatuses.Count;
+        
+        // Insert old, inactive API status records directly (8 days old)
+        var oldTimestamp = DateTime.UtcNow.AddDays(-8);
+        var oldStatusCount = 3;
+        await InsertOldApiStatus(oldTimestamp, oldStatusCount);
+        
+        // Note: GetAllApiStatuses only returns active statuses, so we can't verify
+        // the old inactive records were inserted via the API. We trust the insert worked.
+        
+        // Act - Run cleanup service (should delete the old, inactive API status records)
+        int deletedCount;
+        using (var scope = GetServiceScope())
+        {
+            var cleanupService = scope.ServiceProvider.GetRequiredService<IDataCleanupService>();
+            deletedCount = await cleanupService.PerformCleanupAsync();
+        }
+        
+        // Assert - The old API status records should be deleted
+        Assert.That(deletedCount, Is.GreaterThanOrEqualTo(oldStatusCount), 
+            "Should have deleted old API status records");
+        
+        // Verify count remains the same (only active statuses, old inactive ones were cleaned up)
+        var statusesAfter = await GetAllApiStatuses();
+        Assert.That(statusesAfter.Count, Is.EqualTo(initialCount), 
+            "Active API status count should remain unchanged after cleanup");
+    }
+    
+    [Test]
+    public async Task ShallDeleteOldSettingHistory()
+    {
+        // Arrange - Configure cleanup for setting history older than 7 days
+        await SetConfiguration(CreateConfiguration(settingHistoryCleanupDays: 7));
+        
+        var startTime = DateTime.UtcNow;
+        
+        // Create some test data by making setting changes
+        var settings = await RegisterSettings<ThreeSettings>();
+        
+        // Make several setting changes to generate history records
+        for (int i = 0; i < 5; i++)
+        {
+            await SetSettings(settings.ClientName, new List<SettingDataContract>
+            {
+                new(nameof(settings.AStringSetting), new StringSettingDataContract($"HistoryValue{i}"))
+            });
+            await Task.Delay(100); // Small delay between changes
+        }
+        
+        // Wait a moment for history to be saved
+        await Task.Delay(500);
+        
+        // Verify we have setting history
+        var historyBefore = await GetHistory(settings.ClientName, nameof(settings.AStringSetting));
+        var historyCountBefore = historyBefore.Count();
+        Assert.That(historyCountBefore, Is.GreaterThan(0), "Should have created setting history records");
+        
+        // Backdate the setting history to make it older than the retention period (8 days old)
+        var oldTimestamp = DateTime.UtcNow.AddDays(-8);
+        await BackdateSettingHistory(startTime, DateTime.UtcNow, oldTimestamp);
+        
+        // Act - Run cleanup service (should delete the old setting history)
+        int deletedCount;
+        using (var scope = GetServiceScope())
+        {
+            var cleanupService = scope.ServiceProvider.GetRequiredService<IDataCleanupService>();
+            deletedCount = await cleanupService.PerformCleanupAsync();
+        }
+        
+        // Assert - The old setting history should be deleted
+        Assert.That(deletedCount, Is.GreaterThan(0), "Should have deleted old setting history records");
+        
+        var historyAfter = await GetHistory(settings.ClientName, nameof(settings.AStringSetting));
+        Assert.That(historyAfter.Count(), Is.EqualTo(0), 
+            "Old setting history should no longer exist");
+    }
+}
+

--- a/src/web/Fig.Web/Converters/FigConfigurationConverter.cs
+++ b/src/web/Fig.Web/Converters/FigConfigurationConverter.cs
@@ -21,7 +21,11 @@ public class FigConfigurationConverter : IFigConfigurationConverter
             PollIntervalOverride = model.PollIntervalOverride,
             AllowDisplayScripts = model.AllowDisplayScripts,
             EnableTimeMachine = model.EnableTimeMachine,
-            TimelineDurationDays = model.TimelineDurationDays
+            TimelineDurationDays = model.TimelineDurationDays,
+            TimeMachineCleanupDays = model.TimeMachineCleanupDays,
+            EventLogsCleanupDays = model.EventLogsCleanupDays,
+            ApiStatusCleanupDays = model.ApiStatusCleanupDays,
+            SettingHistoryCleanupDays = model.SettingHistoryCleanupDays
         };
     }
 
@@ -41,7 +45,11 @@ public class FigConfigurationConverter : IFigConfigurationConverter
             PollIntervalOverride = dataContract.PollIntervalOverride,
             AllowDisplayScripts = dataContract.AllowDisplayScripts,
             EnableTimeMachine = dataContract.EnableTimeMachine,
-            TimelineDurationDays = dataContract.TimelineDurationDays
+            TimelineDurationDays = dataContract.TimelineDurationDays,
+            TimeMachineCleanupDays = dataContract.TimeMachineCleanupDays,
+            EventLogsCleanupDays = dataContract.EventLogsCleanupDays,
+            ApiStatusCleanupDays = dataContract.ApiStatusCleanupDays,
+            SettingHistoryCleanupDays = dataContract.SettingHistoryCleanupDays
         };
     }
 }

--- a/src/web/Fig.Web/Models/Configuration/FigConfigurationModel.cs
+++ b/src/web/Fig.Web/Models/Configuration/FigConfigurationModel.cs
@@ -25,8 +25,16 @@ public class FigConfigurationModel
     public bool AllowDisplayScripts { get; set; }
     
     public bool EnableTimeMachine { get; set; }
-    
+
     public int TimelineDurationDays { get; set; } = 60;
+
+    public int? TimeMachineCleanupDays { get; set; }
+    
+    public int? EventLogsCleanupDays { get; set; }
+    
+    public int? ApiStatusCleanupDays { get; set; }
+    
+    public int? SettingHistoryCleanupDays { get; set; }
 
     public FigConfigurationModel Clone()
     {
@@ -44,7 +52,11 @@ public class FigConfigurationModel
             PollIntervalOverride = PollIntervalOverride,
             AllowDisplayScripts = AllowDisplayScripts,
             EnableTimeMachine = EnableTimeMachine,
-            TimelineDurationDays = TimelineDurationDays
+            TimelineDurationDays = TimelineDurationDays,
+            TimeMachineCleanupDays = TimeMachineCleanupDays,
+            EventLogsCleanupDays = EventLogsCleanupDays,
+            ApiStatusCleanupDays = ApiStatusCleanupDays,
+            SettingHistoryCleanupDays = SettingHistoryCleanupDays
         };
     }
 
@@ -63,5 +75,9 @@ public class FigConfigurationModel
         AllowDisplayScripts = model.AllowDisplayScripts;
         EnableTimeMachine = model.EnableTimeMachine;
         TimelineDurationDays = model.TimelineDurationDays;
+        TimeMachineCleanupDays = model.TimeMachineCleanupDays;
+        EventLogsCleanupDays = model.EventLogsCleanupDays;
+        ApiStatusCleanupDays = model.ApiStatusCleanupDays;
+        SettingHistoryCleanupDays = model.SettingHistoryCleanupDays;
     }
 }

--- a/src/web/Fig.Web/Pages/Configuration.razor
+++ b/src/web/Fig.Web/Pages/Configuration.razor
@@ -147,6 +147,81 @@
                 </div>
             </RadzenCard>
 
+            <RadzenCard class="m-3">
+                <h3 class="h5">Data Cleanup</h3>
+                <p>Regularly clean up old data from the database to manage storage and improve performance.</p>
+                <p>The cleanup job runs on startup and then every 8 to 12 hours (randomized).</p>
+                <p>Specify the maximum age in days for different types of data or disable using the check box.</p>
+                
+                <div class="pt-3">
+                    <h5>Time Machine (Checkpoints)</h5>
+                    <p>Clean up checkpoint snapshots older than the specified number of days.</p>
+                    <div class="p-1">
+                        <RadzenCheckBox @bind-Value="@_timeMachineCleanupEnabled" 
+                                       @onchange="@(args => OnTimeMachineCleanupEnabledChanged(args.Value as bool? ?? false))"/>
+                        <label class="ms-2">Clean up checkpoints older than</label>
+                        <RadzenNumeric TValue="int?" @bind-Value="@(ConfigurationModel.TimeMachineCleanupDays)" 
+                                      Disabled="@(!_timeMachineCleanupEnabled)"
+                                      Change="OnConfigurationValueChanged" 
+                                      Min="1" 
+                                      class="ms-2" 
+                                      Style="width: 100px"/>
+                        <label class="ms-2">days</label>
+                    </div>
+                </div>
+                
+                <div class="pt-3">
+                    <h5>Event Logs</h5>
+                    <p>Clean up audit trail event logs older than the specified number of days.</p>
+                    <div class="p-1">
+                        <RadzenCheckBox @bind-Value="@_eventLogsCleanupEnabled" 
+                                       @onchange="@(args => OnEventLogsCleanupEnabledChanged(args.Value as bool? ?? false))"/>
+                        <label class="ms-2">Clean up event logs older than</label>
+                        <RadzenNumeric TValue="int?" @bind-Value="@(ConfigurationModel.EventLogsCleanupDays)" 
+                                      Disabled="@(!_eventLogsCleanupEnabled)"
+                                      Change="OnConfigurationValueChanged" 
+                                      Min="1" 
+                                      class="ms-2" 
+                                      Style="width: 100px"/>
+                        <label class="ms-2">days</label>
+                    </div>
+                </div>
+                
+                <div class="pt-3">
+                    <h5>API Status</h5>
+                    <p>Clean up inactive API instance status records older than the specified number of days.</p>
+                    <div class="p-1">
+                        <RadzenCheckBox @bind-Value="@_apiStatusCleanupEnabled" 
+                                       @onchange="@(args => OnApiStatusCleanupEnabledChanged(args.Value as bool? ?? false))"/>
+                        <label class="ms-2">Clean up API status older than</label>
+                        <RadzenNumeric TValue="int?" @bind-Value="@(ConfigurationModel.ApiStatusCleanupDays)" 
+                                      Disabled="@(!_apiStatusCleanupEnabled)"
+                                      Change="OnConfigurationValueChanged" 
+                                      Min="1" 
+                                      class="ms-2" 
+                                      Style="width: 100px"/>
+                        <label class="ms-2">days</label>
+                    </div>
+                </div>
+                
+                <div class="pt-3">
+                    <h5>Setting History</h5>
+                    <p>Clean up setting value change history older than the specified number of days.</p>
+                    <div class="p-1">
+                        <RadzenCheckBox @bind-Value="@_settingHistoryCleanupEnabled" 
+                                       @onchange="@(args => OnSettingHistoryCleanupEnabledChanged(args.Value as bool? ?? false))"/>
+                        <label class="ms-2">Clean up setting history older than</label>
+                        <RadzenNumeric TValue="int?" @bind-Value="@(ConfigurationModel.SettingHistoryCleanupDays)" 
+                                      Disabled="@(!_settingHistoryCleanupEnabled)"
+                                      Change="OnConfigurationValueChanged" 
+                                      Min="1" 
+                                      class="ms-2" 
+                                      Style="width: 100px"/>
+                        <label class="ms-2">days</label>
+                    </div>
+                </div>
+            </RadzenCard>
+
         </div>
         <div class="col">
         </div>

--- a/src/web/Fig.Web/Pages/Configuration.razor.cs
+++ b/src/web/Fig.Web/Pages/Configuration.razor.cs
@@ -12,6 +12,10 @@ namespace Fig.Web.Pages
     {
         private bool _isMigrationInProgress;
         private bool _isTestingAzureKeyVault;
+        private bool _timeMachineCleanupEnabled;
+        private bool _eventLogsCleanupEnabled;
+        private bool _apiStatusCleanupEnabled;
+        private bool _settingHistoryCleanupEnabled;
         
         [Inject]
         private IConfigurationFacade ConfigurationFacade { get; set; } = null!;
@@ -27,6 +31,13 @@ namespace Fig.Web.Pages
         protected override async Task OnInitializedAsync()
         {
             await ConfigurationFacade.LoadConfiguration();
+            
+            // Initialize checkbox states based on whether cleanup days have values
+            _timeMachineCleanupEnabled = ConfigurationModel.TimeMachineCleanupDays is > 0;
+            _eventLogsCleanupEnabled = ConfigurationModel.EventLogsCleanupDays is > 0;
+            _apiStatusCleanupEnabled = ConfigurationModel.ApiStatusCleanupDays is > 0;
+            _settingHistoryCleanupEnabled = ConfigurationModel.SettingHistoryCleanupDays is > 0;
+            
             await base.OnInitializedAsync();
         }
 
@@ -75,6 +86,58 @@ namespace Fig.Web.Pages
             {
                 _isTestingAzureKeyVault = false;
             }
+        }
+        
+        private void OnTimeMachineCleanupEnabledChanged(bool enabled)
+        {
+            if (!enabled)
+            {
+                ConfigurationModel.TimeMachineCleanupDays = null;
+            }
+            else if (!ConfigurationModel.TimeMachineCleanupDays.HasValue)
+            {
+                ConfigurationModel.TimeMachineCleanupDays = 90;
+            }
+            OnConfigurationValueChanged();
+        }
+        
+        private void OnEventLogsCleanupEnabledChanged(bool enabled)
+        {
+            if (!enabled)
+            {
+                ConfigurationModel.EventLogsCleanupDays = null;
+            }
+            else if (!ConfigurationModel.EventLogsCleanupDays.HasValue)
+            {
+                ConfigurationModel.EventLogsCleanupDays = 90;
+            }
+            OnConfigurationValueChanged();
+        }
+        
+        private void OnApiStatusCleanupEnabledChanged(bool enabled)
+        {
+            if (!enabled)
+            {
+                ConfigurationModel.ApiStatusCleanupDays = null;
+            }
+            else if (!ConfigurationModel.ApiStatusCleanupDays.HasValue)
+            {
+                ConfigurationModel.ApiStatusCleanupDays = 90;
+            }
+            OnConfigurationValueChanged();
+        }
+        
+        private void OnSettingHistoryCleanupEnabledChanged(bool enabled)
+        {
+            if (!enabled)
+            {
+                ConfigurationModel.SettingHistoryCleanupDays = null;
+            }
+            else if (!ConfigurationModel.SettingHistoryCleanupDays.HasValue)
+            {
+                ConfigurationModel.SettingHistoryCleanupDays = 90;
+            }
+            OnConfigurationValueChanged();
         }
     }
 }


### PR DESCRIPTION
… history and api status records can be deleted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic background data cleanup that periodically removes old records.
  * New configuration options (enable + retention days) for Time Machine (checkpoints), Event Logs, API Status, and Setting History exposed in the Configuration page.

* **Improvements**
  * Retention settings are applied system-wide with sensible defaults when enabled.

* **Tests**
  * Integration tests added to validate configuration acceptance and cleanup behavior.

* **Documentation**
  * Configuration docs updated with a Data Cleanup section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->