### PR TITLE
Add tooltip to clients with no running instances to show the last tim…

### DIFF
--- a/src/api/Fig.Api/Converters/ClientStatusConverter.cs
+++ b/src/api/Fig.Api/Converters/ClientStatusConverter.cs
@@ -16,7 +16,9 @@ public class ClientStatusConverter : IClientStatusConverter
             client.Instance,
             client.LastRegistration,
             client.LastSettingValueUpdate,
-            runSessions);
+            runSessions,
+            client.LastRunSessionDisconnected,
+            client.LastRunSessionMachineName);
     }
 
     private List<ClientRunSessionDataContract> Convert(IEnumerable<ClientRunSessionBusinessEntity> sessions)

--- a/src/api/Fig.Datalayer/BusinessEntities/ClientStatusBusinessEntity.cs
+++ b/src/api/Fig.Datalayer/BusinessEntities/ClientStatusBusinessEntity.cs
@@ -3,4 +3,7 @@ namespace Fig.Datalayer.BusinessEntities;
 // ReSharper disable once ClassNeverInstantiated.Global used by NHibernate
 public class ClientStatusBusinessEntity : ClientBase
 {
+    public virtual DateTime? LastRunSessionDisconnected { get; set; }
+
+    public virtual string? LastRunSessionMachineName { get; set; }
 }

--- a/src/api/Fig.Datalayer/Mappings/ClientStatusMap.cs
+++ b/src/api/Fig.Datalayer/Mappings/ClientStatusMap.cs
@@ -31,6 +31,12 @@ public class ClientStatusMap : ClassMapping<ClientStatusBusinessEntity>
             x.Column("last_update");
             x.Type(NHibernateUtil.UtcTicks);
         });
+        Property(x => x.LastRunSessionDisconnected, x =>
+        {
+            x.Column("last_run_session_disconnected");
+            x.Type(NHibernateUtil.UtcTicks);
+        });
+        Property(x => x.LastRunSessionMachineName, x => x.Column("last_run_session_machine_name"));
         Bag(x => x.RunSessions,
             x =>
             {

--- a/src/common/Fig.Contracts/Status/ClientStatusDataContract.cs
+++ b/src/common/Fig.Contracts/Status/ClientStatusDataContract.cs
@@ -5,13 +5,21 @@ namespace Fig.Contracts.Status
 {
     public class ClientStatusDataContract
     {
-        public ClientStatusDataContract(string name, string? instance, DateTime? lastRegistration, DateTime? lastSettingValueUpdate, ICollection<ClientRunSessionDataContract> runSessions)
+        public ClientStatusDataContract(string name,
+            string? instance,
+            DateTime? lastRegistration,
+            DateTime? lastSettingValueUpdate,
+            ICollection<ClientRunSessionDataContract> runSessions,
+            DateTime? lastRunSessionDisconnected = null,
+            string? lastRunSessionMachineName = null)
         {
             Name = name;
             Instance = instance;
             LastRegistration = lastRegistration;
             LastSettingValueUpdate = lastSettingValueUpdate;
             RunSessions = runSessions;
+            LastRunSessionDisconnected = lastRunSessionDisconnected;
+            LastRunSessionMachineName = lastRunSessionMachineName;
         }
 
         public string Name { get; }
@@ -21,6 +29,10 @@ namespace Fig.Contracts.Status
         public DateTime? LastRegistration { get; }
 
         public DateTime? LastSettingValueUpdate { get; }
+        
+        public DateTime? LastRunSessionDisconnected { get; }
+        
+        public string? LastRunSessionMachineName { get; }
         
         public ICollection<ClientRunSessionDataContract> RunSessions { get; }
     }

--- a/src/web/Fig.Web/Facades/IClientStatusFacade.cs
+++ b/src/web/Fig.Web/Facades/IClientStatusFacade.cs
@@ -10,6 +10,8 @@ public interface IClientStatusFacade
 
     Task Refresh();
 
+    LastSeenModel? GetLastSeen(string clientName, string? instance);
+
     Task RequestRestart(ClientRunSessionModel client);
 
     Task SetLiveReload(ClientRunSessionModel client);

--- a/src/web/Fig.Web/Facades/SettingClientFacade.cs
+++ b/src/web/Fig.Web/Facades/SettingClientFacade.cs
@@ -4,6 +4,7 @@ using Fig.Contracts.Scheduling;
 using Fig.Contracts.SettingClients;
 using Fig.Contracts.SettingDefinitions;
 using Fig.Contracts.Settings;
+using Fig.Contracts.Status;
 using Fig.Web.Builders;
 using Fig.Web.Converters;
 using Fig.Web.Events;
@@ -151,6 +152,14 @@ public class SettingClientFacade : ISettingClientFacade
             client.CurrentRunSessions = clientRunSessions.Count(a => a.Instance == client.Instance);
             client.CurrentHealth = ConvertHealth(clientRunSessions.Select(a => a.Health).ToList());
             client.AllRunSessionsRunningLatest = clientRunSessions.All(a => a.RunningLatestSettings);
+            
+            // Map LastRunSessionDisconnected and LastRunSessionMachineName from client status
+            var lastSeen = _clientStatusFacade.GetLastSeen(client.Name, client.Instance);
+            if (lastSeen != null)
+            {
+                client.LastRunSessionDisconnected = lastSeen.LastSeen;
+                client.LastRunSessionMachineName = lastSeen.LastSeenMachineName;
+            }
         }
         
         bool AreSettingsUsedByClient(List<string?> settingInstances, string? runSessionInstance, string? clientInstance)

--- a/src/web/Fig.Web/Models/Clients/LastSeenModel.cs
+++ b/src/web/Fig.Web/Models/Clients/LastSeenModel.cs
@@ -1,0 +1,3 @@
+namespace Fig.Web.Models.Clients;
+
+public record LastSeenModel(DateTime? LastSeen, string? LastSeenMachineName);

--- a/src/web/Fig.Web/Models/Setting/SettingClientConfigurationModel.cs
+++ b/src/web/Fig.Web/Models/Setting/SettingClientConfigurationModel.cs
@@ -57,6 +57,10 @@ public class SettingClientConfigurationModel
     public int CurrentRunSessions { get; set; }
 
     public bool AllRunSessionsRunningLatest { get; set; }
+    
+    public DateTime? LastRunSessionDisconnected { get; set; }
+    
+    public string? LastRunSessionMachineName { get; set; }
 
     public int DirtySettingCount { get; private set; }
     


### PR DESCRIPTION
…e they were online

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Display humanized "last seen" timestamps and machine name for clients in the UI.
  * Show last-run info in run-session tooltips when no sessions are currently running.
  * Provide a public helper to retrieve a client's last-seen info for other UI components.

* **Bug Fixes**
  * Include offline clients in status views so historical last-seen data is visible.
  * Ensure status processing updates last-seen info when sessions expire.

* **Tests**
  * Added integration tests validating last-seen behavior and updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->