### PR TITLE
Fix problem where data grid imports were incorrect if there was more …

### DIFF
--- a/src/web/Fig.Web/Pages/Setting/SettingEditors/DataGrid/DataGridSetting.razor
+++ b/src/web/Fig.Web/Pages/Setting/SettingEditors/DataGrid/DataGridSetting.razor
@@ -22,7 +22,7 @@
         @if (Setting.DataGridConfiguration?.IsLocked == false)
         {
             <div class="d-flex">
-                <RadzenButton Icon="publish" style="padding: 0.25rem 0.75rem; margin-right: 5px;" Text="Import CSV" ButtonStyle="ButtonStyle.Secondary" Size="ButtonSize.Small" Disabled="@Setting.IsReadOnly" Click="@(async () => await JsRuntime.InvokeVoidAsync("clickElementById", "dataGridCsvInputFile"))" />
+                <RadzenButton Icon="publish" style="padding: 0.25rem 0.75rem; margin-right: 5px;" Text="Import CSV" ButtonStyle="ButtonStyle.Secondary" Size="ButtonSize.Small" Disabled="@Setting.IsReadOnly" Click="@(async () => await JsRuntime.InvokeVoidAsync("clickElementById", $"dataGridCsvInputFile_{SanitizeIdString(Setting.Name)}"))" />
                 <RadzenButton Icon="get_app" style="padding: 0.25rem 0.75rem; margin-right: 5px;" Text="Export CSV" ButtonStyle="ButtonStyle.Secondary" Size="ButtonSize.Small" Disabled="@(Setting.IsReadOnly || Setting.Value?.Count == 0)" Click="@ExportCsv" />
                 <RadzenButton Icon="add_circle_outline" style="padding: 0.25rem 0.75rem" Text="Add Row" ButtonStyle="ButtonStyle.Secondary" Size="ButtonSize.Small" Disabled="@Setting.IsReadOnly" Click="@InsertRow" />
             </div>
@@ -138,4 +138,4 @@
     <p class="@(Setting.IsValid ? "collapse" : "")" style="color: pink; font-size: small">@Setting.ValidationExplanation</p>
 </div>
 
-<InputFile @ref="_inputFile" id="dataGridCsvInputFile" OnChange="@HandleFileSelected" accept=".csv" style="display: none;" />
+<InputFile @ref="_inputFile" id="@("dataGridCsvInputFile_" + SanitizeIdString(Setting.Name))" OnChange="@HandleFileSelected" accept=".csv" style="display: none;" />

--- a/src/web/Fig.Web/Pages/Setting/SettingEditors/DataGrid/DataGridSetting.razor.cs
+++ b/src/web/Fig.Web/Pages/Setting/SettingEditors/DataGrid/DataGridSetting.razor.cs
@@ -31,6 +31,15 @@ public partial class DataGridSetting
     [Inject] 
     private NotificationService NotificationService { get; set; } = null!;
 
+    private string SanitizeIdString(string input)
+    {
+        if (string.IsNullOrEmpty(input))
+            return "dataGrid";
+        
+        // Replace any character that's not A-Z, a-z, 0-9, hyphen, underscore, or period with underscore
+        return Regex.Replace(input, @"[^A-Za-z0-9\-_\.]", "_");
+    }
+
     private void SetValue(Dictionary<string, object> context, string key, object value)
     {
         context[key] = value;
@@ -308,7 +317,7 @@ public partial class DataGridSetting
         await InvokeAsync(StateHasChanged);
         if (_inputFile != null)
         {
-            await JsRuntime.InvokeVoidAsync("resetFileInputValueById", "dataGridCsvInputFile");
+            await JsRuntime.InvokeVoidAsync("resetFileInputValueById", $"dataGridCsvInputFile_{SanitizeIdString(Setting.Name)}");
         }
         
         bool IsFileSizeValid(IBrowserFile file)


### PR DESCRIPTION
…than one data grid in use

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CSV import for data grids now uses per-grid file inputs, preventing interference when multiple data grids are on the same page. Each grid’s import dialog operates independently, improving reliability and preventing accidental file selection mix-ups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->