### PR TITLE
Add support for copying the CA certificates to the trusted root store…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,11 @@ services:
         condition: service_completed_successfully
     environment:
       - ApiSettings:DbConnectionString=Server=${fqdn};User Id=${FIG_USER_NAME};Password=${FIG_DB_PWD};Initial Catalog=${FIG_DB_NAME}
+      # Uncomment to enable CA certificate loading from mounted volume
+      # - FIG_CA_CERTIFICATE_PATH=/app/ca-certificates
+    # Uncomment to mount CA certificates for encrypted SQL Server connections
+    # volumes:
+    #   - ./ca-certificates:/app/ca-certificates:ro
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/_health"]
       start_period: 30s

--- a/src/api/Fig.Api/ApiSettings.cs
+++ b/src/api/Fig.Api/ApiSettings.cs
@@ -45,6 +45,15 @@ public class ApiSettings
     // to supply forwarded headers.
     public List<string>? KnownNetworks { get; set; }
 
+    /// <summary>
+    /// Path to a directory containing CA certificate files (.crt, .cer, .pem).
+    /// Certificates in this directory will be automatically added to the system trust store on startup.
+    /// This enables trusted SSL/TLS connections to services (like SQL Server) that use certificates
+    /// signed by custom or enterprise Certificate Authorities.
+    /// In Docker, mount your CA certificates to this path (e.g., /app/ca-certificates).
+    /// </summary>
+    public string? CaCertificatePath { get; set; }
+
     public string GetDecryptedSecret()
     {
         if (!SecretsDpapiEncrypted)

--- a/src/api/Fig.Api/Certificates/CaCertificateInstaller.cs
+++ b/src/api/Fig.Api/Certificates/CaCertificateInstaller.cs
@@ -1,0 +1,142 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Fig.Api.Certificates;
+
+/// <summary>
+/// Installs CA certificates from a configured directory into the system trust store.
+/// This enables trusted SSL/TLS connections to services (like SQL Server) that use certificates
+/// signed by custom or enterprise Certificate Authorities.
+/// </summary>
+public static class CaCertificateInstaller
+{
+    private static readonly string[] SupportedExtensions = [".crt", ".cer", ".pem"];
+
+    /// <summary>
+    /// Installs all CA certificates found in the specified directory path.
+    /// On Linux, certificates are copied to /usr/local/share/ca-certificates and update-ca-certificates is run.
+    /// On Windows, certificates are added to the LocalMachine Root store.
+    /// </summary>
+    /// <param name="caCertificatePath">The directory path containing CA certificate files (.crt, .cer, .pem)</param>
+    /// <param name="logger">Logger for recording certificate installation progress</param>
+    public static void InstallCertificates(string? caCertificatePath, Serilog.ILogger logger)
+    {
+        if (string.IsNullOrWhiteSpace(caCertificatePath))
+        {
+            logger.Debug("CA certificate path not configured. Skipping CA certificate installation");
+            return;
+        }
+
+        if (!Directory.Exists(caCertificatePath))
+        {
+            logger.Warning("CA certificate path '{CaCertificatePath}' does not exist. Skipping CA certificate installation", 
+                caCertificatePath);
+            return;
+        }
+
+        var certificateFiles = GetCertificateFiles(caCertificatePath);
+        
+        if (certificateFiles.Length == 0)
+        {
+            logger.Information("No certificate files found in '{CaCertificatePath}'. Supported extensions: {Extensions}", 
+                caCertificatePath, string.Join(", ", SupportedExtensions));
+            return;
+        }
+
+        logger.Information("Found {Count} CA certificate file(s) in '{CaCertificatePath}'", 
+            certificateFiles.Length, caCertificatePath);
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            InstallCertificatesOnLinux(certificateFiles, logger);
+        }
+        else
+        {
+            logger.Warning("CA certificate installation is not supported on this platform: {Platform}", 
+                RuntimeInformation.OSDescription);
+        }
+    }
+
+    private static string[] GetCertificateFiles(string directoryPath)
+    {
+        return Directory.GetFiles(directoryPath)
+            .Where(f => SupportedExtensions.Contains(Path.GetExtension(f).ToLowerInvariant()))
+            .ToArray();
+    }
+
+    private static void InstallCertificatesOnLinux(string[] certificateFiles, Serilog.ILogger logger)
+    {
+        const string systemCertPath = "/usr/local/share/ca-certificates";
+        
+        try
+        {
+            // Ensure the system certificate directory exists
+            if (!Directory.Exists(systemCertPath))
+            {
+                logger.Warning("System CA certificate directory '{Path}' does not exist. " +
+                    "Ensure the container has the 'ca-certificates' package installed", systemCertPath);
+                return;
+            }
+
+            var installedCount = 0;
+            foreach (var certFile in certificateFiles)
+            {
+                try
+                {
+                    var fileName = Path.GetFileName(certFile);
+                    // Ensure the file has .crt extension for update-ca-certificates to recognize it
+                    if (!fileName.EndsWith(".crt", StringComparison.OrdinalIgnoreCase))
+                    {
+                        fileName = Path.GetFileNameWithoutExtension(fileName) + ".crt";
+                    }
+                    
+                    var destPath = Path.Combine(systemCertPath, fileName);
+                    File.Copy(certFile, destPath, overwrite: true);
+                    logger.Debug("Copied CA certificate '{SourceFile}' to '{DestFile}'", certFile, destPath);
+                    installedCount++;
+                }
+                catch (Exception ex)
+                {
+                    logger.Warning(ex, "Failed to copy CA certificate '{CertFile}' to system store", certFile);
+                }
+            }
+
+            if (installedCount > 0)
+            {
+                // Run update-ca-certificates to refresh the trust store
+                var processInfo = new ProcessStartInfo
+                {
+                    FileName = "update-ca-certificates",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                };
+
+                using var process = Process.Start(processInfo);
+                if (process != null)
+                {
+                    var output = process.StandardOutput.ReadToEnd();
+                    var error = process.StandardError.ReadToEnd();
+                    process.WaitForExit();
+
+                    if (process.ExitCode == 0)
+                    {
+                        logger.Information("Successfully installed {Count} CA certificate(s) to system trust store. {Output}", 
+                            installedCount, output.Trim());
+                    }
+                    else
+                    {
+                        logger.Error("Failed to update CA certificates. Exit code: {ExitCode}. Error: {Error}", 
+                            process.ExitCode, error);
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.Error(ex, "Failed to install CA certificates on Linux");
+        }
+    }
+}

--- a/src/api/Fig.Api/Dockerfile
+++ b/src/api/Fig.Api/Dockerfile
@@ -5,8 +5,16 @@ WORKDIR /app
 EXPOSE 80
 EXPOSE 443
 
+# Install curl for health checks and ca-certificates for custom CA certificate support
+# The ca-certificates package enables adding custom root CA certificates to the trust store
+# at container startup, which is required for encrypted SQL Server connections using 
+# MicrosoftDataSqlDriver with certificates signed by enterprise/custom CAs.
 RUN apt-get update \
-    && apt-get install -y curl
+    && apt-get install -y curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create directory for CA certificate mounts
+RUN mkdir -p /app/ca-certificates
 
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 

--- a/src/api/Fig.Api/Program.cs
+++ b/src/api/Fig.Api/Program.cs
@@ -1,6 +1,7 @@
 using Fig.Api;
 using Fig.Api.ApiStatus;
 using Fig.Api.Authorization;
+using Fig.Api.Certificates;
 using Fig.Api.Converters;
 using Fig.Api.Datalayer;
 using Fig.Api.DataImport;
@@ -58,6 +59,11 @@ var apiSettings = configuration.GetSection("ApiSettings");
 
 var logger = CreateLogger(builder);
 builder.Host.UseSerilog(logger);
+
+// Install CA certificates from configured path before database connections are established
+var caCertPath = configuration.GetValue<string>("ApiSettings:CaCertificatePath") 
+    ?? Environment.GetEnvironmentVariable("FIG_CA_CERTIFICATE_PATH");
+CaCertificateInstaller.InstallCertificates(caCertPath, logger);
 
 builder.AddServiceDefaults(ApiActivitySource.Name);
 

--- a/src/api/Fig.Api/appsettings.json
+++ b/src/api/Fig.Api/appsettings.json
@@ -18,6 +18,7 @@
     ],
     "KnownNetworks": [
     ],
+    "CaCertificatePath": null,
     "RateLimiting": {
       "GlobalPolicy": {
         "Enabled": true,


### PR DESCRIPTION
… in the linux container to support encrypted sql server connections

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for custom CA certificate configuration enabling automatic certificate discovery and installation during application startup
  * Users can now specify a CA certificate directory path via configuration settings or environment variables

* **Chores**
  * Updated Docker image with CA certificate package dependencies and added example configuration for certificate volume mounting

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->