### PR TITLE
Hide some setting icons for non-admins. Refactor setting card to spli…

### DIFF
--- a/src/web/Fig.Web/Pages/Setting/CustomActionCard.razor
+++ b/src/web/Fig.Web/Pages/Setting/CustomActionCard.razor
@@ -374,20 +374,6 @@ else
 }
 
 <style>
-    .custom-card {
-        position: relative;
-        overflow: hidden;
-        border: none;
-        background: rgba(255, 255, 255, 0.05);
-        backdrop-filter: blur(10px);
-        transition: all 0.2s ease;
-        margin-bottom: 0.25rem !important;
-    }
-
-    .custom-card:hover {
-        transform: translateY(-1px);
-        background: rgba(255, 255, 255, 0.08);
-    }
 
     /* Expand/collapse icon */
     .expand-collapse-icon {
@@ -441,8 +427,12 @@ else
     .description-text {
         font-size: 0.85rem;
         line-height: 1.2;
-        margin-top: 0.25rem;
+        margin-bottom: 0.25rem;
         color: rgba(255, 255, 255, 0.7);
+        word-wrap: break-word;
+        overflow-wrap: break-word;
+        hyphens: auto;
+        max-width: 100%;
     }
 
     .settings-badges {

--- a/src/web/Fig.Web/Pages/Setting/SettingCard.razor
+++ b/src/web/Fig.Web/Pages/Setting/SettingCard.razor
@@ -53,39 +53,7 @@
                                 {
                                     @Setting.DisplayName
                                 }
-                                <RadzenIcon Icon="bolt" IconStyle="IconStyle.Secondary" Visible="@Setting.SupportsLiveUpdate" Style="font-size: 1em; margin-left: 6px; font-variation-settings: 'FILL' 1;"
-                                            MouseEnter="@(args => ShowTooltip(args, "Supports live update (no restart required)"))"/>
-                                <RadzenIcon Icon="tune" IconStyle="IconStyle.Info" Visible="@(Setting.Advanced && IsAdmin)" Style="font-size: 1em; margin-left: 6px;"
-                                            MouseEnter="@(args => ShowTooltip(args, "Advanced setting"))"/>
-                                <RadzenIcon Icon="business_center" IconStyle="IconStyle.Success" Visible="@(Setting.Classification == Classification.Functional && IsAdmin)" Style="font-size: 1em; margin-left: 6px;"
-                                            MouseEnter="@(args => ShowTooltip(args, "Functional setting"))"/>
-                                <RadzenIcon Icon="stars" IconStyle="IconStyle.Warning" Visible="@(Setting.Classification == Classification.Special && IsAdmin)" Style="font-size: 1em; margin-left: 6px; font-variation-settings: 'FILL' 1;"
-                                            MouseEnter="@(args => ShowTooltip(args, "Special setting"))"/>
-                                @if (GetDependentSettingsCount() > 0)
-                                {
-                                    <RadzenIcon Icon="visibility" IconStyle="IconStyle.Info" Style="font-size: 1em; margin-left: 6px"
-                                                MouseEnter="@(args => ShowTooltip(args, $"Controls visibility of {GetDependentSettingsCount()} setting{(GetDependentSettingsCount() == 1 ? "" : "s")}"))" />
-                                }
-                                @if (Setting.MatchesBaseValue.HasValue)
-                                {
-                                    @if (Setting.MatchesBaseValue.Value)
-                                    {
-                                        <RadzenIcon Icon="equal" IconStyle="IconStyle.Success" Style="font-size: 1em; margin-left: 6px"
-                                                   MouseEnter="@(args => ShowTooltip(args, "Matches base setting value"))" />
-                                    }
-                                    else
-                                    {
-                                        <RadzenIcon Icon="difference" IconStyle="IconStyle.Warning" Style="font-size: 1em; margin-left: 6px"
-                                                   MouseEnter="@(args => ShowTooltip(args, $"Different from base setting value ({Setting.BaseSetting?.StringValue})"))" />
-                                    }
-                                }
-                            <RadzenIcon Icon="javascript" IconStyle="IconStyle.Warning" Visible="@(Setting.HasDisplayScript && IsAdmin)" Style="font-size: 1.5em; margin-left: 6px"
-                                        MouseEnter="@(args => ShowTooltip(args, Setting.DisplayScript is not null ? ScriptRunner.FormatScript(Setting.DisplayScript) : "No Script", multiLine: true))" />
-                            @if (Setting.ScheduledChangeDescription != null)
-                            {
-                                <RadzenIcon Icon="schedule" IconStyle="IconStyle.Warning" Style="font-size: 1em; margin-left: 4px"
-                                            MouseEnter="@(args => ShowTooltip(args, Setting.ScheduledChangeDescription, multiLine: true))" />
-                            }
+                                <SettingIcons Setting="@Setting" FontSize="1.0" ShowTooltip="@HandleTooltipRequest" />
                             </span>
                         </h3>
                     </div>
@@ -131,59 +99,14 @@ else
                                     <span class="setting-parent">@string.Join("->", tokens.Take(tokens.Length - 1))</span>
                                     <span class="setting-name d-flex align-items-center">
                                         @tokens.Last()
-                                        <RadzenIcon Icon="bolt" IconStyle="IconStyle.Warning" Visible="@Setting.SupportsLiveUpdate" Style="font-size: 0.7em; margin-left: 4px" />
-                                        @if (Setting.MatchesBaseValue.HasValue)
-                                        {
-                                            @if (Setting.MatchesBaseValue.Value)
-                                            {
-                                                <RadzenIcon Icon="sync" IconStyle="IconStyle.Success" Style="font-size: 0.7em; margin-left: 4px"
-                                                           MouseEnter="@(args => ShowTooltip(args, "Matches parent setting value"))" />
-                                            }
-                                            else
-                                            {
-                                                <RadzenIcon Icon="sync_problem" IconStyle="IconStyle.Warning" Style="font-size: 0.7em; margin-left: 4px"
-                                                           MouseEnter="@(args => ShowTooltip(args, "Different from parent setting value"))" />
-                                            }
-                                        }
+                                        <SettingIcons Setting="@Setting" FontSize="0.7" ShowTooltip="@HandleTooltipRequest" />
                                     </span>
                                 </div>
                             }
                             else
                             {
                                 <span>@Setting.DisplayName</span>
-                                <RadzenIcon Icon="bolt" IconStyle="IconStyle.Secondary" Visible="@Setting.SupportsLiveUpdate" Style="font-size: 1em; margin-left: 6px; font-variation-settings: 'FILL' 1;"
-                                            MouseEnter="@(args => ShowTooltip(args, "Supports live update (no restart required)"))"/>
-                                <RadzenIcon Icon="tune" IconStyle="IconStyle.Info" Visible="@Setting.Advanced" Style="font-size: 1em; margin-left: 6px;"
-                                            MouseEnter="@(args => ShowTooltip(args, "Advanced setting"))"/>
-                                <RadzenIcon Icon="business_center" IconStyle="IconStyle.Success" Visible="@(Setting.Classification == Classification.Functional)" Style="font-size: 1em; margin-left: 6px;"
-                                            MouseEnter="@(args => ShowTooltip(args, "Functional setting"))"/>
-                                <RadzenIcon Icon="stars" IconStyle="IconStyle.Warning" Visible="@(Setting.Classification == Classification.Special)" Style="font-size: 1em; margin-left: 6px; font-variation-settings: 'FILL' 1;"
-                                            MouseEnter="@(args => ShowTooltip(args, "Special setting"))"/>
-                                @if (Setting.MatchesBaseValue.HasValue)
-                                {
-                                    @if (Setting.MatchesBaseValue.Value)
-                                    {
-                                        <RadzenIcon Icon="equal" IconStyle="IconStyle.Success" Style="font-size: 1em; margin-left: 6px"
-                                                   MouseEnter="@(args => ShowTooltip(args, "Matches base setting value"))" />
-                                    }
-                                    else
-                                    {
-                                        <RadzenIcon Icon="difference" IconStyle="IconStyle.Warning" Style="font-size: 1em; margin-left: 6px"
-                                                   MouseEnter="@(args => ShowTooltip(args, $"Different from base setting value ({Setting.BaseSetting?.StringValue})"))" />
-                                    }
-                                }
-                            }
-                            <RadzenIcon Icon="javascript" IconStyle="IconStyle.Warning" Visible="@Setting.HasDisplayScript" Style="font-size: 1.5em; margin-left: 6px"
-                                        MouseEnter="@(args => ShowTooltip(args, Setting.DisplayScript is not null ? ScriptRunner.FormatScript(Setting.DisplayScript) : "No Script", multiLine: true))" />
-                            @if (GetDependentSettingsCount() > 0)
-                            {
-                                <RadzenIcon Icon="visibility" IconStyle="IconStyle.Info" Style="font-size: 1em; margin-left: 6px"
-                                            MouseEnter="@(args => ShowTooltip(args, $"Controls visibility of {GetDependentSettingsCount()} setting{(GetDependentSettingsCount() == 1 ? "" : "s")}"))" />
-                            }
-                            @if (Setting.ScheduledChangeDescription != null)
-                            {
-                                <RadzenIcon Icon="schedule" IconStyle="IconStyle.Warning" Style="font-size: 1em; margin-left: 4px"
-                                            MouseEnter="@(args => ShowTooltip(args, Setting.ScheduledChangeDescription, multiLine: true))" />
+                                <SettingIcons Setting="@Setting" FontSize="1.0" ShowTooltip="@HandleTooltipRequest" />
                             }
                         </span>
                     </h3>

--- a/src/web/Fig.Web/Pages/Setting/SettingCard.razor.css
+++ b/src/web/Fig.Web/Pages/Setting/SettingCard.razor.css
@@ -1,20 +1,5 @@
-.custom-card {
-    position: relative;
-    overflow: hidden;
-    background: rgba(255, 255, 255, 0.05);  /* Subtle transparent background */
-    border: none;
-    backdrop-filter: blur(10px);  /* Frosted glass effect */
-    transition: all 0.3s ease-in-out;  /* Updated transition timing */
-    margin-bottom: 0.25rem !important;  /* Reduce space between cards */
-    max-width: 100%;
-    width: 100%;
-    box-sizing: border-box;
-}
+/* The card itself should not add vertical spacing; that lives on the wrapper */
 
-.custom-card:hover {
-    transform: translateY(-1px);  /* Subtle lift effect */
-    background: rgba(255, 255, 255, 0.08);  /* Slightly lighter on hover */
-}
 
 /* Expand/collapse icon */
 .expand-collapse-icon {
@@ -63,7 +48,8 @@
 }
 
 .card-content {
-    padding: 0.35rem 1rem 0.35rem 1.25rem;  /* Reduced top/bottom padding further */
+    /* Keep horizontal padding, but tighten vertical space for a more compact card */
+    padding: 0.25rem 1rem 0.25rem 1.25rem;
     max-width: 100%;
     overflow: hidden;
     box-sizing: border-box;
@@ -72,10 +58,10 @@
 h3, h2 {
     margin: 0;
     font-size: 1rem;  /* Slightly smaller font */
-    line-height: 1.2;
+    line-height: 1.15;
     font-weight: 500;  /* Medium weight */
     color: rgba(255, 255, 255, 0.9);  /* Slightly transparent white */
-    margin-bottom: 0.25rem !important;  /* Reduce space after heading */
+    margin-bottom: 0.15rem !important;  /* Reduce space after heading */
 }
 
 .clickable-heading {
@@ -111,8 +97,8 @@ h3, h2 {
 /* Make description more compact */
 .description-text {
     font-size: 0.85rem;
-    line-height: 1.2;
-    margin-bottom: 0.25rem;
+    line-height: 1.15;
+    margin-bottom: 0.15rem;
     color: rgba(255, 255, 255, 0.7);
     word-wrap: break-word;
     overflow-wrap: break-word;
@@ -152,6 +138,7 @@ h3, h2 {
     max-height: 0;
     opacity: 0;
     transform: translateY(-10px);
+    /* Remove all spacing when collapsed so hidden cards don't affect layout */
     margin: 0 !important;
     padding: 0 !important;
 }

--- a/src/web/Fig.Web/Pages/Setting/SettingIcons.razor
+++ b/src/web/Fig.Web/Pages/Setting/SettingIcons.razor
@@ -1,0 +1,38 @@
+@using Fig.Web.Models.Setting
+@using Fig.Contracts.Authentication
+@using Fig.Common.NetStandard.Scripting
+@using Fig.Client.Abstractions.Data
+
+<RadzenIcon Icon="bolt" IconStyle="IconStyle.Secondary" Visible="@Setting.SupportsLiveUpdate" Style="@GetBoltIconStyle()"
+            MouseEnter="@(args => OnShowTooltip(args, "Supports live update (no restart required)"))"/>
+<RadzenIcon Icon="tune" IconStyle="IconStyle.Info" Visible="@(Setting.Advanced && IsAdmin)" Style="@GetIconStyle()"
+            MouseEnter="@(args => OnShowTooltip(args, "Advanced setting"))"/>
+<RadzenIcon Icon="business_center" IconStyle="IconStyle.Success" Visible="@(Setting.Classification == Classification.Functional && IsAdmin)" Style="@GetIconStyle()"
+            MouseEnter="@(args => OnShowTooltip(args, "Functional setting"))"/>
+<RadzenIcon Icon="stars" IconStyle="IconStyle.Warning" Visible="@(Setting.Classification == Classification.Special && IsAdmin)" Style="@GetStarsIconStyle()"
+            MouseEnter="@(args => OnShowTooltip(args, "Special setting"))"/>
+@if (GetDependentSettingsCount() > 0)
+{
+    <RadzenIcon Icon="visibility" IconStyle="IconStyle.Info" Style="@GetIconStyle()"
+                MouseEnter="@(args => OnShowTooltip(args, $"Controls visibility of {GetDependentSettingsCount()} setting{(GetDependentSettingsCount() == 1 ? "" : "s")}"))" />
+}
+@if (Setting.MatchesBaseValue.HasValue)
+{
+    @if (Setting.MatchesBaseValue.Value)
+    {
+        <RadzenIcon Icon="equal" IconStyle="IconStyle.Success" Style="@GetIconStyle()"
+                   MouseEnter="@(args => OnShowTooltip(args, "Matches base setting value"))" />
+    }
+    else
+    {
+        <RadzenIcon Icon="difference" IconStyle="IconStyle.Warning" Style="@GetIconStyle()"
+                   MouseEnter="@(args => OnShowTooltip(args, $"Different from base setting value ({Setting.BaseSetting?.StringValue})"))" />
+    }
+}
+<RadzenIcon Icon="javascript" IconStyle="IconStyle.Warning" Visible="@(Setting.HasDisplayScript && IsAdmin)" Style="@GetJavascriptIconStyle()"
+            MouseEnter="@(args => OnShowTooltip(args, Setting.DisplayScript is not null ? ScriptRunner.FormatScript(Setting.DisplayScript) : "No Script", multiLine: true))" />
+@if (Setting.ScheduledChangeDescription != null)
+{
+    <RadzenIcon Icon="schedule" IconStyle="IconStyle.Warning" Style="@GetScheduleIconStyle()"
+                MouseEnter="@(args => OnShowTooltip(args, Setting.ScheduledChangeDescription, multiLine: true))" />
+}

--- a/src/web/Fig.Web/Pages/Setting/SettingIcons.razor.cs
+++ b/src/web/Fig.Web/Pages/Setting/SettingIcons.razor.cs
@@ -1,0 +1,68 @@
+using Fig.Client.Abstractions.Data;
+using Fig.Common.NetStandard.Scripting;
+using Fig.Contracts.Authentication;
+using Fig.Web.Models.Setting;
+using Fig.Web.Services;
+using Microsoft.AspNetCore.Components;
+using Radzen;
+
+namespace Fig.Web.Pages.Setting;
+
+public partial class SettingIcons
+{
+    [Parameter]
+    public ISetting Setting { get; set; } = null!;
+    
+    [Parameter]
+    public double FontSize { get; set; } = 1.0;
+    
+    [Parameter]
+    public EventCallback<(ElementReference element, string tooltip, bool multiLine)> ShowTooltip { get; set; }
+    
+    [Inject]
+    private IAccountService AccountService { get; set; } = null!;
+    
+    [Inject]
+    private IScriptRunner ScriptRunner { get; set; } = null!;
+    
+    private bool IsAdmin => AccountService.AuthenticatedUser?.Role == Role.Administrator;
+    
+    private string GetIconStyle()
+    {
+        return $"font-size: {FontSize}em; margin-left: {(FontSize >= 1.0 ? 6 : 4)}px";
+    }
+    
+    private string GetBoltIconStyle()
+    {
+        return $"font-size: {FontSize}em; margin-left: {(FontSize >= 1.0 ? 6 : 4)}px; font-variation-settings: 'FILL' 1;";
+    }
+    
+    private string GetStarsIconStyle()
+    {
+        return $"font-size: {FontSize}em; margin-left: {(FontSize >= 1.0 ? 6 : 4)}px; font-variation-settings: 'FILL' 1;";
+    }
+    
+    private string GetJavascriptIconStyle()
+    {
+        return "font-size: 1.5em; margin-left: 6px";
+    }
+    
+    private string GetScheduleIconStyle()
+    {
+        return $"font-size: {FontSize}em; margin-left: 4px";
+    }
+    
+    private int GetDependentSettingsCount()
+    {
+        if (Setting?.Parent?.Settings == null) return 0;
+        return Setting.Parent.Settings.Count(s => s.DependsOnProperty == Setting.Name);
+    }
+    
+    private async Task OnShowTooltip(ElementReference element, string tooltip, bool multiLine = false)
+    {
+        if (ShowTooltip.HasDelegate)
+        {
+            await ShowTooltip.InvokeAsync((element, tooltip, multiLine));
+        }
+    }
+}

--- a/src/web/Fig.Web/wwwroot/css/app.css
+++ b/src/web/Fig.Web/wwwroot/css/app.css
@@ -200,3 +200,21 @@ pre:hover {
     border: none !important;
 }
 
+.custom-card {
+    position: relative;
+    overflow: hidden;
+    background: rgba(255, 255, 255, 0.05);  /* Subtle transparent background */
+    border: none;
+    backdrop-filter: blur(10px);  /* Frosted glass effect */
+    transition: all 0.3s ease-in-out;  /* Updated transition timing */
+    max-width: 100%;
+    width: 100%;
+    box-sizing: border-box;
+    margin-bottom: 0.25rem !important;
+}
+
+.custom-card:hover {
+    transform: translateY(-1px);  /* Subtle lift effect */
+    background: rgba(255, 255, 255, 0.08);  /* Slightly lighter on hover */
+}
+


### PR DESCRIPTION
…t it into multiple files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized setting icons rendered via a new component; some metadata icons now show only to administrators.
  * Enhanced card interactions: improved tooltips, unlock confirmation flow, compact toggles and expand/collapse behavior.

* **Style**
  * New comprehensive styles for setting cards: compact/dense layout, reserved badge slot to avoid layout shifts, expand/collapse icon visuals, and frosted-card touch-ups.

* **Refactor**
  * Streamlined UI: replaced inline icon markup and large inline styles with the new component and stylesheet.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->