### PR TITLE
Add ability to resize the width of the setting clients list

### DIFF
--- a/src/web/Fig.Web/Pages/Setting/Settings.razor
+++ b/src/web/Fig.Web/Pages/Setting/Settings.razor
@@ -7,7 +7,7 @@
 
 <div class="container-fluid p-0">
     <div class="row g-3">
-        <div class="col-lg-3 col-md-4">
+        <div class="col" style="flex: 0 0 @(_leftPanelWidth)%; max-width: @(_leftPanelWidth)%; transition: none;">
             <div style="position: relative;">
                     <span style="
                         position: absolute;
@@ -165,7 +165,15 @@
 
         </div>
 
-        <div class="col-lg-9 col-md-8">
+        <!-- Resize handle -->
+        <div class="resize-handle" @ref="_resizeHandleRef"
+             @onmousedown="OnResizeStart"
+             @onmousedown:preventDefault="true"
+             style="flex: 0 0 1px; cursor: col-resize; background: transparent; position: relative; z-index: 10;">
+            <div class="resize-handle-indicator"></div>
+        </div>
+
+        <div class="col" style="flex: 1 1 auto; min-width: 0; transition: none;">
             <!-- Toolbar reference point for calculating floating position -->
             <div @ref="_toolbarRef" class="toolbar-reference"></div>
             
@@ -475,6 +483,44 @@
         box-shadow: 0 0 0 4px yellow, 0 0 16px 8px yellow;
         transition: box-shadow 0.3s ease;
         z-index: 100;
+    }
+
+    /* Resize handle styles */
+    .resize-handle {
+        display: flex;
+        align-items: stretch;
+        justify-content: center;
+        user-select: none;
+        -webkit-user-select: none;
+        -moz-user-select: none;
+        -ms-user-select: none;
+        padding: 0 8px; /* Expand hover zone on both sides */
+        margin: 0 -8px; /* Negative margin to compensate and keep visual gap minimal */
+    }
+
+    .resize-handle:hover .resize-handle-indicator,
+    .resize-handle.dragging .resize-handle-indicator {
+        opacity: 1;
+    }
+
+    .resize-handle-indicator {
+        width: 1px;
+        background: linear-gradient(to bottom, rgba(99, 102, 241, 0.2), rgba(16, 185, 129, 0.2));
+        border-radius: 0.5px;
+        opacity: 0;
+        transition: opacity 0.2s ease;
+        pointer-events: none;
+    }
+
+    .resize-handle.dragging .resize-handle-indicator {
+        width: 2px;
+        background: linear-gradient(to bottom, rgba(99, 102, 241, 0.4), rgba(16, 185, 129, 0.4));
+        box-shadow: 0 0 4px rgba(99, 102, 241, 0.3);
+    }
+
+    /* Disable transitions during drag */
+    .resizing * {
+        transition: none !important;
     }
 
     .toolbar-reference {

--- a/src/web/Fig.Web/wwwroot/js/resize-handler.js
+++ b/src/web/Fig.Web/wwwroot/js/resize-handler.js
@@ -1,0 +1,57 @@
+// resize-handler.js - Handles panel resize functionality
+let dotNetRef = null;
+let isResizing = false;
+
+export function initialize(dotNetReference) {
+    dotNetRef = dotNetReference;
+    
+    // Set up global mouse event listeners
+    document.addEventListener('mousemove', handleMouseMove);
+    document.addEventListener('mouseup', handleMouseUp);
+}
+
+export function cleanup() {
+    document.removeEventListener('mousemove', handleMouseMove);
+    document.removeEventListener('mouseup', handleMouseUp);
+}
+
+function handleMouseMove(e) {
+    if (!isResizing || !dotNetRef) return;
+    
+    e.preventDefault();
+    dotNetRef.invokeMethodAsync('OnResizeMove', e.clientX);
+}
+
+function handleMouseUp(e) {
+    if (!isResizing || !dotNetRef) return;
+    
+    isResizing = false;
+    dotNetRef.invokeMethodAsync('OnResizeEnd');
+    
+    // Remove dragging class from body
+    document.body.classList.remove('resizing');
+    
+    // Re-enable text selection
+    document.body.style.userSelect = '';
+    document.body.style.webkitUserSelect = '';
+    document.body.style.cursor = '';
+}
+
+// Called from C# when resize starts
+window.startResize = function(newNetReference) {
+    isResizing = true;
+    dotNetRef = newNetReference;
+    
+    // Add dragging class to disable transitions
+    document.body.classList.add('resizing');
+    
+    // Disable text selection during drag
+    document.body.style.userSelect = 'none';
+    document.body.style.webkitUserSelect = 'none';
+    document.body.style.cursor = 'col-resize';
+};
+
+// Helper function to get viewport width
+window.getViewportWidth = function() {
+    return window.innerWidth;
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Settings page now includes a resizable left panel with a draggable handle so users can adjust navigation width (15–50%).
  - Mouse-driven resizing includes visual feedback and a smooth drag experience with responsive width updates.

* **Style**
  - Added hover/active states for the resize handle and indicator for clearer interaction feedback.
  - Transitions are disabled while dragging to ensure fluid, lag-free resizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->