### PR TITLE
Fix bug where instances didn't have their value set correctly and cou…

### DIFF
--- a/src/api/Fig.Api/ExtensionMethods/SettingBusinessEntityExtensions.cs
+++ b/src/api/Fig.Api/ExtensionMethods/SettingBusinessEntityExtensions.cs
@@ -3,6 +3,7 @@ using Fig.Common.NetStandard.Json;
 using Fig.Contracts.ExtensionMethods;
 using Fig.Contracts.SettingDefinitions;
 using Fig.Datalayer.BusinessEntities;
+using Fig.Datalayer.BusinessEntities.SettingValues;
 using Newtonsoft.Json;
 
 namespace Fig.Api.ExtensionMethods;
@@ -17,8 +18,8 @@ public static class SettingBusinessEntityExtensions
             Description = original.Description,
             IsSecret = original.IsSecret,
             ValueType = original.ValueType,
-            Value = original.Value,
-            DefaultValue = original.DefaultValue,
+            Value = CloneSettingValue(original.Value),
+            DefaultValue = CloneSettingValue(original.DefaultValue),
             ValidationRegex = original.ValidationRegex,
             ValidationExplanation = original.ValidationExplanation,
             ValidValues = original.ValidValues,
@@ -79,5 +80,15 @@ public static class SettingBusinessEntityExtensions
         return setting?.DataGridDefinitionJson is null
             ? null
             : JsonConvert.DeserializeObject<DataGridDefinitionDataContract>(setting.DataGridDefinitionJson);
+    }
+
+    private static SettingValueBaseBusinessEntity? CloneSettingValue(SettingValueBaseBusinessEntity? value)
+    {
+        if (value == null)
+            return null;
+
+        // Deep clone using JSON serialization to avoid shared references between instances
+        var json = JsonConvert.SerializeObject(value, JsonSettings.FigDefault);
+        return JsonConvert.DeserializeObject<SettingValueBaseBusinessEntity>(json, JsonSettings.FigDefault);
     }
 }


### PR DESCRIPTION
…ld end up being null when settings were added during registration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of setting value cloning to prevent unintended value sharing.
  * Ensures default values are automatically applied to newly added properties after a settings update.
  * Preserves existing instance-specific overrides when settings are updated.

* **Tests**
  * Added an integration test verifying that new properties receive default values on both default clients and instances, while existing instance overrides remain intact during settings updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->