### PR TITLE
Fix ObjectDisposedException in FigLookupWorker and FigHealthWorker

### DIFF
--- a/src/client/Fig.Client/Workers/FigHealthWorker.cs
+++ b/src/client/Fig.Client/Workers/FigHealthWorker.cs
@@ -16,19 +16,24 @@ public class FigHealthWorker<T> : IHostedService where T : SettingsBase
     
     private readonly HealthCheckService _healthCheckService;
     private readonly ILogger<FigHealthWorker<T>> _logger;
+    private readonly IHostApplicationLifetime _hostApplicationLifetime;
 
-    public FigHealthWorker(HealthCheckService healthCheckService, ILogger<FigHealthWorker<T>> logger)
+    public FigHealthWorker(HealthCheckService healthCheckService, ILogger<FigHealthWorker<T>> logger,
+        IHostApplicationLifetime hostApplicationLifetime)
     {
         _healthCheckService = healthCheckService;
         _logger = logger;
+        _hostApplicationLifetime = hostApplicationLifetime;
     }
     
     public Task StartAsync(CancellationToken cancellationToken)
     {
+        var appStopping = _hostApplicationLifetime.ApplicationStopping;
+        
         HealthCheckBridge.GetHealthReportAsync = async () =>
         {
             using var timeoutCts = new CancellationTokenSource(HealthCheckTimeout);
-            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(appStopping, timeoutCts.Token);
             
             try
             {

--- a/src/client/Fig.Client/Workers/FigLookupWorker.cs
+++ b/src/client/Fig.Client/Workers/FigLookupWorker.cs
@@ -23,6 +23,7 @@ public class FigLookupWorker<T> : IHostedService, IDisposable where T : Settings
     private readonly HashSet<string> _validLookupTableNames;
     private CancellationTokenSource? _stoppingCts;
     private Task? _executingTask;
+    private bool _disposed;
 
     public FigLookupWorker(ILogger<FigLookupWorker<T>> logger, 
         IServiceScopeFactory serviceScopeFactory,
@@ -133,6 +134,10 @@ public class FigLookupWorker<T> : IHostedService, IDisposable where T : Settings
         {
             _stoppingCts?.Cancel();
         }
+        catch (ObjectDisposedException)
+        {
+            // CTS was already disposed — expected if Dispose() ran first
+        }
         finally
         {
             // Wait for the background task to complete or timeout
@@ -146,11 +151,25 @@ public class FigLookupWorker<T> : IHostedService, IDisposable where T : Settings
 
     public void Dispose()
     {
-        if (_stoppingCts != null)
+        if (_disposed)
+            return;
+
+        _disposed = true;
+
+        var cts = _stoppingCts;
+        _stoppingCts = null;
+
+        if (cts != null)
         {
-            _stoppingCts.Cancel();
-        
-            // Wait for the task to complete (with a reasonable timeout)
+            try
+            {
+                cts.Cancel();
+            }
+            catch (ObjectDisposedException)
+            {
+                // Already disposed — ignore
+            }
+
             try
             {
                 _executingTask?.Wait(TimeSpan.FromSeconds(5));
@@ -159,8 +178,8 @@ public class FigLookupWorker<T> : IHostedService, IDisposable where T : Settings
             {
                 // Task was cancelled or faulted - expected during disposal
             }
-        
-            _stoppingCts.Dispose();
+
+            cts.Dispose();
         }
     }
 


### PR DESCRIPTION
## Problem

Integration tests (and potentially production) throw `ObjectDisposedException` during teardown:

```
System.ObjectDisposedException: The CancellationTokenSource has been disposed.
  at System.Threading.CancellationTokenSource.Cancel()
  at Fig.Client.Workers.FigLookupWorker`1.StopAsync(CancellationToken)
```

## Root Causes

### FigLookupWorker — StopAsync/Dispose race

Both `StopAsync` and `Dispose` called `_stoppingCts.Cancel()`, and `Dispose` also called `_stoppingCts.Dispose()`. In test teardown via `WebApplicationFactory.DisposeAsync()`, `Dispose` could run before a second `StopAsync` call, leaving the CTS disposed when `StopAsync` tried to cancel it.

### FigHealthWorker — captured startup token used after source disposal

`StartAsync` captured its `cancellationToken` parameter in a long-lived closure assigned to `HealthCheckBridge.GetHealthReportAsync`. The startup token's `CancellationTokenSource` is disposed after startup completes, so later calls to `CreateLinkedTokenSource(cancellationToken, ...)` would throw `ObjectDisposedException`.

## Fixes

**FigLookupWorker:**
- Catch `ObjectDisposedException` in `StopAsync` around `Cancel()`
- Add `_disposed` guard to prevent double-disposal
- Null out `_stoppingCts` before disposing so concurrent `StopAsync` calls safely skip via `?.`

**FigHealthWorker:**
- Inject `IHostApplicationLifetime` and use `ApplicationStopping` token in the closure instead of the startup token — `ApplicationStopping` remains valid for the full application lifetime

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* Improved health check cancellation during application shutdown to ensure in-flight checks are properly aborted when the host begins stopping.
* Enhanced disposal safety in background workers to prevent errors and ensure cleanup operations are idempotent, preventing issues when shutdown procedures interact with resource cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->