### PR TITLE
Add category filter and count of filtered setting results

### DIFF
--- a/src/web/Fig.Web/Models/Setting/CategoryFilterModel.cs
+++ b/src/web/Fig.Web/Models/Setting/CategoryFilterModel.cs
@@ -1,0 +1,27 @@
+namespace Fig.Web.Models.Setting;
+
+public class CategoryFilterModel
+{
+    public CategoryFilterModel(string name, string color)
+    {
+        Name = name;
+        Color = color;
+    }
+    
+    public string Name { get; }
+    public string Color { get; }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is CategoryFilterModel other)
+        {
+            return Name.Equals(other.Name, StringComparison.OrdinalIgnoreCase);
+        }
+        return false;
+    }
+
+    public override int GetHashCode()
+    {
+        return Name.ToLowerInvariant().GetHashCode();
+    }
+}

--- a/src/web/Fig.Web/Models/Setting/ISetting.cs
+++ b/src/web/Fig.Web/Models/Setting/ISetting.cs
@@ -127,6 +127,8 @@ public interface ISetting : IScriptableSetting
     void UpdateEnabledStatus();
 
     void FilterChanged(string filter);
+    
+    void CategoryFilterChanged(string? categoryName);
 
     string GetStringValue(int maxLength = 200);
 

--- a/src/web/Fig.Web/Models/Setting/SettingClientConfigurationModel.cs
+++ b/src/web/Fig.Web/Models/Setting/SettingClientConfigurationModel.cs
@@ -175,6 +175,26 @@ public class SettingClientConfigurationModel
             setting.FilterChanged(filter);
         }
     }
+    
+    public void FilterSettingsByCategory(string? categoryName)
+    {
+        foreach (var setting in Settings)
+        {
+            setting.CategoryFilterChanged(categoryName);
+        }
+    }
+    
+    public List<CategoryFilterModel> GetUniqueCategories()
+    {
+        var categories = Settings
+            .Where(s => !string.IsNullOrWhiteSpace(s.CategoryName))
+            .Select(s => new CategoryFilterModel(s.CategoryName, s.CategoryColor))
+            .Distinct()
+            .OrderBy(c => c.Name)
+            .ToList();
+            
+        return categories;
+    }
 
     public void CollapseAll()
     {

--- a/src/web/Fig.Web/Models/Setting/SettingConfigurationModel.cs
+++ b/src/web/Fig.Web/Models/Setting/SettingConfigurationModel.cs
@@ -25,6 +25,7 @@ public abstract class SettingConfigurationModel<T> : ISetting, ISearchableSettin
     private bool _showAdvanced;
     private bool _isEnabled = true;
     private bool _matchesFilter = true;
+    private bool _matchesCategoryFilter = true;
     private bool _isVisibleFromScript;
     private bool _showModifiedOnly;
     private readonly string _lowerName;
@@ -344,6 +345,13 @@ public abstract class SettingConfigurationModel<T> : ISetting, ISearchableSettin
                          StringValue.ToLower().Contains(filter.ToLower());
         UpdateVisibility();
     }
+    
+    public void CategoryFilterChanged(string? categoryName)
+    {
+        _matchesCategoryFilter = string.IsNullOrWhiteSpace(categoryName) ||
+                                 CategoryName.Equals(categoryName, StringComparison.OrdinalIgnoreCase);
+        UpdateVisibility();
+    }
 
     public abstract ISetting Clone(SettingClientConfigurationModel parent, bool setDirty, bool isReadOnly);
 
@@ -638,12 +646,14 @@ public abstract class SettingConfigurationModel<T> : ISetting, ISearchableSettin
                 IsAdvancedAndAdvancedHidden() || 
                 IsNotEnabled() || 
                 IsFilteredOut() ||
+                IsCategoryFilteredOut() ||
                 IsHiddenByBaseValueMatch() ||
                 IsHiddenByDependency();
 
         bool IsAdvancedAndAdvancedHidden() => Advanced && !_showAdvanced;
         bool IsNotEnabled() => !_isEnabled;
         bool IsFilteredOut() => !_matchesFilter;
+        bool IsCategoryFilteredOut() => !_matchesCategoryFilter;
         bool IsHiddenByBaseValueMatch() => _showModifiedOnly && MatchesBaseValue == true;
         bool IsHiddenByDependency() => !IsVisibleBasedOnDependency();
     }

--- a/src/web/Fig.Web/Pages/Setting/Settings.razor
+++ b/src/web/Fig.Web/Pages/Setting/Settings.razor
@@ -172,8 +172,37 @@
             <!-- Floating toolbar container -->
             <div class="@GetToolbarCssClass()" style="@GetToolbarStyle()">
                 <div class="d-flex justify-content-end align-items-center toolbar-content">
-                    <div class="p-1 flex-fill" style="margin-right: 5px">
-                        <RadzenTextBox Placeholder="Filter" class="w-100" @oninput=@_filterTerm.OnNext Disabled=@IsToolbarFilterDisabled/>
+                    <div class="p-1 flex-fill" style="margin-right: 5px; position: relative;">
+                        <RadzenTextBox Placeholder="Filter" class="w-100" @bind-Value="_settingFilter" @oninput=@_filterTerm.OnNext Disabled=@IsToolbarFilterDisabled style="padding-right: 80px;"/>
+                        @if (!string.IsNullOrWhiteSpace(_settingFilter) || _selectedCategory != null)
+                        {
+                            <div style="position: absolute; right: 10px; top: 50%; transform: translateY(-50%); display: flex; align-items: center; gap: 8px;">
+                                <span style="position: absolute; right: 30px; top: 50%; transform: translateY(-50%); font-size: 0.85em; width:50px; color: #666;">
+                                    @GetVisibleSettingsCount() of @GetTotalSettingsCount()
+                                </span>
+                                <RadzenIcon Icon="close" 
+                                            Style="cursor: pointer; position: absolute; right: 8px; top: 50%; transform: translateY(-50%); opacity: 0.6;" 
+                                            @onclick="@ClearSettingFilter" />
+                            </div>
+                        }
+                    </div>
+                    <div class="p-1" style="margin-right: 5px; min-width: 180px;">
+                        <RadzenDropDown @bind-Value="_selectedCategory"
+                                       Data="@_availableCategories"
+                                       TextProperty="Name"
+                                       Placeholder="Filter by category..."
+                                       AllowFiltering="true"
+                                       AllowClear="true"
+                                       Change="@OnCategoryFilterChanged"
+                                       Disabled="@IsToolbarFilterDisabled"
+                                       Style="width: 100%;">
+                            <Template Context="category">
+                                <div style="display: flex; align-items: center; gap: 8px;">
+                                    <span style="display: inline-block; width: 10px; height: 10px; border-radius: 50%; background-color: @category.Color;"></span>
+                                    <span>@category.Name</span>
+                                </div>
+                            </Template>
+                        </RadzenDropDown>
                     </div>
                     @if (SelectedSettingClient?.Instance != null)
                     {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Category-based filtering for settings via a dropdown with colored indicators.
  - Combined text and category filters for more precise results.

- **Enhancements**
  - Filter box shows visible/total counts and a one-click clear action.
  - Category options populate per selected client and reset when switching clients.
  - Toolbar layout adjusted to accommodate the new filtering controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->