### PR TITLE
Fix flakey test

### DIFF
--- a/src/tests/Fig.Integration.Test/Api/TimeMachineTests.cs
+++ b/src/tests/Fig.Integration.Test/Api/TimeMachineTests.cs
@@ -24,6 +24,9 @@ public class TimeMachineTests : IntegrationTestBase
     [Test]
     public async Task ShallCreateCheckpointOnClientRegistration()
     {
+        // Wait for any cleanup-triggered checkpoints to complete
+        await WaitForNoRecentCheckpoints();
+        
         var startTime = DateTime.UtcNow;
         var settings = await RegisterSettings<SettingsWithCustomAction>();
 
@@ -33,6 +36,9 @@ public class TimeMachineTests : IntegrationTestBase
     [Test]
     public async Task ShallNotCheckpointOnDuplicateClientRegistration()
     {
+        // Wait for any cleanup-triggered checkpoints to complete
+        await WaitForNoRecentCheckpoints();
+        
         var secret = GetNewSecret();
         var startTime = DateTime.UtcNow;
         var settings = await RegisterSettings<SettingsWithCustomAction>(secret);

--- a/src/tests/Fig.Test.Common/IntegrationTestBase.cs
+++ b/src/tests/Fig.Test.Common/IntegrationTestBase.cs
@@ -378,6 +378,20 @@ public abstract class IntegrationTestBase
         await ApiClient.Delete(requestUri);
     }
 
+    protected async Task WaitForNoRecentCheckpoints()
+    {
+        // Wait until there are no checkpoints created in the last 200ms
+        // This ensures any cleanup-triggered checkpoints have completed
+        await WaitForCondition(
+            async () => 
+            {
+                var recentStart = DateTime.UtcNow.AddMilliseconds(-200);
+                var checkpoints = await GetCheckpoints(recentStart, DateTime.UtcNow);
+                return !checkpoints.CheckPoints.Any();
+            },
+            TimeSpan.FromSeconds(3));
+    }
+
     protected async Task<SettingsClientDefinitionDataContract> GetClient(TestSettingsBase settings)
     {
         return await GetClient(settings.ClientName);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved integration test reliability by implementing checkpoint synchronization. Tests now properly wait for recent checkpoint operations to complete before proceeding. Added a reusable helper method to the test infrastructure that waits up to 3 seconds for cleanup operations, reducing timing-related failures and ensuring consistent test behavior in client registration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->