### PR TITLE
Add dynamic setting groups and Groups page overhaul

### DIFF
--- a/doc/fig-documentation/docs/features/34-groups.md
+++ b/doc/fig-documentation/docs/features/34-groups.md
@@ -1,0 +1,142 @@
+---
+sidebar_position: 34
+sidebar_label: Groups
+---
+
+# Groups
+
+## Overview
+
+The Groups page provides a dedicated interface for managing setting groups in Fig. Groups allow you to link related settings from multiple clients so they can be organized and managed together. For example, if several microservices need the same database connection string, you can group those settings so the relationship is clearly visible and maintained in one place.
+
+Groups are managed entirely from the web application — no code changes are required to create, modify, or delete groups after initial setup.
+
+## Creating Groups
+
+To create a new group:
+
+1. Navigate to the **Groups** page from the main menu.
+2. Click the **+** button in the top-right of the left panel.
+3. Enter a name for the group in the dialog that appears.
+4. Click **OK** to create the group.
+
+The new group will appear in the left panel list, ready for you to add grouped settings and source settings.
+
+## Managing Groups
+
+### Editing a Group
+
+Select a group from the left panel to view and edit its details:
+
+- **Name** — The display name of the group. Editable inline by administrators.
+- **Description** — An optional description explaining the purpose of the group.
+
+Click **Save** to persist changes, or **Delete** to remove the group entirely. Deleting a group does not delete or modify the underlying settings — they simply become ungrouped.
+
+### Adding Grouped Settings
+
+A grouped setting represents a logical configuration item within a group. For example, a group called "Database" might contain grouped settings like "Connection String" and "Database Name".
+
+To add a grouped setting:
+
+1. Select a group from the left panel.
+2. Click **Add Grouped Setting**.
+3. Edit the name, description, and value type as needed.
+
+Each grouped setting has a **Value Type** badge (e.g., `System.String`, `System.Int32`) that indicates the data type of the underlying settings.
+
+### Adding Source Settings
+
+Source settings are the actual client settings that a grouped setting links to. Each source setting is identified by a **Client Name** and **Setting Name** pair.
+
+To add source settings:
+
+1. Click **Add Source Setting** on a grouped setting card.
+2. A dialog appears listing all available (ungrouped) settings from registered clients.
+3. Select one or more settings and confirm.
+
+Settings that are already assigned to any group are automatically excluded from the selection list. Each source setting can belong to only one grouped setting at a time.
+
+### Removing Source Settings
+
+Click the **×** button next to any source setting to remove it from the grouped setting. The underlying setting is not deleted — it simply becomes ungrouped.
+
+### Removing Grouped Settings
+
+Click the delete icon on a grouped setting card to remove it and all its source setting associations from the group.
+
+## Automatic Group Creation
+
+When a client registers with Fig for the first time, any settings decorated with the `[Group]` attribute are automatically added to groups:
+
+```csharp
+[Setting("Database connection string")]
+[Group("Database")]
+public string ConnectionString { get; set; } = "Server=localhost;";
+
+[Setting("Database name")]
+[Group("Database")]
+public string DatabaseName { get; set; } = "MyDb";
+```
+
+On first registration:
+
+- If a group with the specified name does not exist, it is created automatically.
+- If the group already exists, the setting is added to the appropriate grouped setting within it.
+- Settings are grouped by their leaf name (the last segment of hierarchical setting names).
+
+After initial auto-creation, groups are fully managed from the Groups page. The `[Group]` attribute is only used during the first registration of a client — subsequent registrations do not modify existing group membership.
+
+## Import and Export
+
+Group configurations can be exported and imported from the **Import / Export** page.
+
+### Export
+
+1. Navigate to the **Import / Export** page.
+2. In the **Group Export** section, click **Export**.
+3. A JSON file (`FigGroupExport-<timestamp>.json`) is downloaded containing all group definitions and their source setting mappings.
+
+:::note
+Group export includes group structure only (names, descriptions, grouped settings, and source setting references). It does not include actual setting values.
+:::
+
+### Import
+
+1. Navigate to the **Import / Export** page.
+2. In the **Group Import** section, upload a previously exported group JSON file.
+3. Select an import strategy:
+   - **Clear and Import** — Deletes all existing groups and imports the groups from the file.
+   - **Add New** — Only imports groups that do not already exist. Existing groups are left unchanged.
+   - **Replace Existing** — Updates existing groups by name and creates any new groups from the file.
+4. Click **Import** to apply.
+
+## Migration
+
+When upgrading to a version of Fig that includes the Groups page, any existing groups created via `[Group]` attributes are automatically migrated to the new system. This migration:
+
+- Reads all settings that have a `Group` value set.
+- Creates `SettingGroup` records for each unique group name.
+- Links the appropriate source settings to their grouped settings.
+- Skips groups that have already been migrated.
+
+No manual action is required — existing group relationships are preserved.
+
+## Permissions
+
+| Action | Administrator | User | Read Only |
+| --- | --- | --- | --- |
+| View groups | ✅ | ✅ | ✅ |
+| Create groups | ✅ | ❌ | ❌ |
+| Edit groups | ✅ | ❌ | ❌ |
+| Delete groups | ✅ | ❌ | ❌ |
+| Export groups | ✅ | ❌ | ❌ |
+| Import groups | ✅ | ❌ | ❌ |
+
+## Filtering
+
+The left panel includes a filter text box to quickly find groups by name. Type any part of the group name to narrow the list.
+
+## Audit Trail
+
+All group operations (creation, updates, deletions, imports, and exports) are recorded in the Fig event log. Each event includes the username of the person who performed the action, or "System" for automatic operations such as migration and client registration.

--- a/doc/fig-documentation/docs/features/settings-management/10-groups.md
+++ b/doc/fig-documentation/docs/features/settings-management/10-groups.md
@@ -4,9 +4,15 @@ sidebar_position: 10
 
 # Groups
 
+:::tip[Groups Page]
+Groups are now managed via the dedicated **[Groups page](../34-groups.md)**. You can create, edit, and delete groups and their source settings directly from the web application without any code changes. The `[Group]` attribute described below is used only for automatic group creation on first client registration.
+:::
+
 Fig has the capability to group settings from multiple setting clients so they can be edited in one place. This is useful when multiple applications require the same configuration such as a database connection string. With the groups feature this can be set once and applied to all requesting clients simultaneously.
 
 ## Usage
+
+The `[Group]` attribute is used to define initial group membership when a client registers with Fig for the first time. After the initial registration, group membership is managed from the [Groups page](../34-groups.md).
 
 ```csharp
 [Setting("Environment name")]
@@ -38,7 +44,7 @@ See [Instances](../19-instances.md) for more information.
 
 ## Aligning Settings within a group
 
-Grouping happens client side only so it is possible that two applications register a setting in the same group with different default values. In that case, the members of the group will have different values. The group will display one of these values.
+When multiple applications register a setting in the same group with different default values, the members of the group will have different values. The group will display one of these values.
 
 Starting in Fig version 3.4, the groups will show if there are any misligned members and allow users to align all group members to have the same value. This can also be done by updating the value of the group which will automatically be pushed down to all members.
 

--- a/doc/fig-documentation/versioned_docs/version-3.x/features/34-groups.md
+++ b/doc/fig-documentation/versioned_docs/version-3.x/features/34-groups.md
@@ -1,0 +1,142 @@
+---
+sidebar_position: 34
+sidebar_label: Groups
+---
+
+# Groups
+
+## Overview
+
+The Groups page provides a dedicated interface for managing setting groups in Fig. Groups allow you to link related settings from multiple clients so they can be organized and managed together. For example, if several microservices need the same database connection string, you can group those settings so the relationship is clearly visible and maintained in one place.
+
+Groups are managed entirely from the web application — no code changes are required to create, modify, or delete groups after initial setup.
+
+## Creating Groups
+
+To create a new group:
+
+1. Navigate to the **Groups** page from the main menu.
+2. Click the **+** button in the top-right of the left panel.
+3. Enter a name for the group in the dialog that appears.
+4. Click **OK** to create the group.
+
+The new group will appear in the left panel list, ready for you to add grouped settings and source settings.
+
+## Managing Groups
+
+### Editing a Group
+
+Select a group from the left panel to view and edit its details:
+
+- **Name** — The display name of the group. Editable inline by administrators.
+- **Description** — An optional description explaining the purpose of the group.
+
+Click **Save** to persist changes, or **Delete** to remove the group entirely. Deleting a group does not delete or modify the underlying settings — they simply become ungrouped.
+
+### Adding Grouped Settings
+
+A grouped setting represents a logical configuration item within a group. For example, a group called "Database" might contain grouped settings like "Connection String" and "Database Name".
+
+To add a grouped setting:
+
+1. Select a group from the left panel.
+2. Click **Add Grouped Setting**.
+3. Edit the name, description, and value type as needed.
+
+Each grouped setting has a **Value Type** badge (e.g., `System.String`, `System.Int32`) that indicates the data type of the underlying settings.
+
+### Adding Source Settings
+
+Source settings are the actual client settings that a grouped setting links to. Each source setting is identified by a **Client Name** and **Setting Name** pair.
+
+To add source settings:
+
+1. Click **Add Source Setting** on a grouped setting card.
+2. A dialog appears listing all available (ungrouped) settings from registered clients.
+3. Select one or more settings and confirm.
+
+Settings that are already assigned to any group are automatically excluded from the selection list. Each source setting can belong to only one grouped setting at a time.
+
+### Removing Source Settings
+
+Click the **×** button next to any source setting to remove it from the grouped setting. The underlying setting is not deleted — it simply becomes ungrouped.
+
+### Removing Grouped Settings
+
+Click the delete icon on a grouped setting card to remove it and all its source setting associations from the group.
+
+## Automatic Group Creation
+
+When a client registers with Fig for the first time, any settings decorated with the `[Group]` attribute are automatically added to groups:
+
+```csharp
+[Setting("Database connection string")]
+[Group("Database")]
+public string ConnectionString { get; set; } = "Server=localhost;";
+
+[Setting("Database name")]
+[Group("Database")]
+public string DatabaseName { get; set; } = "MyDb";
+```
+
+On first registration:
+
+- If a group with the specified name does not exist, it is created automatically.
+- If the group already exists, the setting is added to the appropriate grouped setting within it.
+- Settings are grouped by their leaf name (the last segment of hierarchical setting names).
+
+After initial auto-creation, groups are fully managed from the Groups page. The `[Group]` attribute is only used during the first registration of a client — subsequent registrations do not modify existing group membership.
+
+## Import and Export
+
+Group configurations can be exported and imported from the **Import / Export** page.
+
+### Export
+
+1. Navigate to the **Import / Export** page.
+2. In the **Group Export** section, click **Export**.
+3. A JSON file (`FigGroupExport-<timestamp>.json`) is downloaded containing all group definitions and their source setting mappings.
+
+:::note
+Group export includes group structure only (names, descriptions, grouped settings, and source setting references). It does not include actual setting values.
+:::
+
+### Import
+
+1. Navigate to the **Import / Export** page.
+2. In the **Group Import** section, upload a previously exported group JSON file.
+3. Select an import strategy:
+   - **Clear and Import** — Deletes all existing groups and imports the groups from the file.
+   - **Add New** — Only imports groups that do not already exist. Existing groups are left unchanged.
+   - **Replace Existing** — Updates existing groups by name and creates any new groups from the file.
+4. Click **Import** to apply.
+
+## Migration
+
+When upgrading to a version of Fig that includes the Groups page, any existing groups created via `[Group]` attributes are automatically migrated to the new system. This migration:
+
+- Reads all settings that have a `Group` value set.
+- Creates `SettingGroup` records for each unique group name.
+- Links the appropriate source settings to their grouped settings.
+- Skips groups that have already been migrated.
+
+No manual action is required — existing group relationships are preserved.
+
+## Permissions
+
+| Action | Administrator | User | Read Only |
+| --- | --- | --- | --- |
+| View groups | ✅ | ✅ | ✅ |
+| Create groups | ✅ | ❌ | ❌ |
+| Edit groups | ✅ | ❌ | ❌ |
+| Delete groups | ✅ | ❌ | ❌ |
+| Export groups | ✅ | ❌ | ❌ |
+| Import groups | ✅ | ❌ | ❌ |
+
+## Filtering
+
+The left panel includes a filter text box to quickly find groups by name. Type any part of the group name to narrow the list.
+
+## Audit Trail
+
+All group operations (creation, updates, deletions, imports, and exports) are recorded in the Fig event log. Each event includes the username of the person who performed the action, or "System" for automatic operations such as migration and client registration.

--- a/doc/fig-documentation/versioned_docs/version-3.x/features/settings-management/10-groups.md
+++ b/doc/fig-documentation/versioned_docs/version-3.x/features/settings-management/10-groups.md
@@ -4,9 +4,15 @@ sidebar_position: 10
 
 # Groups
 
+:::tip[Groups Page]
+Groups are now managed via the dedicated **[Groups page](../34-groups.md)**. You can create, edit, and delete groups and their source settings directly from the web application without any code changes. The `[Group]` attribute described below is used only for automatic group creation on first client registration.
+:::
+
 Fig has the capability to group settings from multiple setting clients so they can be edited in one place. This is useful when multiple applications require the same configuration such as a database connection string. With the groups feature this can be set once and applied to all requesting clients simultaneously.
 
 ## Usage
+
+The `[Group]` attribute is used to define initial group membership when a client registers with Fig for the first time. After the initial registration, group membership is managed from the [Groups page](../34-groups.md).
 
 ```csharp
 [Setting("Environment name")]
@@ -38,7 +44,7 @@ See [Instances](../19-instances.md) for more information.
 
 ## Aligning Settings within a group
 
-Grouping happens client side only so it is possible that two applications register a setting in the same group with different default values. In that case, the members of the group will have different values. The group will display one of these values.
+When multiple applications register a setting in the same group with different default values, the members of the group will have different values. The group will display one of these values.
 
 Starting in Fig version 3.4, the groups will show if there are any misligned members and allow users to align all group members to have the same value. This can also be done by updating the value of the group which will automatically be pushed down to all members.
 

--- a/src/api/Fig.Api/Controllers/SettingGroupDataController.cs
+++ b/src/api/Fig.Api/Controllers/SettingGroupDataController.cs
@@ -1,0 +1,40 @@
+using Fig.Api.Attributes;
+using Fig.Api.Services;
+using Fig.Contracts.Authentication;
+using Fig.Contracts.ImportExport;
+using Fig.Contracts.SettingGroups;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Fig.Api.Controllers;
+
+[ApiController]
+[Route("settinggroupdata")]
+public class SettingGroupDataController : ControllerBase
+{
+    private readonly ILogger<SettingGroupDataController> _logger;
+    private readonly IGroupImportExportService _groupImportExportService;
+
+    public SettingGroupDataController(ILogger<SettingGroupDataController> logger, 
+        IGroupImportExportService groupImportExportService)
+    {
+        _logger = logger;
+        _groupImportExportService = groupImportExportService;
+    }
+
+    [Authorize(Role.Administrator)]
+    [HttpGet]
+    public async Task<IActionResult> ExportGroups()
+    {
+        var data = await _groupImportExportService.ExportGroups();
+        return Ok(data);
+    }
+
+    [Authorize(Role.Administrator)]
+    [HttpPut]
+    public async Task<IActionResult> ImportGroups([FromBody] SettingGroupExportDataContract data, 
+        [FromQuery] ImportType importType = ImportType.AddNew)
+    {
+        var result = await _groupImportExportService.ImportGroups(data, importType);
+        return Ok(result);
+    }
+}

--- a/src/api/Fig.Api/Controllers/SettingGroupsController.cs
+++ b/src/api/Fig.Api/Controllers/SettingGroupsController.cs
@@ -1,0 +1,61 @@
+using Fig.Api.Attributes;
+using Fig.Api.Services;
+using Fig.Contracts.Authentication;
+using Fig.Contracts.SettingGroups;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Fig.Api.Controllers;
+
+[ApiController]
+[Route("settinggroups")]
+public class SettingGroupsController : ControllerBase
+{
+    private readonly ILogger<SettingGroupsController> _logger;
+    private readonly ISettingGroupService _settingGroupService;
+
+    public SettingGroupsController(ILogger<SettingGroupsController> logger, ISettingGroupService settingGroupService)
+    {
+        _logger = logger;
+        _settingGroupService = settingGroupService;
+    }
+
+    [Authorize(Role.Administrator, Role.User, Role.ReadOnly)]
+    [HttpGet]
+    public async Task<IActionResult> GetAllGroups()
+    {
+        var groups = await _settingGroupService.GetAllGroups();
+        return Ok(groups);
+    }
+
+    [Authorize(Role.Administrator, Role.User, Role.ReadOnly)]
+    [HttpGet("{id}")]
+    public async Task<IActionResult> GetGroup(Guid id)
+    {
+        var group = await _settingGroupService.GetGroup(id);
+        return Ok(group);
+    }
+
+    [Authorize(Role.Administrator)]
+    [HttpPost]
+    public async Task<IActionResult> CreateGroup([FromBody] SettingGroupDataContract group)
+    {
+        var result = await _settingGroupService.CreateGroup(group);
+        return Ok(result);
+    }
+
+    [Authorize(Role.Administrator)]
+    [HttpPut("{id}")]
+    public async Task<IActionResult> UpdateGroup(Guid id, [FromBody] SettingGroupDataContract group)
+    {
+        var result = await _settingGroupService.UpdateGroup(id, group);
+        return Ok(result);
+    }
+
+    [Authorize(Role.Administrator)]
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> DeleteGroup(Guid id)
+    {
+        await _settingGroupService.DeleteGroup(id);
+        return Ok();
+    }
+}

--- a/src/api/Fig.Api/DatabaseMigrations/Migrations/Migration_005_SeedSettingGroups.cs
+++ b/src/api/Fig.Api/DatabaseMigrations/Migrations/Migration_005_SeedSettingGroups.cs
@@ -46,7 +46,9 @@ public class Migration_005_SeedSettingGroups : IDatabaseMigration
                         ClientName = client.Name,
                         SettingName = s.Name,
                         GroupName = s.Group!,
-                        ValueType = s.ValueType?.FullName ?? "System.String"
+                        ValueType = s.ValueType?.FullName ?? "System.String",
+                        CategoryName = s.CategoryName,
+                        CategoryColor = s.CategoryColor
                     }))
                 .ToList();
 
@@ -81,7 +83,11 @@ public class Migration_005_SeedSettingGroups : IDatabaseMigration
                         .ToList();
 
                     groupedSettings.Add(new GroupedSettingDataContract(
-                        first.SettingName, null, first.ValueType, sourceSettings));
+                        first.SettingName, null, first.ValueType, sourceSettings)
+                    {
+                        CategoryName = first.CategoryName,
+                        CategoryColor = first.CategoryColor
+                    });
                 }
 
                 var entity = new SettingGroupBusinessEntity

--- a/src/api/Fig.Api/DatabaseMigrations/Migrations/Migration_005_SeedSettingGroups.cs
+++ b/src/api/Fig.Api/DatabaseMigrations/Migrations/Migration_005_SeedSettingGroups.cs
@@ -1,0 +1,116 @@
+using Fig.Api.Datalayer.Repositories;
+using Fig.Api.Utils;
+using Fig.Contracts.SettingGroups;
+using Fig.Datalayer.BusinessEntities;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace Fig.Api.DatabaseMigrations.Migrations;
+
+/// <summary>
+/// Seeds setting groups from existing client group attributes.
+/// The setting_groups table is created by NHibernate SchemaUpdate from the mapping;
+/// this migration only populates initial data.
+/// </summary>
+public class Migration_005_SeedSettingGroups : IDatabaseMigration
+{
+    public int ExecutionNumber => 5;
+
+    public string Description => "Seed setting groups from existing client group attributes";
+
+    public string SqlServerScript => "SELECT 'Setting groups table created by NHibernate SchemaUpdate' as result;";
+
+    public string SqliteScript => "SELECT 'Setting groups table created by NHibernate SchemaUpdate' as result;";
+
+    public async Task? ExecuteCode(IServiceProvider serviceProvider)
+    {
+        var logger = serviceProvider.GetRequiredService<ILogger<Migration_005_SeedSettingGroups>>();
+        var settingClientRepository = serviceProvider.GetRequiredService<ISettingClientRepository>();
+        var settingGroupRepository = serviceProvider.GetRequiredService<ISettingGroupRepository>();
+
+        logger.LogInformation("Starting seed of setting groups from existing client group attributes");
+
+        try
+        {
+            var allClients = await settingClientRepository.GetAllClients(new ServiceUser(), upgradeLock: false, validateCode: false);
+
+            // Collect all settings that have a Group attribute, across base clients only
+            // (exclude instance overrides to match original SettingGroupBuilder behavior)
+            var settingsWithGroups = allClients
+                .Where(client => client.Instance == null)
+                .SelectMany(client => (client.Settings ?? Enumerable.Empty<SettingBusinessEntity>())
+                    .Where(s => !string.IsNullOrWhiteSpace(s.Group))
+                    .Select(s => new
+                    {
+                        ClientName = client.Name,
+                        SettingName = s.Name,
+                        GroupName = s.Group!,
+                        ValueType = s.ValueType?.FullName ?? "System.String"
+                    }))
+                .ToList();
+
+            if (!settingsWithGroups.Any())
+            {
+                logger.LogInformation("No settings with group attributes found. Skipping group seeding");
+                return;
+            }
+
+            var groupsByName = settingsWithGroups.GroupBy(s => s.GroupName);
+
+            foreach (var grouping in groupsByName)
+            {
+                var groupName = grouping.Key;
+
+                var existing = await settingGroupRepository.GetGroupByName(groupName);
+                if (existing != null)
+                {
+                    logger.LogInformation("Setting group '{GroupName}' already exists, skipping", groupName);
+                    continue;
+                }
+
+                // Sub-group by leaf setting name (last part after "->")
+                var settingsByLeaf = grouping.GroupBy(s => GetLeafName(s.SettingName));
+
+                var groupedSettings = new List<GroupedSettingDataContract>();
+                foreach (var leafGroup in settingsByLeaf)
+                {
+                    var first = leafGroup.First();
+                    var sourceSettings = leafGroup
+                        .Select(s => new SourceSettingDataContract(s.ClientName, s.SettingName))
+                        .ToList();
+
+                    groupedSettings.Add(new GroupedSettingDataContract(
+                        first.SettingName, null, first.ValueType, sourceSettings));
+                }
+
+                var entity = new SettingGroupBusinessEntity
+                {
+                    Name = groupName,
+                    GroupSettingsJson = JsonConvert.SerializeObject(groupedSettings),
+                    CreatedAt = DateTime.UtcNow,
+                    LastModifiedAt = DateTime.UtcNow,
+                    LastModifiedBy = "Migration"
+                };
+
+                await settingGroupRepository.AddGroup(entity);
+                logger.LogInformation("Created setting group '{GroupName}' with {Count} grouped settings",
+                    groupName, groupedSettings.Count);
+            }
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to seed setting groups");
+            throw;
+        }
+    }
+
+    private static string GetLeafName(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            return string.Empty;
+
+        var parts = name.Split("->", StringSplitOptions.RemoveEmptyEntries);
+        return parts.Length == 0 ? name.Trim() : parts[^1].Trim();
+    }
+}

--- a/src/api/Fig.Api/Datalayer/FigSessionFactory.cs
+++ b/src/api/Fig.Api/Datalayer/FigSessionFactory.cs
@@ -178,7 +178,8 @@ public class FigSessionFactory : IFigSessionFactory
             typeof(CustomActionExecutionMap),
             typeof(CustomActionMap),
             typeof(DatabaseMigrationMap),
-            typeof(ClientRegistrationHistoryMap)
+            typeof(ClientRegistrationHistoryMap),
+            typeof(SettingGroupMap)
         });
 
         return mapper.CompileMappingForAllExplicitlyAddedEntities();

--- a/src/api/Fig.Api/Datalayer/Repositories/ISettingGroupRepository.cs
+++ b/src/api/Fig.Api/Datalayer/Repositories/ISettingGroupRepository.cs
@@ -1,0 +1,18 @@
+using Fig.Datalayer.BusinessEntities;
+
+namespace Fig.Api.Datalayer.Repositories;
+
+public interface ISettingGroupRepository
+{
+    Task<IList<SettingGroupBusinessEntity>> GetAllGroups();
+
+    Task<SettingGroupBusinessEntity?> GetGroup(Guid id);
+
+    Task<SettingGroupBusinessEntity?> GetGroupByName(string name);
+
+    Task<Guid> AddGroup(SettingGroupBusinessEntity group);
+
+    Task UpdateGroup(SettingGroupBusinessEntity group);
+
+    Task DeleteGroup(SettingGroupBusinessEntity group);
+}

--- a/src/api/Fig.Api/Datalayer/Repositories/SettingGroupRepository.cs
+++ b/src/api/Fig.Api/Datalayer/Repositories/SettingGroupRepository.cs
@@ -1,0 +1,53 @@
+using System.Diagnostics;
+using Fig.Api.Observability;
+using Fig.Datalayer.BusinessEntities;
+using NHibernate;
+using NHibernate.Criterion;
+using ISession = NHibernate.ISession;
+
+namespace Fig.Api.Datalayer.Repositories;
+
+public class SettingGroupRepository : RepositoryBase<SettingGroupBusinessEntity>, ISettingGroupRepository
+{
+    public SettingGroupRepository(ISession session)
+        : base(session)
+    {
+    }
+
+    public async Task<IList<SettingGroupBusinessEntity>> GetAllGroups()
+    {
+        return await GetAll(false);
+    }
+
+    public async Task<SettingGroupBusinessEntity?> GetGroup(Guid id)
+    {
+        using Activity? activity = ApiActivitySource.Instance.StartActivity();
+        var criteria = Session.CreateCriteria<SettingGroupBusinessEntity>();
+        criteria.Add(Restrictions.Eq(nameof(SettingGroupBusinessEntity.Id), id));
+        criteria.SetLockMode(LockMode.Upgrade);
+        return await criteria.UniqueResultAsync<SettingGroupBusinessEntity>();
+    }
+
+    public async Task<SettingGroupBusinessEntity?> GetGroupByName(string name)
+    {
+        using Activity? activity = ApiActivitySource.Instance.StartActivity();
+        var criteria = Session.CreateCriteria<SettingGroupBusinessEntity>();
+        criteria.Add(Restrictions.Eq(nameof(SettingGroupBusinessEntity.Name), name));
+        return await criteria.UniqueResultAsync<SettingGroupBusinessEntity>();
+    }
+
+    public async Task<Guid> AddGroup(SettingGroupBusinessEntity group)
+    {
+        return await Save(group);
+    }
+
+    public async Task UpdateGroup(SettingGroupBusinessEntity group)
+    {
+        await Update(group);
+    }
+
+    public async Task DeleteGroup(SettingGroupBusinessEntity group)
+    {
+        await Delete(group);
+    }
+}

--- a/src/api/Fig.Api/EventLogFactory.cs
+++ b/src/api/Fig.Api/EventLogFactory.cs
@@ -335,6 +335,47 @@ public class EventLogFactory : IEventLogFactory
             message: $"Invalid client secret attempt to {action} from {requesterHostname ?? EventMessage.UnknownHostname} ({requestIpAddress ?? EventMessage.UnknownIp})");
     }
 
+    public EventLogBusinessEntity GroupCreated(string groupName, string? authenticatedUsername)
+    {
+        return Create(EventMessage.GroupCreated,
+            message: $"Setting group '{groupName}' created",
+            authenticatedUsername: authenticatedUsername);
+    }
+
+    public EventLogBusinessEntity GroupUpdated(string groupName, string? originalValue, string? newValue, string? authenticatedUsername)
+    {
+        return Create(EventMessage.GroupUpdated,
+            originalValue: originalValue,
+            newValue: newValue,
+            message: $"Setting group '{groupName}' updated",
+            authenticatedUsername: authenticatedUsername);
+    }
+
+    public EventLogBusinessEntity GroupDeleted(string groupName, string? authenticatedUsername)
+    {
+        return Create(EventMessage.GroupDeleted,
+            message: $"Setting group '{groupName}' deleted",
+            authenticatedUsername: authenticatedUsername);
+    }
+
+    public EventLogBusinessEntity GroupSettingAdded(string groupName, string settingName, string clientName, string? authenticatedUsername)
+    {
+        return Create(EventMessage.GroupSettingAdded,
+            clientName: clientName,
+            settingName: settingName,
+            message: $"Setting '{settingName}' from '{clientName}' added to group '{groupName}'",
+            authenticatedUsername: authenticatedUsername);
+    }
+
+    public EventLogBusinessEntity GroupSettingRemoved(string groupName, string settingName, string clientName, string? authenticatedUsername)
+    {
+        return Create(EventMessage.GroupSettingRemoved,
+            clientName: clientName,
+            settingName: settingName,
+            message: $"Setting '{settingName}' from '{clientName}' removed from group '{groupName}'",
+            authenticatedUsername: authenticatedUsername);
+    }
+
     private EventLogBusinessEntity Create(string eventType,
         Guid? clientId = null,
         string? clientName = null,

--- a/src/api/Fig.Api/IEventLogFactory.cs
+++ b/src/api/Fig.Api/IEventLogFactory.cs
@@ -123,4 +123,14 @@ public interface IEventLogFactory
     EventLogBusinessEntity CustomActionExecutionCompleted(string clientName, string customActionName, bool succeeded);
     
     EventLogBusinessEntity InvalidClientSecretAttempt(string clientName, string action, string? requestIpAddress, string? requesterHostname);
+
+    EventLogBusinessEntity GroupCreated(string groupName, string? authenticatedUsername);
+    
+    EventLogBusinessEntity GroupUpdated(string groupName, string? originalValue, string? newValue, string? authenticatedUsername);
+    
+    EventLogBusinessEntity GroupDeleted(string groupName, string? authenticatedUsername);
+    
+    EventLogBusinessEntity GroupSettingAdded(string groupName, string settingName, string clientName, string? authenticatedUsername);
+    
+    EventLogBusinessEntity GroupSettingRemoved(string groupName, string settingName, string clientName, string? authenticatedUsername);
 }

--- a/src/api/Fig.Api/Middleware/ErrorHandlerMiddleware.cs
+++ b/src/api/Fig.Api/Middleware/ErrorHandlerMiddleware.cs
@@ -54,6 +54,7 @@ public class ErrorHandlerMiddleware
                 case ApplicationException:
                 case InvalidImportException:
                 case InvalidClientNameException:
+                case ArgumentException:
                     response.StatusCode = (int) HttpStatusCode.BadRequest;
                     break;
                 case KeyNotFoundException:

--- a/src/api/Fig.Api/Program.cs
+++ b/src/api/Fig.Api/Program.cs
@@ -139,6 +139,7 @@ builder.Services.AddScoped<IDeferredChangeRepository, DeferredChangeRepository>(
 builder.Services.AddScoped<ICustomActionRepository, CustomActionRepository>();
 builder.Services.AddScoped<ICustomActionExecutionRepository, CustomActionExecutionRepository>();
 builder.Services.AddScoped<IDatabaseMigrationRepository, DatabaseMigrationRepository>();
+builder.Services.AddScoped<ISettingGroupRepository, SettingGroupRepository>();
 
 builder.Services.AddSingleton<IVersionHelper, VersionHelper>();
 builder.Services.AddSingleton<IEventDistributor, EventDistributor>();
@@ -176,6 +177,8 @@ builder.Services.AddScoped<IDataCleanupService, DataCleanupService>();
 builder.Services.AddScoped<ISessionCleanupService, SessionCleanupService>();
 builder.Services.AddScoped<IClientRegistrationHistoryRepository, ClientRegistrationHistoryRepository>();
 builder.Services.AddScoped<IClientRegistrationHistoryService, ClientRegistrationHistoryService>();
+builder.Services.AddScoped<ISettingGroupService, SettingGroupService>();
+builder.Services.AddScoped<IGroupImportExportService, GroupImportExportService>();
 
 builder.Services.AddHttpClient();
 
@@ -186,6 +189,7 @@ builder.Services.AddTransient<IDatabaseMigration, Migration_001_IncreaseValidati
 builder.Services.AddTransient<IDatabaseMigration, Migration_002_DisableTimeMachine>();
 builder.Services.AddTransient<IDatabaseMigration, Migration_003_MigrateCodeHashes>();
 builder.Services.AddTransient<IDatabaseMigration, Migration_004_PopulateClientRegistrationHistory>();
+builder.Services.AddTransient<IDatabaseMigration, Migration_005_SeedSettingGroups>();
 
 // Add background services in priority order
 // DatabaseMigrationWorker must run first before other services
@@ -207,6 +211,8 @@ builder.Services.AddScoped<IAuthenticatedService>(a => a.GetService<IUserService
 builder.Services.AddScoped<IAuthenticatedService>(a => a.GetService<IStatusService>()!);
 builder.Services.AddScoped<IAuthenticatedService>(a => a.GetService<IEncryptionMigrationService>()!);
 builder.Services.AddScoped<IAuthenticatedService>(a => a.GetService<ICustomActionService>()!);
+builder.Services.AddScoped<IAuthenticatedService>(a => a.GetService<ISettingGroupService>()!);
+builder.Services.AddScoped<IAuthenticatedService>(a => a.GetService<IGroupImportExportService>()!);
 
 // Add rate limiting services
 var apiSettingsObject = configuration.GetSection("ApiSettings").Get<ApiSettings>();

--- a/src/api/Fig.Api/Services/GroupImportExportService.cs
+++ b/src/api/Fig.Api/Services/GroupImportExportService.cs
@@ -1,0 +1,154 @@
+using Fig.Api.Datalayer.Repositories;
+using Fig.Contracts.ImportExport;
+using Fig.Contracts.SettingGroups;
+using Fig.Datalayer.BusinessEntities;
+using Newtonsoft.Json;
+
+namespace Fig.Api.Services;
+
+public class GroupImportExportService : AuthenticatedService, IGroupImportExportService
+{
+    private readonly ISettingGroupRepository _settingGroupRepository;
+    private readonly IEventLogRepository _eventLogRepository;
+    private readonly IEventLogFactory _eventLogFactory;
+    private readonly ILogger<GroupImportExportService> _logger;
+
+    public GroupImportExportService(
+        ISettingGroupRepository settingGroupRepository,
+        IEventLogRepository eventLogRepository,
+        IEventLogFactory eventLogFactory,
+        ILogger<GroupImportExportService> logger)
+    {
+        _settingGroupRepository = settingGroupRepository;
+        _eventLogRepository = eventLogRepository;
+        _eventLogFactory = eventLogFactory;
+        _logger = logger;
+    }
+
+    public async Task<SettingGroupExportDataContract> ExportGroups()
+    {
+        var entities = await _settingGroupRepository.GetAllGroups();
+        var groups = entities.Select(ConvertToDataContract).ToList();
+
+        await _eventLogRepository.Add(_eventLogFactory.DataExported(AuthenticatedUser));
+
+        return new SettingGroupExportDataContract(DateTime.UtcNow, 1, groups);
+    }
+
+    public async Task<ImportResultDataContract> ImportGroups(SettingGroupExportDataContract data, ImportType importType)
+    {
+        try
+        {
+            switch (importType)
+            {
+                case ImportType.ClearAndImport:
+                    await ClearAndImport(data);
+                    break;
+                case ImportType.AddNew:
+                    await AddNew(data);
+                    break;
+                case ImportType.ReplaceExisting:
+                    await ReplaceExisting(data);
+                    break;
+            }
+
+            await _eventLogRepository.Add(
+                _eventLogFactory.DataImported(importType, DataImport.ImportMode.Api, data.Groups.Count, AuthenticatedUser));
+
+            return new ImportResultDataContract();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to import setting groups");
+            return new ImportResultDataContract
+            {
+                ErrorMessage = ex.Message
+            };
+        }
+    }
+
+    private async Task ClearAndImport(SettingGroupExportDataContract data)
+    {
+        var existingGroups = await _settingGroupRepository.GetAllGroups();
+        foreach (var existing in existingGroups)
+        {
+            await _settingGroupRepository.DeleteGroup(existing);
+        }
+
+        foreach (var group in data.Groups)
+        {
+            await CreateGroupEntity(group);
+        }
+    }
+
+    private async Task AddNew(SettingGroupExportDataContract data)
+    {
+        foreach (var group in data.Groups)
+        {
+            var existing = await _settingGroupRepository.GetGroupByName(group.Name);
+            if (existing == null)
+            {
+                await CreateGroupEntity(group);
+            }
+        }
+    }
+
+    private async Task ReplaceExisting(SettingGroupExportDataContract data)
+    {
+        foreach (var group in data.Groups)
+        {
+            var existing = await _settingGroupRepository.GetGroupByName(group.Name);
+            if (existing != null)
+            {
+                existing.Description = group.Description;
+                existing.GroupSettingsJson = SerializeGroupedSettings(group.GroupedSettings);
+                existing.LastModifiedAt = DateTime.UtcNow;
+                existing.LastModifiedBy = AuthenticatedUser?.Username;
+                await _settingGroupRepository.UpdateGroup(existing);
+            }
+            else
+            {
+                await CreateGroupEntity(group);
+            }
+        }
+    }
+
+    private async Task CreateGroupEntity(SettingGroupDataContract group)
+    {
+        var entity = new SettingGroupBusinessEntity
+        {
+            Name = group.Name,
+            Description = group.Description,
+            GroupSettingsJson = SerializeGroupedSettings(group.GroupedSettings),
+            CreatedAt = DateTime.UtcNow,
+            LastModifiedAt = DateTime.UtcNow,
+            LastModifiedBy = AuthenticatedUser?.Username ?? "Import"
+        };
+        await _settingGroupRepository.AddGroup(entity);
+    }
+
+    private static SettingGroupDataContract ConvertToDataContract(SettingGroupBusinessEntity entity)
+    {
+        var groupedSettings = DeserializeGroupedSettings(entity.GroupSettingsJson);
+        return new SettingGroupDataContract(entity.Id, entity.Name, entity.Description, groupedSettings)
+        {
+            CreatedAt = entity.CreatedAt,
+            LastModifiedAt = entity.LastModifiedAt,
+            LastModifiedBy = entity.LastModifiedBy
+        };
+    }
+
+    private static List<GroupedSettingDataContract> DeserializeGroupedSettings(string json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+            return new List<GroupedSettingDataContract>();
+
+        return JsonConvert.DeserializeObject<List<GroupedSettingDataContract>>(json)
+            ?? new List<GroupedSettingDataContract>();
+    }
+
+    private static string SerializeGroupedSettings(List<GroupedSettingDataContract> groupedSettings)
+    {
+        return JsonConvert.SerializeObject(groupedSettings);
+    }
+}

--- a/src/api/Fig.Api/Services/IGroupImportExportService.cs
+++ b/src/api/Fig.Api/Services/IGroupImportExportService.cs
@@ -1,0 +1,11 @@
+using Fig.Contracts.ImportExport;
+using Fig.Contracts.SettingGroups;
+
+namespace Fig.Api.Services;
+
+public interface IGroupImportExportService : IAuthenticatedService
+{
+    Task<SettingGroupExportDataContract> ExportGroups();
+    
+    Task<ImportResultDataContract> ImportGroups(SettingGroupExportDataContract data, ImportType importType);
+}

--- a/src/api/Fig.Api/Services/ISettingGroupService.cs
+++ b/src/api/Fig.Api/Services/ISettingGroupService.cs
@@ -1,0 +1,20 @@
+using Fig.Contracts.SettingGroups;
+
+namespace Fig.Api.Services;
+
+public interface ISettingGroupService : IAuthenticatedService
+{
+    Task<IEnumerable<SettingGroupDataContract>> GetAllGroups();
+    
+    Task<SettingGroupDataContract> GetGroup(Guid id);
+    
+    Task<SettingGroupDataContract> CreateGroup(SettingGroupDataContract group);
+    
+    Task<SettingGroupDataContract> UpdateGroup(Guid id, SettingGroupDataContract group);
+    
+    Task DeleteGroup(Guid id);
+    
+    Task RemoveClientFromGroups(string clientName);
+    
+    Task HandleInitialRegistrationGroups(string clientName, IEnumerable<(string SettingName, string GroupName, string ValueType)> settingsWithGroups);
+}

--- a/src/api/Fig.Api/Services/SettingGroupService.cs
+++ b/src/api/Fig.Api/Services/SettingGroupService.cs
@@ -1,0 +1,271 @@
+using Fig.Api.Datalayer.Repositories;
+using Fig.Common.Constants;
+using Fig.Contracts.SettingGroups;
+using Fig.Datalayer.BusinessEntities;
+using Newtonsoft.Json;
+
+namespace Fig.Api.Services;
+
+public class SettingGroupService : AuthenticatedService, ISettingGroupService
+{
+    private readonly ISettingGroupRepository _settingGroupRepository;
+    private readonly IEventLogRepository _eventLogRepository;
+    private readonly IEventLogFactory _eventLogFactory;
+    private readonly ILogger<SettingGroupService> _logger;
+
+    public SettingGroupService(
+        ISettingGroupRepository settingGroupRepository,
+        IEventLogRepository eventLogRepository,
+        IEventLogFactory eventLogFactory,
+        ILogger<SettingGroupService> logger)
+    {
+        _settingGroupRepository = settingGroupRepository;
+        _eventLogRepository = eventLogRepository;
+        _eventLogFactory = eventLogFactory;
+        _logger = logger;
+    }
+
+    public async Task<IEnumerable<SettingGroupDataContract>> GetAllGroups()
+    {
+        var entities = await _settingGroupRepository.GetAllGroups();
+        return entities.Select(ConvertToDataContract).ToList();
+    }
+
+    public async Task<SettingGroupDataContract> GetGroup(Guid id)
+    {
+        var entity = await _settingGroupRepository.GetGroup(id)
+            ?? throw new KeyNotFoundException($"No setting group found with id {id}");
+        return ConvertToDataContract(entity);
+    }
+
+    public async Task<SettingGroupDataContract> CreateGroup(SettingGroupDataContract group)
+    {
+        await ValidateGroupName(group.Name);
+        ValidateGroupedSettings(group);
+
+        var entity = new SettingGroupBusinessEntity
+        {
+            Name = group.Name,
+            Description = group.Description,
+            GroupSettingsJson = SerializeGroupedSettings(group.GroupedSettings),
+            CreatedAt = DateTime.UtcNow,
+            LastModifiedAt = DateTime.UtcNow,
+            LastModifiedBy = AuthenticatedUser?.Username
+        };
+
+        var id = await _settingGroupRepository.AddGroup(entity);
+        await _eventLogRepository.Add(_eventLogFactory.GroupCreated(group.Name, AuthenticatedUser?.Username));
+
+        group.Id = id;
+        group.CreatedAt = entity.CreatedAt;
+        group.LastModifiedAt = entity.LastModifiedAt;
+        group.LastModifiedBy = entity.LastModifiedBy;
+        return group;
+    }
+
+    public async Task<SettingGroupDataContract> UpdateGroup(Guid id, SettingGroupDataContract group)
+    {
+        var entity = await _settingGroupRepository.GetGroup(id)
+            ?? throw new KeyNotFoundException($"No setting group found with id {id}");
+
+        // Check name uniqueness if changed
+        if (!string.Equals(entity.Name, group.Name, StringComparison.Ordinal))
+        {
+            await ValidateGroupName(group.Name);
+        }
+
+        ValidateGroupedSettings(group);
+
+        var originalJson = entity.GroupSettingsJson;
+        entity.Name = group.Name;
+        entity.Description = group.Description;
+        entity.GroupSettingsJson = SerializeGroupedSettings(group.GroupedSettings);
+        entity.LastModifiedAt = DateTime.UtcNow;
+        entity.LastModifiedBy = AuthenticatedUser?.Username;
+
+        await _settingGroupRepository.UpdateGroup(entity);
+        await _eventLogRepository.Add(_eventLogFactory.GroupUpdated(
+            group.Name, originalJson, entity.GroupSettingsJson, AuthenticatedUser?.Username));
+
+        return ConvertToDataContract(entity);
+    }
+
+    public async Task DeleteGroup(Guid id)
+    {
+        var entity = await _settingGroupRepository.GetGroup(id)
+            ?? throw new KeyNotFoundException($"No setting group found with id {id}");
+
+        await _settingGroupRepository.DeleteGroup(entity);
+        await _eventLogRepository.Add(_eventLogFactory.GroupDeleted(entity.Name, AuthenticatedUser?.Username));
+    }
+
+    public async Task RemoveClientFromGroups(string clientName)
+    {
+        var allGroups = await _settingGroupRepository.GetAllGroups();
+        foreach (var entity in allGroups)
+        {
+            var groupedSettings = DeserializeGroupedSettings(entity.GroupSettingsJson);
+            var modified = false;
+
+            foreach (var gs in groupedSettings.ToList())
+            {
+                var removed = gs.SourceSettings.RemoveAll(s =>
+                    string.Equals(s.ClientName, clientName, StringComparison.OrdinalIgnoreCase));
+                if (removed > 0)
+                    modified = true;
+
+                if (gs.SourceSettings.Count == 0)
+                {
+                    groupedSettings.Remove(gs);
+                    modified = true;
+                }
+            }
+
+            if (!modified) continue;
+
+            if (groupedSettings.Count == 0)
+            {
+                await _settingGroupRepository.DeleteGroup(entity);
+                _logger.LogInformation("Deleted empty setting group '{GroupName}' after removing client '{ClientName}'",
+                    entity.Name, clientName);
+            }
+            else
+            {
+                entity.GroupSettingsJson = SerializeGroupedSettings(groupedSettings);
+                entity.LastModifiedAt = DateTime.UtcNow;
+                entity.LastModifiedBy = "System";
+                await _settingGroupRepository.UpdateGroup(entity);
+                _logger.LogInformation("Removed client '{ClientName}' references from setting group '{GroupName}'",
+                    clientName, entity.Name);
+            }
+        }
+    }
+
+    public async Task HandleInitialRegistrationGroups(string clientName, 
+        IEnumerable<(string SettingName, string GroupName, string ValueType)> settingsWithGroups)
+    {
+        var allGroups = await _settingGroupRepository.GetAllGroups();
+        var groupsByName = allGroups.ToDictionary(g => g.Name, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var (settingName, groupName, valueType) in settingsWithGroups)
+        {
+            if (groupsByName.TryGetValue(groupName, out var existingGroup))
+            {
+                var groupedSettings = DeserializeGroupedSettings(existingGroup.GroupSettingsJson);
+                var leafName = GetLeafName(settingName);
+
+                var matchingGs = groupedSettings.FirstOrDefault(gs =>
+                    string.Equals(GetLeafName(gs.Name), leafName, StringComparison.Ordinal));
+
+                if (matchingGs != null)
+                {
+                    // Add to existing grouped setting if not already there
+                    if (!matchingGs.SourceSettings.Any(s =>
+                        string.Equals(s.ClientName, clientName, StringComparison.OrdinalIgnoreCase) &&
+                        string.Equals(s.SettingName, settingName, StringComparison.Ordinal)))
+                    {
+                        matchingGs.SourceSettings.Add(new SourceSettingDataContract(clientName, settingName));
+                    }
+                }
+                else
+                {
+                    // Create new grouped setting in existing group
+                    groupedSettings.Add(new GroupedSettingDataContract(
+                        settingName, null, valueType,
+                        new List<SourceSettingDataContract> { new(clientName, settingName) }));
+                }
+
+                existingGroup.GroupSettingsJson = SerializeGroupedSettings(groupedSettings);
+                existingGroup.LastModifiedAt = DateTime.UtcNow;
+                existingGroup.LastModifiedBy = "System";
+                await _settingGroupRepository.UpdateGroup(existingGroup);
+            }
+            else
+            {
+                // Create new group
+                var newGroup = new SettingGroupBusinessEntity
+                {
+                    Name = groupName,
+                    GroupSettingsJson = SerializeGroupedSettings(new List<GroupedSettingDataContract>
+                    {
+                        new(settingName, null, valueType,
+                            new List<SourceSettingDataContract> { new(clientName, settingName) })
+                    }),
+                    CreatedAt = DateTime.UtcNow,
+                    LastModifiedAt = DateTime.UtcNow,
+                    LastModifiedBy = "System"
+                };
+                await _settingGroupRepository.AddGroup(newGroup);
+                groupsByName[groupName] = newGroup;
+            }
+        }
+    }
+
+    private async Task ValidateGroupName(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Group name cannot be empty.");
+
+        var existing = await _settingGroupRepository.GetGroupByName(name);
+        if (existing != null)
+            throw new InvalidOperationException($"A setting group with the name '{name}' already exists.");
+    }
+
+    private static void ValidateGroupedSettings(SettingGroupDataContract group)
+    {
+        if (group.GroupedSettings == null)
+            return;
+
+        foreach (var gs in group.GroupedSettings)
+        {
+            if (string.IsNullOrWhiteSpace(gs.Name))
+                throw new ArgumentException("Grouped setting name cannot be empty.");
+
+            if (gs.SourceSettings == null || gs.SourceSettings.Count == 0)
+                continue;
+
+            // All source settings must specify client and setting name
+            foreach (var ss in gs.SourceSettings)
+            {
+                if (string.IsNullOrWhiteSpace(ss.ClientName))
+                    throw new ArgumentException("Source setting client name cannot be empty.");
+                if (string.IsNullOrWhiteSpace(ss.SettingName))
+                    throw new ArgumentException("Source setting name cannot be empty.");
+            }
+        }
+    }
+
+    private static SettingGroupDataContract ConvertToDataContract(SettingGroupBusinessEntity entity)
+    {
+        var groupedSettings = DeserializeGroupedSettings(entity.GroupSettingsJson);
+        return new SettingGroupDataContract(entity.Id, entity.Name, entity.Description, groupedSettings)
+        {
+            CreatedAt = entity.CreatedAt,
+            LastModifiedAt = entity.LastModifiedAt,
+            LastModifiedBy = entity.LastModifiedBy
+        };
+    }
+
+    private static List<GroupedSettingDataContract> DeserializeGroupedSettings(string json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+            return new List<GroupedSettingDataContract>();
+
+        return JsonConvert.DeserializeObject<List<GroupedSettingDataContract>>(json) 
+            ?? new List<GroupedSettingDataContract>();
+    }
+
+    private static string SerializeGroupedSettings(List<GroupedSettingDataContract> groupedSettings)
+    {
+        return JsonConvert.SerializeObject(groupedSettings);
+    }
+
+    private static string GetLeafName(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            return string.Empty;
+
+        var parts = name.Split("->", StringSplitOptions.RemoveEmptyEntries);
+        return parts.Length == 0 ? name.Trim() : parts[^1].Trim();
+    }
+}

--- a/src/api/Fig.Api/Services/SettingGroupService.cs
+++ b/src/api/Fig.Api/Services/SettingGroupService.cs
@@ -1,4 +1,5 @@
 using Fig.Api.Datalayer.Repositories;
+using Fig.Api.ExtensionMethods;
 using Fig.Common.Constants;
 using Fig.Contracts.SettingGroups;
 using Fig.Datalayer.BusinessEntities;
@@ -127,7 +128,7 @@ public class SettingGroupService : AuthenticatedService, ISettingGroupService
             {
                 await _settingGroupRepository.DeleteGroup(entity);
                 _logger.LogInformation("Deleted empty setting group '{GroupName}' after removing client '{ClientName}'",
-                    entity.Name, clientName);
+                    entity.Name.Sanitize(), clientName.Sanitize());
             }
             else
             {
@@ -136,7 +137,7 @@ public class SettingGroupService : AuthenticatedService, ISettingGroupService
                 entity.LastModifiedBy = "System";
                 await _settingGroupRepository.UpdateGroup(entity);
                 _logger.LogInformation("Removed client '{ClientName}' references from setting group '{GroupName}'",
-                    clientName, entity.Name);
+                    clientName.Sanitize(), entity.Name.Sanitize());
             }
         }
     }
@@ -222,7 +223,7 @@ public class SettingGroupService : AuthenticatedService, ISettingGroupService
                 throw new ArgumentException("Grouped setting name cannot be empty.");
 
             if (gs.SourceSettings == null || gs.SourceSettings.Count == 0)
-                continue;
+                throw new ArgumentException($"Grouped setting '{gs.Name}' must contain at least one source setting.");
 
             // All source settings must specify client and setting name
             foreach (var ss in gs.SourceSettings)

--- a/src/api/Fig.Api/Services/SettingsService.cs
+++ b/src/api/Fig.Api/Services/SettingsService.cs
@@ -226,8 +226,8 @@ public class SettingsService : AuthenticatedService, ISettingsService
             await _eventLogRepository.Add(_eventLogFactory.ClientDeleted(client.Id, clientName, instance, AuthenticatedUser));
             await _settingChangeRepository.RegisterChange();
 
-            // Only remove from groups when deleting the base client (not an instance override)
-            if (instance == null)
+            var remaining = await _settingClientRepository.GetAllInstancesOfClient(clientName);
+            if (!remaining.Any())
                 await _settingGroupService.RemoveClientFromGroups(clientName);
 
             await _eventDistributor.PublishAsync(EventConstants.CheckPointTrigger,
@@ -637,10 +637,6 @@ public class SettingsService : AuthenticatedService, ISettingsService
         await _secretStoreHandler.SaveSecrets(clientBusinessEntity);
         
         await ApplyDeferredImport(clientBusinessEntity);
-        await _settingChangeRepository.RegisterChange();
-        await _eventDistributor.PublishAsync(EventConstants.CheckPointTrigger,
-            new CheckPointTrigger($"Initial Registration for client {clientBusinessEntity.Name}", AuthenticatedUser?.Username));
-        await _webHookDisseminationService.NewClientRegistration(clientBusinessEntity);
 
         var settingsWithGroups = clientBusinessEntity.Settings
             .Where(s => !string.IsNullOrWhiteSpace(s.Group))
@@ -651,6 +647,11 @@ public class SettingsService : AuthenticatedService, ISettingsService
         {
             await _settingGroupService.HandleInitialRegistrationGroups(clientBusinessEntity.Name, settingsWithGroups);
         }
+
+        await _settingChangeRepository.RegisterChange();
+        await _eventDistributor.PublishAsync(EventConstants.CheckPointTrigger,
+            new CheckPointTrigger($"Initial Registration for client {clientBusinessEntity.Name}", AuthenticatedUser?.Username));
+        await _webHookDisseminationService.NewClientRegistration(clientBusinessEntity);
     }
 
     private async Task ApplyDeferredImport(SettingClientBusinessEntity client)

--- a/src/api/Fig.Api/Services/SettingsService.cs
+++ b/src/api/Fig.Api/Services/SettingsService.cs
@@ -45,6 +45,7 @@ public class SettingsService : AuthenticatedService, ISettingsService
     private readonly IClientRegistrationLockService _clientRegistrationLockService;
     private readonly IRegistrationStatusValidator _registrationStatusValidator;
     private readonly IClientRegistrationHistoryService _clientRegistrationHistoryService;
+    private readonly ISettingGroupService _settingGroupService;
     private string? _requesterHostname;
     private string? _requestIpAddress;
 
@@ -68,7 +69,8 @@ public class SettingsService : AuthenticatedService, ISettingsService
         IDeferredChangeRepository deferredChangeRepository,
         IClientRegistrationLockService clientRegistrationLockService,
         IRegistrationStatusValidator registrationStatusValidator,
-        IClientRegistrationHistoryService clientRegistrationHistoryService)
+        IClientRegistrationHistoryService clientRegistrationHistoryService,
+        ISettingGroupService settingGroupService)
     {
         _logger = logger;
         _settingClientRepository = settingClientRepository;
@@ -91,6 +93,7 @@ public class SettingsService : AuthenticatedService, ISettingsService
         _clientRegistrationLockService = clientRegistrationLockService;
         _registrationStatusValidator = registrationStatusValidator;
         _clientRegistrationHistoryService = clientRegistrationHistoryService;
+        _settingGroupService = settingGroupService;
     }
 
     public async Task RegisterSettings(string clientSecret, SettingsClientDefinitionDataContract client)
@@ -222,6 +225,11 @@ public class SettingsService : AuthenticatedService, ISettingsService
             await _settingClientRepository.DeleteClient(client);
             await _eventLogRepository.Add(_eventLogFactory.ClientDeleted(client.Id, clientName, instance, AuthenticatedUser));
             await _settingChangeRepository.RegisterChange();
+
+            // Only remove from groups when deleting the base client (not an instance override)
+            if (instance == null)
+                await _settingGroupService.RemoveClientFromGroups(clientName);
+
             await _eventDistributor.PublishAsync(EventConstants.CheckPointTrigger,
                 new CheckPointTrigger($"Client {client.Name.Sanitize()} deleted", AuthenticatedUser?.Username));
         }
@@ -633,6 +641,16 @@ public class SettingsService : AuthenticatedService, ISettingsService
         await _eventDistributor.PublishAsync(EventConstants.CheckPointTrigger,
             new CheckPointTrigger($"Initial Registration for client {clientBusinessEntity.Name}", AuthenticatedUser?.Username));
         await _webHookDisseminationService.NewClientRegistration(clientBusinessEntity);
+
+        var settingsWithGroups = clientBusinessEntity.Settings
+            .Where(s => !string.IsNullOrWhiteSpace(s.Group))
+            .Select(s => (s.Name, s.Group!, s.ValueType?.FullName ?? "System.String"))
+            .ToList();
+
+        if (settingsWithGroups.Any())
+        {
+            await _settingGroupService.HandleInitialRegistrationGroups(clientBusinessEntity.Name, settingsWithGroups);
+        }
     }
 
     private async Task ApplyDeferredImport(SettingClientBusinessEntity client)

--- a/src/api/Fig.Api/Workers/SchedulingWorker.cs
+++ b/src/api/Fig.Api/Workers/SchedulingWorker.cs
@@ -34,11 +34,10 @@ public class SchedulingWorker : BackgroundService
 
     private async Task EvaluateDeferredChanges()
     {
-        // Create a new scope for each evaluation cycle
-        using var scope = _serviceScopeFactory.CreateScope();
-        
         try
         {
+            // Create a new scope for each evaluation cycle
+            using var scope = _serviceScopeFactory.CreateScope();
             // Get all required services within this scope
             var deferredChangeRepository = scope.ServiceProvider.GetRequiredService<IDeferredChangeRepository>();
 

--- a/src/api/Fig.Datalayer/BusinessEntities/SettingGroupBusinessEntity.cs
+++ b/src/api/Fig.Datalayer/BusinessEntities/SettingGroupBusinessEntity.cs
@@ -1,0 +1,21 @@
+using Newtonsoft.Json;
+
+namespace Fig.Datalayer.BusinessEntities;
+
+// ReSharper disable once ClassWithVirtualMembersNeverInherited.Global required by nhibernate.
+public class SettingGroupBusinessEntity
+{
+    public virtual Guid? Id { get; init; }
+
+    public virtual string Name { get; set; } = default!;
+
+    public virtual string? Description { get; set; }
+
+    public virtual string GroupSettingsJson { get; set; } = "[]";
+
+    public virtual DateTime CreatedAt { get; set; }
+
+    public virtual DateTime LastModifiedAt { get; set; }
+
+    public virtual string? LastModifiedBy { get; set; }
+}

--- a/src/api/Fig.Datalayer/Constants/Mapping.cs
+++ b/src/api/Fig.Datalayer/Constants/Mapping.cs
@@ -25,4 +25,6 @@ public static class Mapping
     public static readonly string CustomActionExecutionsTable = "custom_action_executions";
     public static readonly string DatabaseMigrationsTable = "database_migrations";
     public static readonly string ClientRegistrationHistoryTable = "client_registration_history";
+
+    public static readonly string SettingGroupsTable = "setting_groups";
 }

--- a/src/api/Fig.Datalayer/Mappings/SettingGroupMap.cs
+++ b/src/api/Fig.Datalayer/Mappings/SettingGroupMap.cs
@@ -1,0 +1,43 @@
+using Fig.Datalayer.BusinessEntities;
+using Fig.Datalayer.Constants;
+using NHibernate;
+using NHibernate.Mapping.ByCode;
+using NHibernate.Mapping.ByCode.Conformist;
+
+namespace Fig.Datalayer.Mappings;
+
+public class SettingGroupMap : ClassMapping<SettingGroupBusinessEntity>
+{
+    public SettingGroupMap()
+    {
+        Table(Mapping.SettingGroupsTable);
+        Lazy(false);
+        Id(x => x.Id, m => m.Generator(Generators.GuidComb));
+        Property(x => x.Name, x =>
+        {
+            x.Column("name");
+            x.UniqueKey("ux_setting_groups_name");
+        });
+        Property(x => x.Description, x =>
+        {
+            x.Column("description");
+            x.Type(NHibernateUtil.StringClob);
+        });
+        Property(x => x.GroupSettingsJson, x =>
+        {
+            x.Column("group_settings_json");
+            x.Type(NHibernateUtil.StringClob);
+        });
+        Property(x => x.CreatedAt, x =>
+        {
+            x.Column("created_at");
+            x.Type(NHibernateUtil.UtcTicks);
+        });
+        Property(x => x.LastModifiedAt, x =>
+        {
+            x.Column("last_modified_at");
+            x.Type(NHibernateUtil.UtcTicks);
+        });
+        Property(x => x.LastModifiedBy, x => x.Column("last_modified_by"));
+    }
+}

--- a/src/common/Fig.Common/Constants/EventMessage.cs
+++ b/src/common/Fig.Common/Constants/EventMessage.cs
@@ -44,6 +44,11 @@ public static class EventMessage
     public const string CustomActionExecutionRequested = "Custom Action Execution Requested";
     public const string CustomActionExecutionCompleted = "Custom Action Execution Completed";
     public const string InvalidClientSecretAttempt = "Invalid Client Secret Attempt";
+    public const string GroupCreated = "Setting Group Created";
+    public const string GroupUpdated = "Setting Group Updated";
+    public const string GroupDeleted = "Setting Group Deleted";
+    public const string GroupSettingAdded = "Setting Added to Group";
+    public const string GroupSettingRemoved = "Setting Removed from Group";
 
     public static readonly List<string> UnrestrictedEvents =
     [
@@ -66,6 +71,11 @@ public static class EventMessage
         ConfigurationChanged,
         WebHookSent,
         ClientSecretChanged,
-        HealthStatusChanged
+        HealthStatusChanged,
+        GroupCreated,
+        GroupUpdated,
+        GroupDeleted,
+        GroupSettingAdded,
+        GroupSettingRemoved
     ];
 }

--- a/src/common/Fig.Contracts/SettingGroups/GroupedSettingDataContract.cs
+++ b/src/common/Fig.Contracts/SettingGroups/GroupedSettingDataContract.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+
+namespace Fig.Contracts.SettingGroups
+{
+    public class GroupedSettingDataContract
+    {
+        public GroupedSettingDataContract(string name, string? description, string valueType, List<SourceSettingDataContract> sourceSettings)
+        {
+            Name = name;
+            Description = description;
+            ValueType = valueType;
+            SourceSettings = sourceSettings;
+        }
+
+        public string Name { get; set; }
+
+        public string? Description { get; set; }
+
+        public string ValueType { get; set; }
+
+        public List<SourceSettingDataContract> SourceSettings { get; set; }
+    }
+}

--- a/src/common/Fig.Contracts/SettingGroups/GroupedSettingDataContract.cs
+++ b/src/common/Fig.Contracts/SettingGroups/GroupedSettingDataContract.cs
@@ -18,6 +18,10 @@ namespace Fig.Contracts.SettingGroups
 
         public string ValueType { get; set; }
 
+        public string? CategoryName { get; set; }
+
+        public string? CategoryColor { get; set; }
+
         public List<SourceSettingDataContract> SourceSettings { get; set; }
     }
 }

--- a/src/common/Fig.Contracts/SettingGroups/SettingGroupDataContract.cs
+++ b/src/common/Fig.Contracts/SettingGroups/SettingGroupDataContract.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+
+namespace Fig.Contracts.SettingGroups
+{
+    public class SettingGroupDataContract
+    {
+        public SettingGroupDataContract(Guid? id, string name, string? description, List<GroupedSettingDataContract> groupedSettings)
+        {
+            Id = id;
+            Name = name;
+            Description = description;
+            GroupedSettings = groupedSettings;
+        }
+
+        public Guid? Id { get; set; }
+
+        public string Name { get; set; }
+
+        public string? Description { get; set; }
+
+        public List<GroupedSettingDataContract> GroupedSettings { get; set; }
+
+        public DateTime CreatedAt { get; set; }
+
+        public DateTime LastModifiedAt { get; set; }
+
+        public string? LastModifiedBy { get; set; }
+    }
+}

--- a/src/common/Fig.Contracts/SettingGroups/SettingGroupExportDataContract.cs
+++ b/src/common/Fig.Contracts/SettingGroups/SettingGroupExportDataContract.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+
+namespace Fig.Contracts.SettingGroups
+{
+    public class SettingGroupExportDataContract
+    {
+        public SettingGroupExportDataContract(DateTime exportedAt, int version, List<SettingGroupDataContract> groups)
+        {
+            ExportedAt = exportedAt;
+            Version = version;
+            Groups = groups;
+        }
+
+        public DateTime ExportedAt { get; set; }
+
+        public int Version { get; set; }
+
+        public List<SettingGroupDataContract> Groups { get; set; }
+    }
+}

--- a/src/common/Fig.Contracts/SettingGroups/SourceSettingDataContract.cs
+++ b/src/common/Fig.Contracts/SettingGroups/SourceSettingDataContract.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Fig.Contracts.SettingGroups
+{
+    public class SourceSettingDataContract
+    {
+        public SourceSettingDataContract(string clientName, string settingName)
+        {
+            ClientName = clientName;
+            SettingName = settingName;
+        }
+
+        public string ClientName { get; set; }
+
+        public string SettingName { get; set; }
+    }
+}

--- a/src/tests/Fig.Integration.Test/Api/SchedulingTests.cs
+++ b/src/tests/Fig.Integration.Test/Api/SchedulingTests.cs
@@ -12,10 +12,10 @@ using NUnit.Framework;
 
 namespace Fig.Integration.Test.Api;
 
-// Scheduling tests use a shared fig.db and create pending deferred changes that must survive
-// until the SchedulingWorker applies them. Running in parallel with other fixtures risks those
-// fixtures' SetUp/TearDown calling DeleteAllScheduledChanges() against the shared DB and deleting
-// the pending change before it can be applied. NonParallelizable prevents that race.
+// Each test fixture creates its own isolated DB, so cross-fixture interference from
+// DeleteAllScheduledChanges() is no longer a concern. NonParallelizable ensures that
+// the tests within this fixture do not run concurrently with each other, preserving
+// the integrity of timing-sensitive scheduled change assertions.
 [TestFixture]
 [NonParallelizable]
 public class SchedulingTests : IntegrationTestBase

--- a/src/tests/Fig.Integration.Test/Api/SchedulingTests.cs
+++ b/src/tests/Fig.Integration.Test/Api/SchedulingTests.cs
@@ -373,8 +373,8 @@ public class SchedulingTests : IntegrationTestBase
         var settings = await RegisterSettings<ThreeSettings>(secret);
         const string newValue = "Temporary scheduled value";
         var originalValue = settings.AStringSetting;
-        var applyAt = DateTime.UtcNow.AddSeconds(2);
-        var revertAt = DateTime.UtcNow.AddSeconds(4);
+        var applyAt = DateTime.UtcNow.AddSeconds(4); // Increased from 2s for CI stability
+        var revertAt = DateTime.UtcNow.AddSeconds(8); // Increased from 4s for CI stability
         
         var settingsToUpdate = new List<SettingDataContract>
         {
@@ -405,7 +405,7 @@ public class SchedulingTests : IntegrationTestBase
                 value2 = await GetCurrentSettingValue();
                 return value2 == newValue;
             },
-            TimeSpan.FromSeconds(5), 
+            TimeSpan.FromSeconds(10), // Increased from 5s for CI stability
             () => $"New value ({newValue}) should have been applied but had {value2} instead");
         
         Assert.That(value2, Is.EqualTo(newValue));
@@ -417,7 +417,7 @@ public class SchedulingTests : IntegrationTestBase
                 value3 = await GetCurrentSettingValue();
                 return value3 == originalValue;
             },
-            TimeSpan.FromSeconds(5),
+            TimeSpan.FromSeconds(10), // Increased from 5s for CI stability
             () => $"Original value ({originalValue}) should have been applied but had {value3} instead");
 
         Assert.That(value3, Is.EqualTo(originalValue));

--- a/src/tests/Fig.Integration.Test/Api/SchedulingTests.cs
+++ b/src/tests/Fig.Integration.Test/Api/SchedulingTests.cs
@@ -373,13 +373,18 @@ public class SchedulingTests : IntegrationTestBase
         var settings = await RegisterSettings<ThreeSettings>(secret);
         const string newValue = "Temporary scheduled value";
         var originalValue = settings.AStringSetting;
-        var applyAt = DateTime.UtcNow.AddSeconds(4); // Increased from 2s for CI stability
-        var revertAt = DateTime.UtcNow.AddSeconds(8); // Increased from 4s for CI stability
         
         var settingsToUpdate = new List<SettingDataContract>
         {
             new(nameof(settings.AStringSetting), new StringSettingDataContract(newValue))
         };
+
+        // Capture timestamps immediately before the API call so slow CI setup
+        // (RegisterSettings etc.) does not eat into the apply window.
+        // revertAt is computed relative to applyAt to guarantee a fixed-size
+        // detection window between apply and revert.
+        var applyAt = DateTime.UtcNow.AddSeconds(8);
+        var revertAt = applyAt.AddSeconds(10);
 
         // Act - Schedule a change with revert
         var result = await SetSettings(settings.ClientName, settingsToUpdate, applyAt: applyAt, revertAt: revertAt);
@@ -397,7 +402,6 @@ public class SchedulingTests : IntegrationTestBase
         var value = await GetCurrentSettingValue();
         Assert.That(value, Is.EqualTo(originalValue));
 
-
         string? value2 = null;
         await WaitForCondition(
             async () =>
@@ -405,7 +409,7 @@ public class SchedulingTests : IntegrationTestBase
                 value2 = await GetCurrentSettingValue();
                 return value2 == newValue;
             },
-            TimeSpan.FromSeconds(10), // Increased from 5s for CI stability
+            TimeSpan.FromSeconds(20),
             () => $"New value ({newValue}) should have been applied but had {value2} instead");
         
         Assert.That(value2, Is.EqualTo(newValue));
@@ -417,7 +421,7 @@ public class SchedulingTests : IntegrationTestBase
                 value3 = await GetCurrentSettingValue();
                 return value3 == originalValue;
             },
-            TimeSpan.FromSeconds(10), // Increased from 5s for CI stability
+            TimeSpan.FromSeconds(25),
             () => $"Original value ({originalValue}) should have been applied but had {value3} instead");
 
         Assert.That(value3, Is.EqualTo(originalValue));

--- a/src/tests/Fig.Integration.Test/Api/SchedulingTests.cs
+++ b/src/tests/Fig.Integration.Test/Api/SchedulingTests.cs
@@ -12,7 +12,12 @@ using NUnit.Framework;
 
 namespace Fig.Integration.Test.Api;
 
+// Scheduling tests use a shared fig.db and create pending deferred changes that must survive
+// until the SchedulingWorker applies them. Running in parallel with other fixtures risks those
+// fixtures' SetUp/TearDown calling DeleteAllScheduledChanges() against the shared DB and deleting
+// the pending change before it can be applied. NonParallelizable prevents that race.
 [TestFixture]
+[NonParallelizable]
 public class SchedulingTests : IntegrationTestBase
 {
     [Test]

--- a/src/tests/Fig.Integration.Test/Api/SchedulingTests.cs
+++ b/src/tests/Fig.Integration.Test/Api/SchedulingTests.cs
@@ -373,26 +373,28 @@ public class SchedulingTests : IntegrationTestBase
     [Test]
     public async Task ShallScheduleChangesWithRevertAndDelayedApply()
     {
+        await SetConfiguration(CreateConfiguration(pollIntervalOverrideMs: 1000));
+
         // Arrange
         var secret = GetNewSecret();
-        var settings = await RegisterSettings<ThreeSettings>(secret);
+        var (settings, _) = InitializeConfigurationProvider<ThreeSettings>(secret);
         const string newValue = "Temporary scheduled value";
-        var originalValue = settings.AStringSetting;
+        var originalValue = settings.CurrentValue.AStringSetting;
         
         var settingsToUpdate = new List<SettingDataContract>
         {
-            new(nameof(settings.AStringSetting), new StringSettingDataContract(newValue))
+            new(nameof(settings.CurrentValue.AStringSetting), new StringSettingDataContract(newValue))
         };
 
         // Capture timestamps immediately before the API call so slow CI setup
         // (RegisterSettings etc.) does not eat into the apply window.
         // revertAt is computed relative to applyAt to guarantee a fixed-size
         // detection window between apply and revert.
-        var applyAt = DateTime.UtcNow.AddSeconds(8);
-        var revertAt = applyAt.AddSeconds(10);
+        var applyAt = DateTime.UtcNow.AddSeconds(2);
+        var revertAt = applyAt.AddSeconds(2);
 
         // Act - Schedule a change with revert
-        var result = await SetSettings(settings.ClientName, settingsToUpdate, applyAt: applyAt, revertAt: revertAt);
+        var result = await SetSettings(settings.CurrentValue.ClientName, settingsToUpdate, applyAt: applyAt, revertAt: revertAt);
         
         // Assert - Verify the change and revert were scheduled
         Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.OK));
@@ -402,40 +404,22 @@ public class SchedulingTests : IntegrationTestBase
         
         var applyChange = scheduledChanges.Changes.First(c => c.ExecuteAtUtc == applyAt);
         
-        Assert.That(applyChange.ClientName, Is.EqualTo(settings.ClientName));
-        
-        var value = await GetCurrentSettingValue();
-        Assert.That(value, Is.EqualTo(originalValue));
+        Assert.That(applyChange.ClientName, Is.EqualTo(settings.CurrentValue.ClientName));
+        Assert.That(settings.CurrentValue.AStringSetting, Is.EqualTo(originalValue));
 
-        string? value2 = null;
         await WaitForCondition(
-            async () =>
-            {
-                value2 = await GetCurrentSettingValue();
-                return value2 == newValue;
-            },
+            () => Task.FromResult(settings.CurrentValue.AStringSetting == newValue),
             TimeSpan.FromSeconds(20),
-            () => $"New value ({newValue}) should have been applied but had {value2} instead");
+            () => $"New value ({newValue}) should have been applied but had {settings.CurrentValue.AStringSetting} instead");
         
-        Assert.That(value2, Is.EqualTo(newValue));
+        Assert.That(settings.CurrentValue.AStringSetting, Is.EqualTo(newValue));
 
-        string? value3 = null;
         await WaitForCondition(
-            async () =>
-            {
-                value3 = await GetCurrentSettingValue();
-                return value3 == originalValue;
-            },
+            () => Task.FromResult(settings.CurrentValue.AStringSetting == originalValue),
             TimeSpan.FromSeconds(25),
-            () => $"Original value ({originalValue}) should have been applied but had {value3} instead");
+            () => $"Original value ({originalValue}) should have been applied but had {settings.CurrentValue.AStringSetting} instead");
 
-        Assert.That(value3, Is.EqualTo(originalValue));
-        
-        async Task<string?> GetCurrentSettingValue()
-        {
-            var currentSettings = await GetSettingsForClient(settings.ClientName, secret);
-            return currentSettings.First(a => a.Name == nameof(settings.AStringSetting)).Value!.GetValue()?.ToString();
-        }
+        Assert.That(settings.CurrentValue.AStringSetting, Is.EqualTo(originalValue));
     }
 
     [Test]

--- a/src/tests/Fig.Integration.Test/Api/SettingGroupTests.cs
+++ b/src/tests/Fig.Integration.Test/Api/SettingGroupTests.cs
@@ -1,0 +1,331 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Fig.Common.Constants;
+using Fig.Contracts.EventHistory;
+using Fig.Contracts.ImportExport;
+using Fig.Contracts.SettingGroups;
+using Fig.Integration.Test.Utils;
+using Fig.Test.Common;
+using NUnit.Framework;
+
+namespace Fig.Integration.Test.Api;
+
+[TestFixture]
+public class SettingGroupTests : IntegrationTestBase
+{
+    private SettingGroupDataContract CreateTestGroup(string name, string? description = null)
+    {
+        return new SettingGroupDataContract(
+            null,
+            name,
+            description,
+            new List<GroupedSettingDataContract>());
+    }
+
+    private SettingGroupDataContract CreateTestGroupWithSettings(string name, string? description = null)
+    {
+        return new SettingGroupDataContract(
+            null,
+            name,
+            description,
+            new List<GroupedSettingDataContract>
+            {
+                new("ConnectionString", "Database connection", "String",
+                    new List<SourceSettingDataContract>
+                    {
+                        new("ServiceA", "ConnectionString"),
+                        new("ServiceB", "ConnectionString")
+                    }),
+                new("MaxRetries", "Max retry count", "Int",
+                    new List<SourceSettingDataContract>
+                    {
+                        new("ServiceA", "MaxRetries")
+                    })
+            });
+    }
+
+    [Test]
+    public async Task ShallCreateSettingGroup()
+    {
+        var group = CreateTestGroup("DatabaseSettings", "All database related settings");
+
+        var result = await CreateSettingGroup(group);
+
+        Assert.That(result.Id, Is.Not.Null);
+        Assert.That(result.Name, Is.EqualTo("DatabaseSettings"));
+        Assert.That(result.Description, Is.EqualTo("All database related settings"));
+        Assert.That(result.CreatedAt, Is.GreaterThan(DateTime.UtcNow.Subtract(TimeSpan.FromSeconds(5))));
+        Assert.That(result.LastModifiedAt, Is.GreaterThan(DateTime.UtcNow.Subtract(TimeSpan.FromSeconds(5))));
+    }
+
+    [Test]
+    public async Task ShallCreateSettingGroupWithGroupedSettings()
+    {
+        var group = CreateTestGroupWithSettings("DatabaseSettings", "DB settings");
+
+        var result = await CreateSettingGroup(group);
+
+        Assert.That(result.Id, Is.Not.Null);
+        Assert.That(result.Name, Is.EqualTo("DatabaseSettings"));
+        Assert.That(result.GroupedSettings.Count, Is.EqualTo(2));
+        Assert.That(result.GroupedSettings[0].Name, Is.EqualTo("ConnectionString"));
+        Assert.That(result.GroupedSettings[0].SourceSettings.Count, Is.EqualTo(2));
+        Assert.That(result.GroupedSettings[1].Name, Is.EqualTo("MaxRetries"));
+    }
+
+    [Test]
+    public async Task ShallGetAllSettingGroups()
+    {
+        var group1 = CreateTestGroup("Group1", "First group");
+        var group2 = CreateTestGroup("Group2", "Second group");
+
+        await CreateSettingGroup(group1);
+        await CreateSettingGroup(group2);
+
+        var allGroups = await GetAllSettingGroups();
+
+        Assert.That(allGroups.Count, Is.EqualTo(2));
+        Assert.That(allGroups[0].Name, Is.EqualTo("Group1"));
+        Assert.That(allGroups[1].Name, Is.EqualTo("Group2"));
+    }
+
+    [Test]
+    public async Task ShallGetSingleSettingGroupById()
+    {
+        var group = CreateTestGroupWithSettings("TestGroup", "Test description");
+        var created = await CreateSettingGroup(group);
+
+        var result = await GetSettingGroup(created.Id!.Value);
+
+        Assert.That(result.Id, Is.EqualTo(created.Id));
+        Assert.That(result.Name, Is.EqualTo("TestGroup"));
+        Assert.That(result.Description, Is.EqualTo("Test description"));
+        Assert.That(result.GroupedSettings.Count, Is.EqualTo(2));
+    }
+
+    [Test]
+    public async Task ShallUpdateSettingGroupNameAndDescription()
+    {
+        var group = CreateTestGroup("OriginalName", "Original description");
+        var created = await CreateSettingGroup(group);
+
+        var updated = new SettingGroupDataContract(
+            created.Id,
+            "UpdatedName",
+            "Updated description",
+            created.GroupedSettings);
+
+        var result = await UpdateSettingGroup(created.Id!.Value, updated);
+
+        Assert.That(result.Name, Is.EqualTo("UpdatedName"));
+        Assert.That(result.Description, Is.EqualTo("Updated description"));
+
+        var fetched = await GetSettingGroup(created.Id!.Value);
+        Assert.That(fetched.Name, Is.EqualTo("UpdatedName"));
+        Assert.That(fetched.Description, Is.EqualTo("Updated description"));
+    }
+
+    [Test]
+    public async Task ShallDeleteSettingGroup()
+    {
+        var group1 = CreateTestGroup("ToKeep");
+        var group2 = CreateTestGroup("ToDelete");
+
+        await CreateSettingGroup(group1);
+        var created2 = await CreateSettingGroup(group2);
+
+        await DeleteSettingGroup(created2.Id!.Value);
+
+        var allGroups = await GetAllSettingGroups();
+        Assert.That(allGroups.Count, Is.EqualTo(1));
+        Assert.That(allGroups[0].Name, Is.EqualTo("ToKeep"));
+    }
+
+    [Test]
+    public async Task ShallReturnBadRequestForDuplicateGroupName()
+    {
+        var group = CreateTestGroup("DuplicateName");
+        await CreateSettingGroup(group);
+
+        var duplicate = CreateTestGroup("DuplicateName");
+        var response = await CreateSettingGroupRaw(duplicate);
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
+    }
+
+    [Test]
+    public async Task ShallReturnErrorForEmptyGroupName()
+    {
+        var group = CreateTestGroup("");
+
+        var response = await CreateSettingGroupRaw(group);
+
+        Assert.That(response.IsSuccessStatusCode, Is.False);
+    }
+
+    [Test]
+    public async Task ShallReturnNotFoundForNonExistentGroup()
+    {
+        var nonExistentId = Guid.NewGuid();
+
+        await ApiClient.GetAndVerify($"/settinggroups/{nonExistentId}", HttpStatusCode.NotFound);
+    }
+
+    [Test]
+    public async Task ShallExportSettingGroups()
+    {
+        var group1 = CreateTestGroupWithSettings("ExportGroup1", "First export group");
+        var group2 = CreateTestGroup("ExportGroup2", "Second export group");
+
+        await CreateSettingGroup(group1);
+        await CreateSettingGroup(group2);
+
+        var exported = await ExportSettingGroups();
+
+        Assert.That(exported.ExportedAt, Is.GreaterThan(DateTime.UtcNow.Subtract(TimeSpan.FromSeconds(5))));
+        Assert.That(exported.Version, Is.EqualTo(1));
+        Assert.That(exported.Groups.Count, Is.EqualTo(2));
+        Assert.That(exported.Groups[0].Name, Is.EqualTo("ExportGroup1"));
+        Assert.That(exported.Groups[0].GroupedSettings.Count, Is.EqualTo(2));
+        Assert.That(exported.Groups[1].Name, Is.EqualTo("ExportGroup2"));
+    }
+
+    [Test]
+    public async Task ShallImportSettingGroupsWithAddNew()
+    {
+        var existingGroup = CreateTestGroup("ExistingGroup", "Already exists");
+        await CreateSettingGroup(existingGroup);
+
+        var importData = new SettingGroupExportDataContract(
+            DateTime.UtcNow,
+            1,
+            new List<SettingGroupDataContract>
+            {
+                CreateTestGroup("ExistingGroup", "Should be ignored"),
+                CreateTestGroup("NewGroup", "Should be imported")
+            });
+
+        var result = await ImportSettingGroups(importData, ImportType.AddNew);
+
+        Assert.That(result.ErrorMessage, Is.Null);
+
+        var allGroups = await GetAllSettingGroups();
+        Assert.That(allGroups.Count, Is.EqualTo(2));
+        // ExistingGroup retains original description (not overwritten by AddNew)
+        var existing = allGroups.First(g => g.Name == "ExistingGroup");
+        Assert.That(existing.Description, Is.EqualTo("Already exists"));
+        // NewGroup was imported
+        Assert.That(allGroups.Any(g => g.Name == "NewGroup"), Is.True);
+    }
+
+    [Test]
+    public async Task ShallImportSettingGroupsWithClearAndImport()
+    {
+        var existingGroup = CreateTestGroup("OldGroup", "Will be deleted");
+        await CreateSettingGroup(existingGroup);
+
+        var importData = new SettingGroupExportDataContract(
+            DateTime.UtcNow,
+            1,
+            new List<SettingGroupDataContract>
+            {
+                CreateTestGroup("FreshGroup1", "Imported fresh"),
+                CreateTestGroup("FreshGroup2", "Also imported fresh")
+            });
+
+        var result = await ImportSettingGroups(importData, ImportType.ClearAndImport);
+
+        Assert.That(result.ErrorMessage, Is.Null);
+
+        var allGroups = await GetAllSettingGroups();
+        Assert.That(allGroups.Count, Is.EqualTo(2));
+        Assert.That(allGroups.Any(g => g.Name == "OldGroup"), Is.False);
+        Assert.That(allGroups.Any(g => g.Name == "FreshGroup1"), Is.True);
+        Assert.That(allGroups.Any(g => g.Name == "FreshGroup2"), Is.True);
+    }
+
+    [Test]
+    public async Task ShallLogEventWhenGroupCreated()
+    {
+        var startTime = DateTime.UtcNow;
+
+        var group = CreateTestGroup("EventTestGroup");
+        await CreateSettingGroup(group);
+
+        var endTime = DateTime.UtcNow;
+        var events = await GetEvents(startTime, endTime);
+        var nonCheckPointEvents = events.Events.RemoveCheckPointEvents();
+
+        Assert.That(nonCheckPointEvents.Any(e => e.EventType == EventMessage.GroupCreated), Is.True);
+    }
+
+    [Test]
+    public async Task ShallLogEventWhenGroupUpdated()
+    {
+        var group = CreateTestGroup("UpdateEventGroup");
+        var created = await CreateSettingGroup(group);
+
+        var startTime = DateTime.UtcNow;
+
+        var updated = new SettingGroupDataContract(
+            created.Id,
+            "UpdatedEventGroup",
+            "Updated",
+            created.GroupedSettings);
+        await UpdateSettingGroup(created.Id!.Value, updated);
+
+        var endTime = DateTime.UtcNow;
+        var events = await GetEvents(startTime, endTime);
+        var nonCheckPointEvents = events.Events.RemoveCheckPointEvents();
+
+        Assert.That(nonCheckPointEvents.Any(e => e.EventType == EventMessage.GroupUpdated), Is.True);
+    }
+
+    [Test]
+    public async Task ShallLogEventWhenGroupDeleted()
+    {
+        var group = CreateTestGroup("DeleteEventGroup");
+        var created = await CreateSettingGroup(group);
+
+        var startTime = DateTime.UtcNow;
+        await DeleteSettingGroup(created.Id!.Value);
+        var endTime = DateTime.UtcNow;
+
+        var events = await GetEvents(startTime, endTime);
+        var nonCheckPointEvents = events.Events.RemoveCheckPointEvents();
+
+        Assert.That(nonCheckPointEvents.Any(e => e.EventType == EventMessage.GroupDeleted), Is.True);
+    }
+
+    [Test]
+    public async Task ShallReturnEmptyListWhenNoGroupsExist()
+    {
+        var allGroups = await GetAllSettingGroups();
+
+        Assert.That(allGroups, Is.Empty);
+    }
+
+    [Test]
+    public async Task ShallRoundTripExportAndImportGroups()
+    {
+        var group = CreateTestGroupWithSettings("RoundTripGroup", "Round trip test");
+        await CreateSettingGroup(group);
+
+        var exported = await ExportSettingGroups();
+
+        await DeleteAllSettingGroups();
+        var afterDelete = await GetAllSettingGroups();
+        Assert.That(afterDelete, Is.Empty);
+
+        await ImportSettingGroups(exported, ImportType.AddNew);
+
+        var afterImport = await GetAllSettingGroups();
+        Assert.That(afterImport.Count, Is.EqualTo(1));
+        Assert.That(afterImport[0].Name, Is.EqualTo("RoundTripGroup"));
+        Assert.That(afterImport[0].Description, Is.EqualTo("Round trip test"));
+        Assert.That(afterImport[0].GroupedSettings.Count, Is.EqualTo(2));
+    }
+}

--- a/src/tests/Fig.Integration.Test/Api/SettingGroupTests.cs
+++ b/src/tests/Fig.Integration.Test/Api/SettingGroupTests.cs
@@ -328,4 +328,50 @@ public class SettingGroupTests : IntegrationTestBase
         Assert.That(afterImport[0].Description, Is.EqualTo("Round trip test"));
         Assert.That(afterImport[0].GroupedSettings.Count, Is.EqualTo(2));
     }
+
+    [Test]
+    public async Task ShallPreserveSourceSettingOrderWhenGroupIsUpdated()
+    {
+        var group = new SettingGroupDataContract(
+            null,
+            "OrderedGroup",
+            "Order test",
+            new List<GroupedSettingDataContract>
+            {
+                new("Timeout", null, "System.String",
+                    new List<SourceSettingDataContract>
+                    {
+                        new("ServiceA", "Timeout"),
+                        new("ServiceB", "Timeout"),
+                        new("ServiceC", "Timeout")
+                    })
+            });
+
+        var created = await CreateSettingGroup(group);
+        Assert.That(created.GroupedSettings[0].SourceSettings.Select(s => s.ClientName),
+            Is.EqualTo(new[] { "ServiceA", "ServiceB", "ServiceC" }));
+
+        var reorderedGroup = new SettingGroupDataContract(
+            created.Id,
+            created.Name,
+            created.Description,
+            new List<GroupedSettingDataContract>
+            {
+                new(created.GroupedSettings[0].Name, created.GroupedSettings[0].Description, created.GroupedSettings[0].ValueType,
+                    new List<SourceSettingDataContract>
+                    {
+                        new("ServiceC", "Timeout"),
+                        new("ServiceA", "Timeout"),
+                        new("ServiceB", "Timeout")
+                    })
+            });
+
+        var updated = await UpdateSettingGroup(created.Id!.Value, reorderedGroup);
+        Assert.That(updated.GroupedSettings[0].SourceSettings.Select(s => s.ClientName),
+            Is.EqualTo(new[] { "ServiceC", "ServiceA", "ServiceB" }));
+
+        var fetched = await GetSettingGroup(created.Id.Value);
+        Assert.That(fetched.GroupedSettings[0].SourceSettings.Select(s => s.ClientName),
+            Is.EqualTo(new[] { "ServiceC", "ServiceA", "ServiceB" }));
+    }
 }

--- a/src/tests/Fig.Integration.Test/Api/SettingGroupTests.cs
+++ b/src/tests/Fig.Integration.Test/Api/SettingGroupTests.cs
@@ -88,8 +88,7 @@ public class SettingGroupTests : IntegrationTestBase
         var allGroups = await GetAllSettingGroups();
 
         Assert.That(allGroups.Count, Is.EqualTo(2));
-        Assert.That(allGroups[0].Name, Is.EqualTo("Group1"));
-        Assert.That(allGroups[1].Name, Is.EqualTo("Group2"));
+        Assert.That(allGroups.Select(g => g.Name), Is.EquivalentTo(new[] { "Group1", "Group2" }));
     }
 
     [Test]
@@ -163,7 +162,7 @@ public class SettingGroupTests : IntegrationTestBase
 
         var response = await CreateSettingGroupRaw(group);
 
-        Assert.That(response.IsSuccessStatusCode, Is.False);
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
     }
 
     [Test]
@@ -188,9 +187,11 @@ public class SettingGroupTests : IntegrationTestBase
         Assert.That(exported.ExportedAt, Is.GreaterThan(DateTime.UtcNow.Subtract(TimeSpan.FromSeconds(5))));
         Assert.That(exported.Version, Is.EqualTo(1));
         Assert.That(exported.Groups.Count, Is.EqualTo(2));
-        Assert.That(exported.Groups[0].Name, Is.EqualTo("ExportGroup1"));
-        Assert.That(exported.Groups[0].GroupedSettings.Count, Is.EqualTo(2));
-        Assert.That(exported.Groups[1].Name, Is.EqualTo("ExportGroup2"));
+        var exportGroup1 = exported.Groups.FirstOrDefault(g => g.Name == "ExportGroup1");
+        var exportGroup2 = exported.Groups.FirstOrDefault(g => g.Name == "ExportGroup2");
+        Assert.That(exportGroup1, Is.Not.Null);
+        Assert.That(exportGroup1!.GroupedSettings.Count, Is.EqualTo(2));
+        Assert.That(exportGroup2, Is.Not.Null);
     }
 
     [Test]

--- a/src/tests/Fig.Test.Common/IntegrationTestBase.cs
+++ b/src/tests/Fig.Test.Common/IntegrationTestBase.cs
@@ -54,6 +54,7 @@ public abstract class IntegrationTestBase
     private WebApplicationFactory<FigWebHookAuthMiddleware> _webHookTestApp = null!;
     protected ApiClient ApiClient = null!;
     protected HttpClient WebHookClient = null!;
+    private string _dbFile = string.Empty;
 
     protected readonly ApiSettings Settings = new()
         { DbConnectionString = "Server=localhost;Database=Fig;Trusted_Connection=true;TrustServerCertificate=true;" };
@@ -67,7 +68,8 @@ public abstract class IntegrationTestBase
     [OneTimeSetUp]
     public async Task FixtureSetup()
     {
-        Settings.DbConnectionString = "Data Source=fig.db;Version=3;New=True";
+        _dbFile = $"fig_test_{Guid.NewGuid():N}.db";
+        Settings.DbConnectionString = $"Data Source={_dbFile};Version=3;New=True";
         Settings.Secret = "50b93c880cdf4041954da041386d54f9";
         Settings.TokenLifeMinutes = 60;
         Settings.SchedulingCheckIntervalMs = 547;
@@ -133,16 +135,16 @@ public abstract class IntegrationTestBase
         // Give SQLite a moment to release file locks
         Thread.Sleep(100);
         
-        if (File.Exists("fig.db"))
+        if (File.Exists(_dbFile))
         {
             try
             {
-                File.Delete("fig.db");
+                File.Delete(_dbFile);
             }
             catch (IOException ex)
             {
                 // Log the error but don't fail the test - the file will be cleaned up by the next run
-                Console.WriteLine($"Warning: Could not delete fig.db: {ex.Message}");
+                Console.WriteLine($"Warning: Could not delete {_dbFile}: {ex.Message}");
             }
         }
     }

--- a/src/tests/Fig.Test.Common/IntegrationTestBase.cs
+++ b/src/tests/Fig.Test.Common/IntegrationTestBase.cs
@@ -103,6 +103,15 @@ public abstract class IntegrationTestBase
                 services.AddScoped<ISecretStore>(a => SecretStoreMock.Object);
                 if (configuration is not null)
                     services.Configure<ApiSettings>(configuration.GetSection("ApiSettings"));
+                // PostConfigure runs after ALL Configure actions, guaranteeing these values
+                // regardless of how Program.cs standalone ConfigurationBuilder resolves them.
+                var schedulingMs = Settings.SchedulingCheckIntervalMs;
+                var timeMachineMs = Settings.TimeMachineCheckIntervalMs;
+                services.PostConfigure<ApiSettings>(opts =>
+                {
+                    opts.SchedulingCheckIntervalMs = schedulingMs;
+                    opts.TimeMachineCheckIntervalMs = timeMachineMs;
+                });
             });
         });
 

--- a/src/tests/Fig.Test.Common/IntegrationTestBase.cs
+++ b/src/tests/Fig.Test.Common/IntegrationTestBase.cs
@@ -24,6 +24,7 @@ using Fig.Contracts.Scheduling;
 using Fig.Contracts.SettingClients;
 using Fig.Contracts.SettingDefinitions;
 using Fig.Contracts.Settings;
+using Fig.Contracts.SettingGroups;
 using Fig.Contracts.Status;
 using Fig.Contracts.WebHook;
 using Fig.Datalayer.BusinessEntities;
@@ -148,6 +149,7 @@ public abstract class IntegrationTestBase
         await ResetConfiguration();
         await ResetUsers();
         await DeleteAllLookupTables();
+        await DeleteAllSettingGroups();
         await DeleteAllWebHooks();
         await DeleteAllWebHookClients();
         await DeleteAllScheduledChanges();
@@ -182,6 +184,7 @@ public abstract class IntegrationTestBase
         await ResetConfiguration();
         await ResetUsers();
         await DeleteAllLookupTables();
+        await DeleteAllSettingGroups();
         await DeleteAllWebHooks();
         await DeleteAllWebHookClients();
         await DeleteAllScheduledChanges();
@@ -899,6 +902,71 @@ public abstract class IntegrationTestBase
         var items = await GetAllLookupTables();
         foreach (var item in items)
             await DeleteLookupTable(item.Id);
+    }
+
+    protected async Task<SettingGroupDataContract> CreateSettingGroup(SettingGroupDataContract dataContract)
+    {
+        const string uri = "/settinggroups";
+        var response = await ApiClient.Post(uri, dataContract, authenticate: true);
+        var responseString = await response.Content.ReadAsStringAsync();
+        return JsonConvert.DeserializeObject<SettingGroupDataContract>(responseString, JsonSettings.FigDefault)
+            ?? throw new InvalidOperationException("Create setting group returned null");
+    }
+
+    protected async Task<HttpResponseMessage> CreateSettingGroupRaw(SettingGroupDataContract dataContract)
+    {
+        const string uri = "/settinggroups";
+        return await ApiClient.Post(uri, dataContract, authenticate: true, validateSuccess: false);
+    }
+
+    protected async Task<SettingGroupDataContract> UpdateSettingGroup(Guid id, SettingGroupDataContract dataContract)
+    {
+        var uri = $"/settinggroups/{id}";
+        var result = await ApiClient.Put<SettingGroupDataContract>(uri, dataContract);
+        return result ?? throw new InvalidOperationException("Update setting group returned null");
+    }
+
+    protected async Task<List<SettingGroupDataContract>> GetAllSettingGroups()
+    {
+        const string uri = "/settinggroups";
+        var result = await ApiClient.Get<IEnumerable<SettingGroupDataContract>>(uri);
+        return result?.ToList() ?? [];
+    }
+
+    protected async Task<SettingGroupDataContract> GetSettingGroup(Guid id)
+    {
+        var uri = $"/settinggroups/{id}";
+        var result = await ApiClient.Get<SettingGroupDataContract>(uri);
+        return result ?? throw new InvalidOperationException($"Get setting group {id} returned null");
+    }
+
+    protected async Task DeleteSettingGroup(Guid id)
+    {
+        var uri = $"/settinggroups/{id}";
+        await ApiClient.Delete(uri);
+    }
+
+    protected async Task DeleteAllSettingGroups()
+    {
+        var items = await GetAllSettingGroups();
+        foreach (var item in items)
+            if (item.Id.HasValue)
+                await DeleteSettingGroup(item.Id.Value);
+    }
+
+    protected async Task<SettingGroupExportDataContract> ExportSettingGroups()
+    {
+        const string uri = "/settinggroupdata";
+        var result = await ApiClient.Get<SettingGroupExportDataContract>(uri);
+        return result ?? throw new InvalidOperationException("Export setting groups returned null");
+    }
+
+    protected async Task<ImportResultDataContract> ImportSettingGroups(
+        SettingGroupExportDataContract data, ImportType importType = ImportType.AddNew)
+    {
+        var uri = $"/settinggroupdata?importType={importType}";
+        var result = await ApiClient.Put<ImportResultDataContract>(uri, data);
+        return result ?? throw new InvalidOperationException("Import setting groups returned null");
     }
 
     protected StatusRequestDataContract CreateStatusRequest(DateTime startTime, DateTime lastUpdate,

--- a/src/tests/Fig.Unit.Test/Web/SettingClientFacadeApplyCompareValueTests.cs
+++ b/src/tests/Fig.Unit.Test/Web/SettingClientFacadeApplyCompareValueTests.cs
@@ -6,7 +6,6 @@ using Fig.Common.Events;
 using Fig.Common.NetStandard.Scripting;
 using Fig.Contracts.SettingDefinitions;
 using Fig.Contracts.Settings;
-using Fig.Web.Builders;
 using Fig.Web.Converters;
 using Fig.Web.Events;
 using Fig.Web.Facades;
@@ -15,6 +14,7 @@ using Fig.Web.Models.Setting.ConfigurationModels;
 using Fig.Web.Models.Setting.ConfigurationModels.DataGrid;
 using Fig.Web.Notifications;
 using Fig.Web.Services;
+using Microsoft.Extensions.Options;
 using Moq;
 using NUnit.Framework;
 using Radzen;
@@ -34,7 +34,8 @@ public class SettingClientFacadeApplyCompareValueTests
         var httpService = new Mock<IHttpService>();
         var definitionConverter = new Mock<ISettingsDefinitionConverter>();
         var historyConverter = new Mock<ISettingHistoryConverter>();
-        var groupBuilder = new Mock<ISettingGroupBuilder>();
+        var scriptRunner = new Mock<IScriptRunner>();
+        var webSettings = Microsoft.Extensions.Options.Options.Create(new Fig.Web.WebSettings());
         var notificationService = new NotificationService();
         var notificationFactory = new Mock<INotificationFactory>();
         var clientStatusFacade = new Mock<IClientStatusFacade>();
@@ -46,7 +47,8 @@ public class SettingClientFacadeApplyCompareValueTests
             httpService.Object,
             definitionConverter.Object,
             historyConverter.Object,
-            groupBuilder.Object,
+            scriptRunner.Object,
+            webSettings,
             notificationService,
             notificationFactory.Object,
             clientStatusFacade.Object,
@@ -54,8 +56,8 @@ public class SettingClientFacadeApplyCompareValueTests
             apiVersionFacade.Object,
             schedulingFacade.Object);
 
-        var scriptRunner = Mock.Of<IScriptRunner>();
-        _client = new SettingClientConfigurationModel("TestClient", "Test", null, false, scriptRunner);
+        var scriptRunnerForClient = Mock.Of<IScriptRunner>();
+        _client = new SettingClientConfigurationModel("TestClient", "Test", null, false, scriptRunnerForClient);
 
         _lastSettingEvent = null;
         _client.RegisterEventAction(e =>

--- a/src/tests/Fig.Unit.Test/Web/SettingClientFacadeGroupMetadataTests.cs
+++ b/src/tests/Fig.Unit.Test/Web/SettingClientFacadeGroupMetadataTests.cs
@@ -104,6 +104,54 @@ public class SettingClientFacadeGroupMetadataTests
     }
 
     [Test]
+    public async Task ShallShowCustomGroupedSettingDescriptionOnSettingsPage()
+    {
+        SetupGroupsResponse(new List<SettingGroupDataContract>
+        {
+            new(Guid.NewGuid(), "SharedGroup", null, new List<GroupedSettingDataContract>
+            {
+                new("Timeout", "Grouped timeout description", "System.String",
+                    new List<SourceSettingDataContract>
+                    {
+                        new("ClientA", "Timeout"),
+                        new("ClientB", "Timeout")
+                    })
+            })
+        });
+
+        await _sut.LoadAllClients();
+
+        var groupClient = _sut.SettingClients.Single(client => client.IsGroup && client.Name == "SharedGroup");
+        var groupSetting = (StringSettingConfigurationModel)groupClient.Settings.Single();
+
+        Assert.That(groupSetting.RawDescription, Is.EqualTo("Grouped timeout description"));
+    }
+
+    [Test]
+    public async Task ShallAllowGroupedSettingDescriptionToBeExplicitlyCleared()
+    {
+        SetupGroupsResponse(new List<SettingGroupDataContract>
+        {
+            new(Guid.NewGuid(), "SharedGroup", null, new List<GroupedSettingDataContract>
+            {
+                new("Timeout", string.Empty, "System.String",
+                    new List<SourceSettingDataContract>
+                    {
+                        new("ClientA", "Timeout"),
+                        new("ClientB", "Timeout")
+                    })
+            })
+        });
+
+        await _sut.LoadAllClients();
+
+        var groupClient = _sut.SettingClients.Single(client => client.IsGroup && client.Name == "SharedGroup");
+        var groupSetting = (StringSettingConfigurationModel)groupClient.Settings.Single();
+
+        Assert.That(groupSetting.RawDescription, Is.Empty);
+    }
+
+    [Test]
     public async Task ShallIgnoreStoredCategoryOverridesAndUsePrimarySourceCategory()
     {
         SetupGroupsResponse(new List<SettingGroupDataContract>

--- a/src/tests/Fig.Unit.Test/Web/SettingClientFacadeGroupMetadataTests.cs
+++ b/src/tests/Fig.Unit.Test/Web/SettingClientFacadeGroupMetadataTests.cs
@@ -1,0 +1,197 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Fig.Common.Events;
+using Fig.Common.NetStandard.Scripting;
+using Fig.Contracts.SettingClients;
+using Fig.Contracts.SettingDefinitions;
+using Fig.Contracts.SettingGroups;
+using Fig.Contracts.Settings;
+using Fig.Web;
+using Fig.Web.Converters;
+using Fig.Web.Events;
+using Fig.Web.Facades;
+using Fig.Web.Models.Setting;
+using Fig.Web.Models.Setting.ConfigurationModels;
+using Fig.Web.Notifications;
+using Fig.Web.Services;
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+using Radzen;
+
+namespace Fig.Unit.Test.Web;
+
+[TestFixture]
+public class SettingClientFacadeGroupMetadataTests
+{
+    private Mock<IHttpService> _httpService = null!;
+    private Mock<ISettingsDefinitionConverter> _definitionConverter = null!;
+    private SettingClientFacade _sut = null!;
+    private SettingClientConfigurationModel _clientA = null!;
+    private SettingClientConfigurationModel _clientB = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _httpService = new Mock<IHttpService>();
+        _definitionConverter = new Mock<ISettingsDefinitionConverter>();
+        var historyConverter = new Mock<ISettingHistoryConverter>();
+        var scriptRunner = new Mock<IScriptRunner>();
+        var webSettings = Options.Create(new WebSettings());
+        var notificationService = new NotificationService();
+        var notificationFactory = new Mock<INotificationFactory>();
+        var clientStatusFacade = new Mock<IClientStatusFacade>();
+        var eventDistributor = new Mock<IEventDistributor>();
+        var apiVersionFacade = new Mock<IApiVersionFacade>();
+        var schedulingFacade = new Mock<ISchedulingFacade>();
+
+        _sut = new SettingClientFacade(
+            _httpService.Object,
+            _definitionConverter.Object,
+            historyConverter.Object,
+            scriptRunner.Object,
+            webSettings,
+            notificationService,
+            notificationFactory.Object,
+            clientStatusFacade.Object,
+            eventDistributor.Object,
+            apiVersionFacade.Object,
+            schedulingFacade.Object);
+
+        _clientA = CreateClient("ClientA");
+        _clientB = CreateClient("ClientB");
+        _clientA.Settings.Add(CreateStringSetting(_clientA, "Timeout", "AAA",
+            categoryName: "Category A", categoryColor: "#11AA11", validationRegex: "^A+$"));
+        _clientB.Settings.Add(CreateStringSetting(_clientB, "Timeout", "BBB",
+            categoryName: "Category B", categoryColor: "#2244DD", validationRegex: "^B+$"));
+
+        _httpService
+            .Setup(service => service.GetLarge<List<SettingsClientDefinitionDataContract>>("/clients", It.IsAny<bool>()))
+            .ReturnsAsync(new List<SettingsClientDefinitionDataContract>());
+
+        _definitionConverter
+            .Setup(converter => converter.Convert(
+                It.IsAny<IList<SettingsClientDefinitionDataContract>>(),
+                It.IsAny<Action<(string, double)>>() ))
+            .ReturnsAsync(new List<SettingClientConfigurationModel> { _clientA, _clientB });
+    }
+
+    [Test]
+    public async Task ShallShowCustomGroupedSettingNameOnSettingsPage()
+    {
+        SetupGroupsResponse(new List<SettingGroupDataContract>
+        {
+            new(Guid.NewGuid(), "SharedGroup", null, new List<GroupedSettingDataContract>
+            {
+                new("Friendly Timeout", null, "System.String",
+                    new List<SourceSettingDataContract>
+                    {
+                        new("ClientA", "Timeout"),
+                        new("ClientB", "Timeout")
+                    })
+            })
+        });
+
+        await _sut.LoadAllClients();
+
+        var groupClient = _sut.SettingClients.Single(client => client.IsGroup && client.Name == "SharedGroup");
+        var groupSetting = (StringSettingConfigurationModel)groupClient.Settings.Single();
+
+        Assert.That(groupSetting.Name, Is.EqualTo("Timeout"));
+        Assert.That(groupSetting.DisplayName, Is.EqualTo("Friendly Timeout"));
+    }
+
+    [Test]
+    public async Task ShallIgnoreStoredCategoryOverridesAndUsePrimarySourceCategory()
+    {
+        SetupGroupsResponse(new List<SettingGroupDataContract>
+        {
+            new(Guid.NewGuid(), "SharedGroup", null, new List<GroupedSettingDataContract>
+            {
+                new("Timeout", null, "System.String",
+                    new List<SourceSettingDataContract>
+                    {
+                        new("ClientA", "Timeout"),
+                        new("ClientB", "Timeout")
+                    })
+                {
+                    CategoryName = "Stored Category",
+                    CategoryColor = "#FF3366"
+                }
+            })
+        });
+
+        await _sut.LoadAllClients();
+
+        var groupClient = _sut.SettingClients.Single(client => client.IsGroup && client.Name == "SharedGroup");
+        var groupSetting = (StringSettingConfigurationModel)groupClient.Settings.Single();
+
+        Assert.That(groupSetting.CategoryName, Is.EqualTo("Category A"));
+        Assert.That(groupSetting.CategoryColor, Is.EqualTo("#11AA11"));
+    }
+
+    [Test]
+    public async Task ShallUseSourceOrderToChoosePrimarySourceMetadata()
+    {
+        SetupGroupsResponse(new List<SettingGroupDataContract>
+        {
+            new(Guid.NewGuid(), "SharedGroup", null, new List<GroupedSettingDataContract>
+            {
+                new("Timeout", null, "System.String",
+                    new List<SourceSettingDataContract>
+                    {
+                        new("ClientB", "Timeout"),
+                        new("ClientA", "Timeout")
+                    })
+            })
+        });
+
+        await _sut.LoadAllClients();
+
+        var groupClient = _sut.SettingClients.Single(client => client.IsGroup && client.Name == "SharedGroup");
+        var groupSetting = (StringSettingConfigurationModel)groupClient.Settings.Single();
+
+        Assert.That(groupSetting.CategoryName, Is.EqualTo("Category B"));
+        Assert.That(groupSetting.CategoryColor, Is.EqualTo("#2244DD"));
+        Assert.That(groupSetting.ValidationRegex, Is.EqualTo("^B+$"));
+    }
+
+    private void SetupGroupsResponse(List<SettingGroupDataContract> groups)
+    {
+        _httpService
+            .Setup(service => service.Get<List<SettingGroupDataContract>>("settinggroups", It.IsAny<bool>()))
+            .ReturnsAsync(groups);
+    }
+
+    private static SettingClientConfigurationModel CreateClient(string clientName)
+    {
+        var client = new SettingClientConfigurationModel(clientName, $"{clientName} description", null, false, Mock.Of<IScriptRunner>());
+        return client;
+    }
+
+    private static StringSettingConfigurationModel CreateStringSetting(
+        SettingClientConfigurationModel parent,
+        string name,
+        string value,
+        string? categoryName = null,
+        string? categoryColor = null,
+        string? validationRegex = null)
+    {
+        var definition = new SettingDefinitionDataContract(
+            name,
+            $"{name} description",
+            new StringSettingDataContract(value),
+            false,
+            typeof(string),
+            validationRegex: validationRegex,
+            categoryName: categoryName,
+            categoryColor: categoryColor);
+
+        return new StringSettingConfigurationModel(
+            definition,
+            parent,
+            new SettingPresentation(false));
+    }
+}

--- a/src/web/Fig.Web/Facades/GroupsFacade.cs
+++ b/src/web/Fig.Web/Facades/GroupsFacade.cs
@@ -1,0 +1,51 @@
+using Fig.Contracts.ImportExport;
+using Fig.Contracts.SettingGroups;
+using Fig.Web.Services;
+
+namespace Fig.Web.Facades;
+
+public class GroupsFacade : IGroupsFacade
+{
+    private readonly IHttpService _httpService;
+
+    public GroupsFacade(IHttpService httpService)
+    {
+        _httpService = httpService;
+    }
+
+    public async Task<List<SettingGroupDataContract>> GetAllGroups()
+    {
+        return await _httpService.Get<List<SettingGroupDataContract>>("settinggroups")
+               ?? new List<SettingGroupDataContract>();
+    }
+
+    public async Task<SettingGroupDataContract?> GetGroup(Guid id)
+    {
+        return await _httpService.Get<SettingGroupDataContract>($"settinggroups/{id}");
+    }
+
+    public async Task<SettingGroupDataContract?> CreateGroup(SettingGroupDataContract group)
+    {
+        return await _httpService.Post<SettingGroupDataContract>("settinggroups", group);
+    }
+
+    public async Task<SettingGroupDataContract?> UpdateGroup(SettingGroupDataContract group)
+    {
+        return await _httpService.Put<SettingGroupDataContract>($"settinggroups/{group.Id}", group);
+    }
+
+    public async Task DeleteGroup(Guid id)
+    {
+        await _httpService.Delete($"settinggroups/{id}");
+    }
+
+    public async Task<SettingGroupExportDataContract?> ExportGroups()
+    {
+        return await _httpService.Get<SettingGroupExportDataContract>("settinggroupdata");
+    }
+
+    public async Task<ImportResultDataContract?> ImportGroups(SettingGroupExportDataContract data, ImportType importType)
+    {
+        return await _httpService.Put<ImportResultDataContract>($"settinggroupdata?importType={importType}", data);
+    }
+}

--- a/src/web/Fig.Web/Facades/IGroupsFacade.cs
+++ b/src/web/Fig.Web/Facades/IGroupsFacade.cs
@@ -1,0 +1,21 @@
+using Fig.Contracts.ImportExport;
+using Fig.Contracts.SettingGroups;
+
+namespace Fig.Web.Facades;
+
+public interface IGroupsFacade
+{
+    Task<List<SettingGroupDataContract>> GetAllGroups();
+
+    Task<SettingGroupDataContract?> GetGroup(Guid id);
+
+    Task<SettingGroupDataContract?> CreateGroup(SettingGroupDataContract group);
+
+    Task<SettingGroupDataContract?> UpdateGroup(SettingGroupDataContract group);
+
+    Task DeleteGroup(Guid id);
+
+    Task<SettingGroupExportDataContract?> ExportGroups();
+
+    Task<ImportResultDataContract?> ImportGroups(SettingGroupExportDataContract data, ImportType importType);
+}

--- a/src/web/Fig.Web/Facades/ISettingClientFacade.cs
+++ b/src/web/Fig.Web/Facades/ISettingClientFacade.cs
@@ -36,4 +36,6 @@ public interface ISettingClientFacade
     Task LoadAndNotifyAboutScheduledChanges();
 
     void ApplyPendingValueFromCompare(string clientName, string? instance, string settingName, string? rawValue);
+
+    void MarkGroupsChanged();
 }

--- a/src/web/Fig.Web/Facades/SettingClientFacade.cs
+++ b/src/web/Fig.Web/Facades/SettingClientFacade.cs
@@ -601,6 +601,11 @@ public class SettingClientFacade : ISettingClientFacade
                     cloned.SetDisplayName(gs.Name);
                 }
 
+                if (gs.Description != null)
+                {
+                    cloned.SetDescription(gs.Description);
+                }
+
                 cloned.SetGroupManagedSettings(managedSettings);
                 settings.Add(cloned);
             }

--- a/src/web/Fig.Web/Facades/SettingClientFacade.cs
+++ b/src/web/Fig.Web/Facades/SettingClientFacade.cs
@@ -1,12 +1,14 @@
 using System.ComponentModel;
 using System.Globalization;
 using System.Reflection;
+using System.Text;
 using Fig.Common.Events;
 using Fig.Common.NetStandard.Scripting;
 using Fig.Contracts.Health;
 using Fig.Contracts.Scheduling;
 using Fig.Contracts.SettingClients;
 using Fig.Contracts.SettingDefinitions;
+using Fig.Contracts.SettingGroups;
 using Fig.Contracts.Settings;
 using Fig.Web.Builders;
 using Fig.Web.Converters;
@@ -16,13 +18,13 @@ using Fig.Web.Models.Clients;
 using Fig.Web.Models.Setting;
 using Fig.Web.Notifications;
 using Fig.Web.Services;
+using Microsoft.Extensions.Options;
 using Radzen;
 
 namespace Fig.Web.Facades;
 
 public class SettingClientFacade : ISettingClientFacade
 {
-    private readonly ISettingGroupBuilder _groupBuilder;
     private readonly IHttpService _httpService;
     private readonly INotificationFactory _notificationFactory;
     private readonly IClientStatusFacade _clientStatusFacade;
@@ -32,12 +34,15 @@ public class SettingClientFacade : ISettingClientFacade
     private readonly NotificationService _notificationService;
     private readonly ISettingHistoryConverter _settingHistoryConverter;
     private readonly ISettingsDefinitionConverter _settingsDefinitionConverter;
+    private readonly IScriptRunner _scriptRunner;
+    private readonly WebSettings _webSettings;
     private bool _isLoadInProgress;
     
     public SettingClientFacade(IHttpService httpService,
         ISettingsDefinitionConverter settingsDefinitionConverter,
         ISettingHistoryConverter settingHistoryConverter,
-        ISettingGroupBuilder groupBuilder,
+        IScriptRunner scriptRunner,
+        IOptions<WebSettings> webSettings,
         NotificationService notificationService,
         INotificationFactory notificationFactory,
         IClientStatusFacade clientStatusFacade,
@@ -48,7 +53,8 @@ public class SettingClientFacade : ISettingClientFacade
         _httpService = httpService;
         _settingsDefinitionConverter = settingsDefinitionConverter;
         _settingHistoryConverter = settingHistoryConverter;
-        _groupBuilder = groupBuilder;
+        _scriptRunner = scriptRunner;
+        _webSettings = webSettings.Value;
         _notificationService = notificationService;
         _notificationFactory = notificationFactory;
         _clientStatusFacade = clientStatusFacade;
@@ -476,7 +482,7 @@ public class SettingClientFacade : ISettingClientFacade
         var settings = await LoadSettings();
         var clients = await _settingsDefinitionConverter.Convert(settings,
         progress => OnLoadProgressed?.Invoke(this, progress));
-        clients.AddRange(_groupBuilder.BuildGroups(clients));
+        clients.AddRange(await BuildGroupsFromServer(clients));
 
         LinkInstanceSettingsToTheirBaseSettings();
         
@@ -532,6 +538,89 @@ public class SettingClientFacade : ISettingClientFacade
                 }
             }
         }
+    }
+
+    private async Task<List<SettingClientConfigurationModel>> BuildGroupsFromServer(
+        List<SettingClientConfigurationModel> clients)
+    {
+        var groupContracts = await _httpService.Get<List<SettingGroupDataContract>>("settinggroups")
+            ?? new List<SettingGroupDataContract>();
+
+        var result = new List<SettingClientConfigurationModel>();
+
+        foreach (var group in groupContracts)
+        {
+            var settingGroup = new SettingClientConfigurationModel(
+                group.Name,
+                CreateGroupDescription(group),
+                null,
+                false,
+                _scriptRunner,
+                true);
+
+            var settings = new List<ISetting>();
+
+            foreach (var gs in group.GroupedSettings)
+            {
+                var managedSettings = new List<ISetting>();
+                ISetting? templateSetting = null;
+
+                foreach (var ss in gs.SourceSettings)
+                {
+                    var client = clients.FirstOrDefault(c =>
+                        string.Equals(c.Name, ss.ClientName, StringComparison.OrdinalIgnoreCase) &&
+                        c.Instance == null && !c.IsGroup);
+
+                    if (client == null) continue;
+
+                    var setting = client.Settings.FirstOrDefault(s =>
+                        string.Equals(s.Name, ss.SettingName, StringComparison.Ordinal));
+
+                    if (setting == null) continue;
+
+                    templateSetting ??= setting;
+                    managedSettings.Add(setting);
+                }
+
+                if (templateSetting == null) continue;
+
+                var cloned = templateSetting.Clone(settingGroup, false, templateSetting.IsReadOnly);
+                cloned.IsCompactView = _webSettings.DefaultDisplayCollapsed;
+                cloned.SetGroupManagedSettings(managedSettings);
+                settings.Add(cloned);
+            }
+
+            settingGroup.Settings = settings;
+            result.Add(settingGroup);
+        }
+
+        return result;
+    }
+
+    private static string CreateGroupDescription(SettingGroupDataContract group)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine($"# Setting Group: {group.Name}");
+        builder.AppendLine();
+        if (!string.IsNullOrWhiteSpace(group.Description))
+        {
+            builder.AppendLine(group.Description);
+            builder.AppendLine();
+        }
+        builder.AppendLine($"Group consists of {group.GroupedSettings.Count} setting(s) used by the following clients:");
+
+        var clientNames = group.GroupedSettings
+            .SelectMany(gs => gs.SourceSettings)
+            .Select(ss => ss.ClientName)
+            .Distinct()
+            .OrderBy(n => n);
+
+        foreach (var name in clientNames)
+        {
+            builder.AppendLine($"- {name}");
+        }
+
+        return builder.ToString();
     }
 
     private async Task SaveChangedSettings(SettingClientConfigurationModel client,

--- a/src/web/Fig.Web/Facades/SettingClientFacade.cs
+++ b/src/web/Fig.Web/Facades/SettingClientFacade.cs
@@ -595,11 +595,11 @@ public class SettingClientFacade : ISettingClientFacade
                 var cloned = templateSetting.Clone(settingGroup, false, templateSetting.IsReadOnly);
                 cloned.IsCompactView = _webSettings.DefaultDisplayCollapsed;
 
-                // Apply category overrides from group definition if set
-                if (!string.IsNullOrWhiteSpace(gs.CategoryName))
-                    cloned.CategoryName = gs.CategoryName;
-                if (!string.IsNullOrWhiteSpace(gs.CategoryColor))
-                    cloned.CategoryColor = gs.CategoryColor;
+                if (!string.IsNullOrWhiteSpace(gs.Name) &&
+                    !string.Equals(gs.Name, templateSetting.Name, StringComparison.Ordinal))
+                {
+                    cloned.SetDisplayName(gs.Name);
+                }
 
                 cloned.SetGroupManagedSettings(managedSettings);
                 settings.Add(cloned);

--- a/src/web/Fig.Web/Facades/SettingClientFacade.cs
+++ b/src/web/Fig.Web/Facades/SettingClientFacade.cs
@@ -37,6 +37,7 @@ public class SettingClientFacade : ISettingClientFacade
     private readonly IScriptRunner _scriptRunner;
     private readonly WebSettings _webSettings;
     private bool _isLoadInProgress;
+    private bool _forceReload;
     
     public SettingClientFacade(IHttpService httpService,
         ISettingsDefinitionConverter settingsDefinitionConverter,
@@ -81,10 +82,11 @@ public class SettingClientFacade : ISettingClientFacade
     public async Task LoadAllClients()
     {
         if (_isLoadInProgress || 
-            !_apiVersionFacade.AreSettingsStale && SettingClients.Count > 0)
+            !_forceReload && !_apiVersionFacade.AreSettingsStale && SettingClients.Count > 0)
             return;
 
         _isLoadInProgress = true;
+        _forceReload = false;
 
         try
         {
@@ -128,6 +130,11 @@ public class SettingClientFacade : ISettingClientFacade
 #pragma warning restore CS4014
             }
         }
+    }
+
+    public void MarkGroupsChanged()
+    {
+        _forceReload = true;
     }
 
     private static void ApplyDataGridValue(
@@ -493,6 +500,7 @@ public class SettingClientFacade : ISettingClientFacade
         }
         UpdateSelectedSettingClient();
         CheckForDisabledScripts();
+        SearchableSettings.Clear();
         SearchableSettings.AddRange(SettingClients.SelectMany(a => a.Settings).OfType<ISearchableSetting>());
         
         await _eventDistributor.PublishAsync(EventConstants.SettingsLoaded);
@@ -586,6 +594,13 @@ public class SettingClientFacade : ISettingClientFacade
 
                 var cloned = templateSetting.Clone(settingGroup, false, templateSetting.IsReadOnly);
                 cloned.IsCompactView = _webSettings.DefaultDisplayCollapsed;
+
+                // Apply category overrides from group definition if set
+                if (!string.IsNullOrWhiteSpace(gs.CategoryName))
+                    cloned.CategoryName = gs.CategoryName;
+                if (!string.IsNullOrWhiteSpace(gs.CategoryColor))
+                    cloned.CategoryColor = gs.CategoryColor;
+
                 cloned.SetGroupManagedSettings(managedSettings);
                 settings.Add(cloned);
             }

--- a/src/web/Fig.Web/Models/Setting/ISetting.cs
+++ b/src/web/Fig.Web/Models/Setting/ISetting.cs
@@ -115,6 +115,8 @@ public interface ISetting : IScriptableSetting
 
     void SetDisplayName(string? displayName);
 
+    void SetDescription(string? description);
+
     void SetGroupManagedSettings(List<ISetting> matches);
 
     void ShowAdvancedChanged(bool showAdvanced);

--- a/src/web/Fig.Web/Models/Setting/ISetting.cs
+++ b/src/web/Fig.Web/Models/Setting/ISetting.cs
@@ -113,6 +113,8 @@ public interface ISetting : IScriptableSetting
 
     ISetting Clone(SettingClientConfigurationModel client, bool markDirty, bool isReadOnly);
 
+    void SetDisplayName(string? displayName);
+
     void SetGroupManagedSettings(List<ISetting> matches);
 
     void ShowAdvancedChanged(bool showAdvanced);

--- a/src/web/Fig.Web/Models/Setting/ISetting.cs
+++ b/src/web/Fig.Web/Models/Setting/ISetting.cs
@@ -69,9 +69,9 @@ public interface ISetting : IScriptableSetting
     
     bool SupportsLiveUpdate { get; }
     
-    new string CategoryColor { get; }
+    new string CategoryColor { get; set; }
     
-    new string CategoryName { get; }
+    new string CategoryName { get; set; }
     
     Classification Classification { get; }
     

--- a/src/web/Fig.Web/Models/Setting/SettingConfigurationModel.cs
+++ b/src/web/Fig.Web/Models/Setting/SettingConfigurationModel.cs
@@ -31,6 +31,7 @@ public abstract class SettingConfigurationModel<T> : ISetting, ISearchableSettin
     private static readonly SettingFilterParser _filterParser = new();
     private bool _showModifiedOnly;
     private string _lowerName;
+    private string _lowerDisplayName = string.Empty;
     private readonly string _lowerParentInstance;
     private readonly string _lowerDescription;
     private readonly string _lowerParentName;
@@ -85,7 +86,7 @@ public abstract class SettingConfigurationModel<T> : ISetting, ISearchableSettin
         UpdateVisibility();
         _isVisibleFromScript = Hidden;
         
-        _lowerName = DisplayName.ToLowerInvariant();
+        _lowerName = Name.ToLowerInvariant();
         _lowerParentInstance = parent.Instance?.ToLowerInvariant() ?? string.Empty;
         _lowerDescription = TruncatedDescription.ToLowerInvariant();
         _lowerParentName = parent.Name.ToLowerInvariant();
@@ -409,7 +410,7 @@ public abstract class SettingConfigurationModel<T> : ISetting, ISearchableSettin
         DisplayName = string.IsNullOrWhiteSpace(displayName)
             ? Name.SplitCamelCase()
             : displayName;
-        _lowerName = DisplayName.ToLowerInvariant();
+        _lowerDisplayName = DisplayName.ToLowerInvariant();
     }
 
     public void SetValue(object? value)
@@ -786,6 +787,7 @@ public abstract class SettingConfigurationModel<T> : ISetting, ISearchableSettin
         if (generalTokens.Any())
             match = match && generalTokens.All(token =>
                 _lowerName.Contains(token) ||
+                _lowerDisplayName.Contains(token) ||
                 _lowerParentName.Contains(token) ||
                 _lowerParentInstance.Contains(token));
 

--- a/src/web/Fig.Web/Models/Setting/SettingConfigurationModel.cs
+++ b/src/web/Fig.Web/Models/Setting/SettingConfigurationModel.cs
@@ -30,7 +30,7 @@ public abstract class SettingConfigurationModel<T> : ISetting, ISearchableSettin
     private bool _isVisibleFromScript;
     private static readonly SettingFilterParser _filterParser = new();
     private bool _showModifiedOnly;
-    private readonly string _lowerName;
+    private string _lowerName;
     private readonly string _lowerParentInstance;
     private readonly string _lowerDescription;
     private readonly string _lowerParentName;
@@ -47,7 +47,7 @@ public abstract class SettingConfigurationModel<T> : ISetting, ISearchableSettin
     {
         Presentation = presentation;
         Name = dataContract.Name;
-        DisplayName = Name.SplitCamelCase();
+        SetDisplayName(Name.SplitCamelCase());
         Description = (MarkupString)dataContract.Description.ToHtml();
         RawDescription = dataContract.Description;
         TruncatedDescription = dataContract.Description.StripImagesAndSimplifyLinks().Truncate(90);
@@ -192,7 +192,7 @@ public abstract class SettingConfigurationModel<T> : ISetting, ISearchableSettin
 
     public string Name { get; }
     
-    public string DisplayName { get; }
+    public string DisplayName { get; private set; }
 
     public MarkupString Description { get; }
     
@@ -377,8 +377,9 @@ public abstract class SettingConfigurationModel<T> : ISetting, ISearchableSettin
         var matchesDirty = criteria.Modified == null || IsDirty == criteria.Modified;
 
         // Check general search terms (match any)
-        var matchesGeneralSearch = !criteria.GeneralSearchTerms.Any() || 
+        var matchesGeneralSearch = !criteria.GeneralSearchTerms.Any() ||
                                    criteria.GeneralSearchTerms.Any(term =>
+                                       DisplayName.Contains(term, StringComparison.OrdinalIgnoreCase) ||
                                        Name.Contains(term, StringComparison.OrdinalIgnoreCase) ||
                                        Description.ToString().Contains(term, StringComparison.OrdinalIgnoreCase) ||
                                        StringValue.Contains(term, StringComparison.OrdinalIgnoreCase));
@@ -402,6 +403,14 @@ public abstract class SettingConfigurationModel<T> : ISetting, ISearchableSettin
     }
 
     public abstract ISetting Clone(SettingClientConfigurationModel parent, bool setDirty, bool isReadOnly);
+
+    public void SetDisplayName(string? displayName)
+    {
+        DisplayName = string.IsNullOrWhiteSpace(displayName)
+            ? Name.SplitCamelCase()
+            : displayName;
+        _lowerName = DisplayName.ToLowerInvariant();
+    }
 
     public void SetValue(object? value)
     {

--- a/src/web/Fig.Web/Models/Setting/SettingConfigurationModel.cs
+++ b/src/web/Fig.Web/Models/Setting/SettingConfigurationModel.cs
@@ -33,7 +33,7 @@ public abstract class SettingConfigurationModel<T> : ISetting, ISearchableSettin
     private string _lowerName;
     private string _lowerDisplayName = string.Empty;
     private readonly string _lowerParentInstance;
-    private readonly string _lowerDescription;
+    private string _lowerDescription = string.Empty;
     private readonly string _lowerParentName;
     private readonly Dictionary<int, string> _cachedStringValues = new();
     private ISetting? _baseSetting;
@@ -49,9 +49,7 @@ public abstract class SettingConfigurationModel<T> : ISetting, ISearchableSettin
         Presentation = presentation;
         Name = dataContract.Name;
         SetDisplayName(Name.SplitCamelCase());
-        Description = (MarkupString)dataContract.Description.ToHtml();
-        RawDescription = dataContract.Description;
-        TruncatedDescription = dataContract.Description.StripImagesAndSimplifyLinks().Truncate(90);
+        SetDescription(dataContract.Description);
         SupportsLiveUpdate = dataContract.SupportsLiveUpdate;
         ValidationRegex = dataContract.ValidationRegex;
         ValidationExplanation = string.IsNullOrWhiteSpace(dataContract.ValidationExplanation)
@@ -116,7 +114,7 @@ public abstract class SettingConfigurationModel<T> : ISetting, ISearchableSettin
 
     public string CategoryColor { get; set; }
     
-    public string TruncatedDescription { get; }
+    public string TruncatedDescription { get; private set; } = string.Empty;
 
     public abstract string IconKey { get; }
 
@@ -195,9 +193,9 @@ public abstract class SettingConfigurationModel<T> : ISetting, ISearchableSettin
     
     public string DisplayName { get; private set; }
 
-    public MarkupString Description { get; }
+    public MarkupString Description { get; private set; }
     
-    public string RawDescription { get; }
+    public string RawDescription { get; private set; } = string.Empty;
 
     public string? Group { get; }
 
@@ -411,6 +409,14 @@ public abstract class SettingConfigurationModel<T> : ISetting, ISearchableSettin
             ? Name.SplitCamelCase()
             : displayName;
         _lowerDisplayName = DisplayName.ToLowerInvariant();
+    }
+
+    public void SetDescription(string? description)
+    {
+        RawDescription = description ?? string.Empty;
+        Description = (MarkupString)RawDescription.ToHtml();
+        TruncatedDescription = RawDescription.StripImagesAndSimplifyLinks().Truncate(90);
+        _lowerDescription = TruncatedDescription.ToLowerInvariant();
     }
 
     public void SetValue(object? value)

--- a/src/web/Fig.Web/Pages/Dialogs/SourceSettingSelectionDialog.razor
+++ b/src/web/Fig.Web/Pages/Dialogs/SourceSettingSelectionDialog.razor
@@ -1,0 +1,71 @@
+@using Fig.Contracts.SettingGroups
+@inject DialogService DialogService
+
+<div style="display: flex; flex-direction: column; height: 100%;">
+    <RadzenTextBox Placeholder="Search settings..." @bind-Value="_searchText"
+                   Style="width: 100%; margin-bottom: 8px;"
+                   Change="@(_ => StateHasChanged())" />
+
+    <div style="flex: 1; overflow-y: auto; border: 1px solid var(--rz-base-300); border-radius: 4px; padding: 4px;">
+        @foreach (var setting in FilteredSettings)
+        {
+            <div style="display: flex; align-items: center; padding: 6px 8px; cursor: pointer; border-radius: 4px;
+                        background: @(_selectedSettings.Contains(setting) ? "var(--rz-primary-lighter)" : "transparent");"
+                 @onclick="() => ToggleSelection(setting)">
+                <RadzenCheckBox TValue="bool" Value="@_selectedSettings.Contains(setting)" Style="margin-right: 8px;" />
+                <span><strong>@setting.ClientName</strong> &rarr; @setting.SettingName</span>
+            </div>
+        }
+
+        @if (!FilteredSettings.Any())
+        {
+            <div style="padding: 20px; text-align: center; color: var(--rz-text-tertiary-color);">
+                No matching settings found
+            </div>
+        }
+    </div>
+
+    <div style="display: flex; justify-content: flex-end; gap: 8px; margin-top: 12px;">
+        <RadzenButton Text="Cancel" ButtonStyle="ButtonStyle.Secondary" Click="@Cancel" />
+        <RadzenButton Text="@($"Add ({_selectedSettings.Count})")" ButtonStyle="ButtonStyle.Primary"
+                      Disabled="@(!_selectedSettings.Any())" Click="@Confirm" />
+    </div>
+</div>
+
+@code {
+    [Parameter] public List<SourceSettingDataContract> AvailableSettings { get; set; } = new();
+    [Parameter] public string? ValueTypeFilter { get; set; }
+    [Parameter] public Dictionary<string, string> SettingValueTypes { get; set; } = new();
+
+    private string _searchText = string.Empty;
+    private readonly HashSet<SourceSettingDataContract> _selectedSettings = new();
+
+    private IEnumerable<SourceSettingDataContract> FilteredSettings
+    {
+        get
+        {
+            IEnumerable<SourceSettingDataContract> result = AvailableSettings;
+
+            if (!string.IsNullOrWhiteSpace(ValueTypeFilter))
+                result = result.Where(s => SettingValueTypes.TryGetValue($"{s.ClientName}|{s.SettingName}", out var vt) &&
+                    string.Equals(vt, ValueTypeFilter, StringComparison.OrdinalIgnoreCase));
+
+            if (!string.IsNullOrWhiteSpace(_searchText))
+                result = result.Where(s =>
+                    s.ClientName.Contains(_searchText, StringComparison.OrdinalIgnoreCase) ||
+                    s.SettingName.Contains(_searchText, StringComparison.OrdinalIgnoreCase));
+
+            return result;
+        }
+    }
+
+    private void ToggleSelection(SourceSettingDataContract setting)
+    {
+        if (!_selectedSettings.Remove(setting))
+            _selectedSettings.Add(setting);
+    }
+
+    private void Cancel() => DialogService.Close(null);
+
+    private void Confirm() => DialogService.Close(_selectedSettings.ToList());
+}

--- a/src/web/Fig.Web/Pages/Dialogs/SourceSettingSelectionDialog.razor
+++ b/src/web/Fig.Web/Pages/Dialogs/SourceSettingSelectionDialog.razor
@@ -4,22 +4,30 @@
 <div style="display: flex; flex-direction: column; height: 100%;">
     <RadzenTextBox Placeholder="Search settings..." @bind-Value="_searchText"
                    Style="width: 100%; margin-bottom: 8px;"
-                   Change="@(_ => StateHasChanged())" />
+                   @oninput="@(args => { _searchText = args.Value?.ToString() ?? string.Empty; StateHasChanged(); })" />
 
-    <div style="flex: 1; overflow-y: auto; border: 1px solid var(--rz-base-300); border-radius: 4px; padding: 4px;">
+    <div style="flex: 1; overflow-y: auto; border: 1px solid rgba(255,255,255,0.08); border-radius: 6px; padding: 4px;">
         @foreach (var setting in FilteredSettings)
         {
-            <div style="display: flex; align-items: center; padding: 6px 8px; cursor: pointer; border-radius: 4px;
-                        background: @(_selectedSettings.Contains(setting) ? "var(--rz-primary-lighter)" : "transparent");"
+            var isSelected = _selectedSettings.Contains(setting);
+            <div style="display: flex; align-items: center; padding: 8px 10px; cursor: pointer; border-radius: 4px;
+                        margin-bottom: 2px; transition: background 0.15s ease;
+                        background: @(isSelected ? "rgba(var(--rz-primary-rgb), 0.2)" : "transparent");"
                  @onclick="() => ToggleSelection(setting)">
-                <RadzenCheckBox TValue="bool" Value="@_selectedSettings.Contains(setting)" Style="margin-right: 8px;" />
-                <span><strong>@setting.ClientName</strong> &rarr; @setting.SettingName</span>
+                <RadzenCheckBox TValue="bool" Value="@isSelected" Style="margin-right: 10px;" />
+                <div style="flex: 1; min-width: 0;">
+                    <div style="display: flex; align-items: center; gap: 6px;">
+                        <span style="font-weight: 600; color: rgba(255,255,255,0.85); font-size: 0.88rem;">@setting.ClientName</span>
+                        <span style="color: rgba(255,255,255,0.3); font-size: 0.8rem;">→</span>
+                        <span style="color: rgba(255,255,255,0.7); font-size: 0.88rem;">@setting.SettingName</span>
+                    </div>
+                </div>
             </div>
         }
 
         @if (!FilteredSettings.Any())
         {
-            <div style="padding: 20px; text-align: center; color: var(--rz-text-tertiary-color);">
+            <div style="padding: 24px; text-align: center; color: rgba(255,255,255,0.4);">
                 No matching settings found
             </div>
         }
@@ -38,7 +46,14 @@
     [Parameter] public Dictionary<string, string> SettingValueTypes { get; set; } = new();
 
     private string _searchText = string.Empty;
-    private readonly HashSet<SourceSettingDataContract> _selectedSettings = new();
+    private readonly List<SourceSettingDataContract> _selectedSettings = new();
+
+    private string? _effectiveValueTypeFilter;
+
+    protected override void OnInitialized()
+    {
+        _effectiveValueTypeFilter = ValueTypeFilter;
+    }
 
     private IEnumerable<SourceSettingDataContract> FilteredSettings
     {
@@ -46,9 +61,9 @@
         {
             IEnumerable<SourceSettingDataContract> result = AvailableSettings;
 
-            if (!string.IsNullOrWhiteSpace(ValueTypeFilter))
+            if (!string.IsNullOrWhiteSpace(_effectiveValueTypeFilter))
                 result = result.Where(s => SettingValueTypes.TryGetValue($"{s.ClientName}|{s.SettingName}", out var vt) &&
-                    string.Equals(vt, ValueTypeFilter, StringComparison.OrdinalIgnoreCase));
+                    string.Equals(vt, _effectiveValueTypeFilter, StringComparison.OrdinalIgnoreCase));
 
             if (!string.IsNullOrWhiteSpace(_searchText))
                 result = result.Where(s =>
@@ -61,8 +76,25 @@
 
     private void ToggleSelection(SourceSettingDataContract setting)
     {
-        if (!_selectedSettings.Remove(setting))
+        if (_selectedSettings.Contains(setting))
+        {
+            _selectedSettings.Remove(setting);
+
+            // If all selections removed and no external filter, clear type constraint
+            if (!_selectedSettings.Any() && string.IsNullOrWhiteSpace(ValueTypeFilter))
+                _effectiveValueTypeFilter = null;
+        }
+        else
+        {
+            // On first selection, lock value type filter if not already set
+            if (!_selectedSettings.Any() && string.IsNullOrWhiteSpace(_effectiveValueTypeFilter))
+            {
+                if (SettingValueTypes.TryGetValue($"{setting.ClientName}|{setting.SettingName}", out var vt))
+                    _effectiveValueTypeFilter = vt;
+            }
+
             _selectedSettings.Add(setting);
+        }
     }
 
     private void Cancel() => DialogService.Close(null);

--- a/src/web/Fig.Web/Pages/Dialogs/TextPromptDialog.razor
+++ b/src/web/Fig.Web/Pages/Dialogs/TextPromptDialog.razor
@@ -1,0 +1,19 @@
+@inject DialogService DialogService
+
+<div class="p-3">
+    <p class="mb-2">@Prompt</p>
+    <RadzenTextBox @bind-Value="_value" Style="width: 100%; margin-bottom: 16px;" />
+    <div class="row">
+        <div class="col">
+            <RadzenButton Text="OK" Click="@(() => DialogService.Close(_value))"
+                          Disabled="@string.IsNullOrWhiteSpace(_value)" Class="mr-1" />
+            <RadzenButton Text="Cancel" Click="@(() => DialogService.Close(null))"
+                          ButtonStyle="ButtonStyle.Secondary" Class="mr-1" />
+        </div>
+    </div>
+</div>
+
+@code {
+    [Parameter] public string Prompt { get; set; } = "Enter value:";
+    private string _value = string.Empty;
+}

--- a/src/web/Fig.Web/Pages/Dialogs/TextPromptDialog.razor
+++ b/src/web/Fig.Web/Pages/Dialogs/TextPromptDialog.razor
@@ -1,11 +1,11 @@
 @inject DialogService DialogService
 
 <div class="p-3">
-    <p class="mb-2">@Prompt</p>
-    <RadzenTextBox @bind-Value="_value" Style="width: 100%; margin-bottom: 16px;" />
+    <RadzenLabel Text="@Prompt" Component="promptInput" class="mb-2 d-block" />
+    <RadzenTextBox @bind-Value="_value" Name="promptInput" Style="width: 100%; margin-bottom: 16px;" />
     <div class="row">
         <div class="col">
-            <RadzenButton Text="OK" Click="@(() => DialogService.Close(_value))"
+            <RadzenButton Text="OK" Click="@(() => DialogService.Close(_value?.Trim()))"
                           Disabled="@string.IsNullOrWhiteSpace(_value)" Class="mr-1" />
             <RadzenButton Text="Cancel" Click="@(() => DialogService.Close(null))"
                           ButtonStyle="ButtonStyle.Secondary" Class="mr-1" />

--- a/src/web/Fig.Web/Pages/Dialogs/UnsavedChangesDialog.razor
+++ b/src/web/Fig.Web/Pages/Dialogs/UnsavedChangesDialog.razor
@@ -1,0 +1,21 @@
+@inject DialogService DialogService
+
+<div class="p-3">
+    <p class="mb-3">@Message</p>
+
+    <div class="d-flex gap-2 justify-content-end">
+        <RadzenButton Text="Stay on page"
+                      ButtonStyle="ButtonStyle.Light"
+                      Click="@(() => DialogService.Close(null))" />
+        <RadzenButton Text="Discard"
+                      ButtonStyle="ButtonStyle.Warning"
+                      Click="@(() => DialogService.Close("discard"))" />
+        <RadzenButton Text="Save"
+                      ButtonStyle="ButtonStyle.Success"
+                      Click="@(() => DialogService.Close("save"))" />
+    </div>
+</div>
+
+@code {
+    [Parameter] public string Message { get; set; } = "You have unsaved changes.";
+}

--- a/src/web/Fig.Web/Pages/Groups.razor
+++ b/src/web/Fig.Web/Pages/Groups.razor
@@ -9,69 +9,95 @@
 <PageTitle>Fig - Groups</PageTitle>
 
 <div class="groups-container">
-    @* Left Panel — Group List (RadzenListBox with instant filtering) *@
-    <div class="groups-list-panel">
+    <aside class="groups-list-panel">
         <div class="groups-list-header">
-            <h4>Groups</h4>
+            <div>
+                <h4>Groups</h4>
+                <p class="groups-list-subtitle">
+                    @(_groups.Count == 0
+                        ? "Create a group to organize shared settings."
+                        : $"{_groups.Count} group{(_groups.Count == 1 ? string.Empty : "s")}")
+                </p>
+            </div>
             @if (IsAdmin)
             {
                 <RadzenButton Icon="add_circle_outline" ButtonStyle="ButtonStyle.Secondary" Size="ButtonSize.Small"
-                              Click="@AddGroup"
-                              MouseEnter="@(args => ShowTooltip(args, "Add Group"))" />
+                              Class="groups-header-button"
+                              Click="@AddGroup" />
             }
         </div>
 
-        @if (_loading)
-        {
-            <div style="padding: 24px; text-align: center;">
-                <RadzenProgressBarCircular ShowValue="false" Mode="ProgressBarMode.Indeterminate"
-                                           Size="ProgressBarCircularSize.Medium" />
-            </div>
-        }
-        else
-        {
-            <RadzenListBox AllowFiltering="true" @bind-Value="_selectedGroup"
-                           FilterCaseSensitivity="FilterCaseSensitivity.CaseInsensitive"
-                           TValue="SettingGroupDataContract" Data="@_groups"
-                           TextProperty="Name"
-                           Class="groups-listbox"
-                           Change="@OnGroupSelected">
-                <Template>
-                    @{
-                        var g = (SettingGroupDataContract)context;
-                    }
-                    <div class="d-flex group-list-item">
-                        <div class="p-1">
-                            <RadzenIcon Icon="folder" Size="1.2rem" class="group-icon"
-                                        Style="color: var(--rz-text-color); opacity: 0.8;" />
+        <div class="groups-list-shell">
+            @if (_loading)
+            {
+                <div class="groups-loading-state">
+                    <RadzenProgressBarCircular ShowValue="false" Mode="ProgressBarMode.Indeterminate"
+                                               Size="ProgressBarCircularSize.Medium" />
+                </div>
+            }
+            else if (_groups.Any())
+            {
+                <RadzenListBox AllowFiltering="true" @bind-Value="_selectedGroup"
+                               FilterCaseSensitivity="FilterCaseSensitivity.CaseInsensitive"
+                               TValue="SettingGroupDataContract" Data="@_groups"
+                               TextProperty="Name"
+                               Class="groups-listbox"
+                               Change="@OnGroupSelected">
+                    <Template>
+                        @{
+                            var group = (SettingGroupDataContract)context;
+                            var groupedSettingCount = group.GroupedSettings.Count;
+                        }
+                        <div class="group-list-item">
+                            <div class="group-list-icon-shell">
+                                <RadzenIcon Icon="folder" Size="1.2rem" class="group-icon"
+                                            Style="color: var(--rz-text-color); opacity: 0.85;" />
+                            </div>
+                            <div class="group-list-item-content">
+                                <div class="group-list-item-top">
+                                    <div class="group-name">@group.Name</div>
+                                    <RadzenBadge Text="@groupedSettingCount.ToString()"
+                                                 IsPill="true"
+                                                 BadgeStyle="BadgeStyle.Success" />
+                                </div>
+                                @if (!string.IsNullOrWhiteSpace(group.Description))
+                                {
+                                    <div class="group-list-item-description">@group.Description</div>
+                                }
+                                else
+                                {
+                                    <div class="group-list-item-meta">
+                                        @groupedSettingCount grouped setting@(groupedSettingCount == 1 ? string.Empty : "s")
+                                    </div>
+                                }
+                            </div>
                         </div>
-                        <div class="p-1">
-                            <RadzenBadge Text="@g.GroupedSettings.Count.ToString()"
-                                         IsPill="true" BadgeStyle="BadgeStyle.Success" />
-                        </div>
-                        <div class="flex-grow-1 p-1 group-list-item-text">
-                            <div class="group-name">@g.Name</div>
-                        </div>
-                    </div>
-                </Template>
-            </RadzenListBox>
-        }
-    </div>
+                    </Template>
+                </RadzenListBox>
+            }
+            else
+            {
+                <div class="sidebar-empty-state">
+                    <RadzenIcon Icon="folder_open" Style="font-size: 2rem;" />
+                    <p>No groups yet.</p>
+                </div>
+            }
+        </div>
+    </aside>
 
-    @* Right Panel — Group Details *@
-    <div class="groups-detail-panel">
+    <section class="groups-detail-panel">
         @if (_selectedGroup != null)
         {
-            @* ── Group Header ── *@
             @if (_editingHeader)
             {
                 <div class="group-header-edit">
                     <label>Group Name</label>
-                    <RadzenTextBox @bind-Value="_editName" Placeholder="Group name"
-                                   Style="width: 100%; font-size: 1.1rem; font-weight: 600;" />
+                    <RadzenTextBox @bind-Value="_editName" Placeholder="Group name" Style="width: 100%;" />
+
                     <label>Description</label>
                     <RadzenTextArea @bind-Value="_editDescription" Placeholder="Group description (optional)"
-                                    Style="width: 100%;" Rows="2" />
+                                    Style="width: 100%;" Rows="3" />
+
                     <div class="group-header-edit-actions">
                         <RadzenButton Text="Save" Icon="check" ButtonStyle="ButtonStyle.Primary"
                                       Size="ButtonSize.Small" Click="@SaveHeaderEdit" />
@@ -82,190 +108,209 @@
             }
             else
             {
-                <div class="group-header-display">
-                    <div style="display: flex; justify-content: space-between; align-items: flex-start;">
-                        <div style="flex: 1;">
+                <div class="group-overview-card">
+                    <div class="group-overview-header">
+                        <div class="group-overview-copy">
+                            <div class="group-overview-eyebrow">Setting Group</div>
                             <h2>@_selectedGroup.Name</h2>
-                            @if (!string.IsNullOrWhiteSpace(_selectedGroup.Description))
-                            {
-                                <p>@_selectedGroup.Description</p>
-                            }
+                            <p>
+                                @if (!string.IsNullOrWhiteSpace(_selectedGroup.Description))
+                                {
+                                    @_selectedGroup.Description
+                                }
+                                else
+                                {
+                                    <span>This group collects related settings that should be managed together.</span>
+                                }
+                            </p>
                         </div>
                         <div class="group-header-actions">
                             @if (IsAdmin)
                             {
                                 <RadzenButton Icon="edit" ButtonStyle="ButtonStyle.Light"
-                                              Size="ButtonSize.Small" Variant="Variant.Text"
-                                              Click="@StartHeaderEdit"
-                                              MouseEnter="@(args => ShowTooltip(args, "Edit name and description"))" />
+                                              Size="ButtonSize.Small" Class="groups-icon-button"
+                                              Click="@StartHeaderEdit" />
                                 <RadzenButton Icon="save" ButtonStyle="ButtonStyle.Success"
-                                              Size="ButtonSize.Small" Click="@SaveGroup"
-                                              MouseEnter="@(args => ShowTooltip(args, "Save group"))" />
+                                              Size="ButtonSize.Small" Class="groups-icon-button"
+                                              Click="@SaveGroup" />
                                 <RadzenButton Icon="delete" ButtonStyle="ButtonStyle.Danger"
-                                              Size="ButtonSize.Small" Variant="Variant.Text"
-                                              Click="@DeleteGroup"
-                                              MouseEnter="@(args => ShowTooltip(args, "Delete group"))" />
+                                              Size="ButtonSize.Small" Class="groups-icon-button"
+                                              Click="@DeleteGroup" />
                             }
                         </div>
+                    </div>
+
+                    <div class="group-overview-stats">
+                        <span class="meta-chip">
+                            @_selectedGroup.GroupedSettings.Count grouped setting@(_selectedGroup.GroupedSettings.Count == 1 ? string.Empty : "s")
+                        </span>
+                        <span class="meta-chip">
+                            @GetTotalSourceSettingCount(_selectedGroup) source setting@(GetTotalSourceSettingCount(_selectedGroup) == 1 ? string.Empty : "s")
+                        </span>
                     </div>
                 </div>
             }
 
-            @* ── Grouped Settings ── *@
-            <div class="grouped-settings-header">
-                <h4>Grouped Settings</h4>
-                @if (IsAdmin)
+            <div class="grouped-settings-section-shell">
+                <div class="grouped-settings-header">
+                    <h4>Grouped Settings</h4>
+                    @if (IsAdmin)
+                    {
+                        <RadzenButton Text="Add Grouped Setting" Icon="add_circle_outline" ButtonStyle="ButtonStyle.Secondary"
+                                      Size="ButtonSize.Small" Click="@AddGroupedSetting" />
+                    }
+                </div>
+
+                @if (_selectedGroup.GroupedSettings.Any())
                 {
-                    <RadzenButton Text="Add Grouped Setting" Icon="add_circle_outline" ButtonStyle="ButtonStyle.Secondary"
-                                  Size="ButtonSize.Small" Click="@AddGroupedSetting" />
-                }
-            </div>
+                    <div class="grouped-settings-list">
+                        @foreach (var groupedSetting in _selectedGroup.GroupedSettings)
+                        {
+                            var isEditing = ReferenceEquals(_editingGroupedSetting, groupedSetting);
 
-            @if (_selectedGroup.GroupedSettings.Any())
-            {
-                @foreach (var gs in _selectedGroup.GroupedSettings)
-                {
-                    var isEditing = ReferenceEquals(_editingGroupedSetting, gs);
-                    var cardColor = !string.IsNullOrWhiteSpace(gs.CategoryColor) && gs.CategoryColor != "#00000000"
-                        ? gs.CategoryColor
-                        : "var(--rz-primary)";
-
-                    <RadzenCard class="grouped-setting-card">
-                        <div class="colored-line" style="background-color: @cardColor;"></div>
-                        <div class="card-inner">
-
-                            @if (isEditing)
-                            {
-                                @* ── Edit mode ── *@
-                                <div class="gs-edit-form">
-                                    <label>Setting Name</label>
-                                    <RadzenTextBox @bind-Value="_gsEditName" Placeholder="Setting name"
-                                                   Style="width: 100%;" />
-                                    <label>Description</label>
-                                    <RadzenTextBox @bind-Value="_gsEditDescription" Placeholder="Description (optional)"
-                                                   Style="width: 100%;" />
-                                    <div class="gs-edit-row">
-                                        <div>
-                                            <label>Category</label>
-                                            <RadzenTextBox @bind-Value="_gsEditCategoryName" Placeholder="Category"
+                            <RadzenCard class="grouped-setting-card custom-card">
+                                <div class="card-inner">
+                                    @if (isEditing)
+                                    {
+                                        <div class="gs-edit-form">
+                                            <label>Grouped Setting Name</label>
+                                            <RadzenTextBox @bind-Value="_gsEditName" Placeholder="Setting name"
                                                            Style="width: 100%;" />
-                                        </div>
-                                        <div>
-                                            <label>Category Color</label>
-                                            <div class="color-picker-row">
-                                                <div class="color-preview"
-                                                     style="background-color: @(string.IsNullOrWhiteSpace(_gsEditCategoryColor) ? "#00000000" : _gsEditCategoryColor);">
-                                                </div>
-                                                <RadzenColorPicker @bind-Value="_gsEditCategoryColor"
-                                                                   ShowHSV="true" ShowRGBA="true" ShowColors="true" ShowButton="true"
-                                                                   Style="display: inline-block;" />
+
+                                            <label>Description</label>
+                                            <RadzenTextArea @bind-Value="_gsEditDescription" Placeholder="Description (optional)"
+                                                            Style="width: 100%;" Rows="3" />
+
+                                            <div class="gs-derived-note">
+                                                <RadzenIcon Icon="info" Style="font-size: 1rem;" />
+                                                <span>Top source setting controls inherited category and validation.</span>
+                                            </div>
+
+                                            <div class="gs-edit-actions">
+                                                <RadzenButton Text="Save" Icon="check" ButtonStyle="ButtonStyle.Primary"
+                                                              Size="ButtonSize.Small" Click="@SaveSettingEdit" />
+                                                <RadzenButton Text="Cancel" Icon="close" ButtonStyle="ButtonStyle.Light"
+                                                              Size="ButtonSize.Small" Click="@CancelSettingEdit" />
                                             </div>
                                         </div>
-                                    </div>
-                                    <div class="gs-edit-actions">
-                                        <RadzenButton Text="Save" Icon="check" ButtonStyle="ButtonStyle.Primary"
-                                                      Size="ButtonSize.Small" Click="@SaveSettingEdit" />
-                                        <RadzenButton Text="Cancel" Icon="close" ButtonStyle="ButtonStyle.Light"
-                                                      Size="ButtonSize.Small" Click="@CancelSettingEdit" />
-                                    </div>
-                                </div>
-                            }
-                            else
-                            {
-                                @* ── Display mode ── *@
-                                <div class="gs-display-header">
-                                    <div style="flex: 1;">
-                                        <div class="gs-display-name">@gs.Name</div>
-                                        @if (!string.IsNullOrWhiteSpace(gs.Description))
-                                        {
-                                            <div class="gs-display-description">@gs.Description</div>
-                                        }
-                                        <div class="gs-display-category">
-                                            @if (!string.IsNullOrWhiteSpace(gs.CategoryName))
+                                    }
+                                    else
+                                    {
+                                        <div class="gs-display-header">
+                                            <div class="gs-display-copy">
+                                                <div class="gs-display-name">@groupedSetting.Name</div>
+                                                @if (!string.IsNullOrWhiteSpace(groupedSetting.Description))
+                                                {
+                                                    <div class="gs-display-description">@groupedSetting.Description</div>
+                                                }
+                                                <div class="gs-metadata-row">
+                                                    @if (!string.IsNullOrWhiteSpace(groupedSetting.CategoryName))
+                                                    {
+                                                        <span class="category-chip">
+                                                            <span class="category-dot" style="background-color: @(groupedSetting.CategoryColor ?? "transparent");"></span>
+                                                            @groupedSetting.CategoryName
+                                                        </span>
+                                                    }
+                                                    else
+                                                    {
+                                                        <span class="category-chip muted">No category</span>
+                                                    }
+                                                </div>
+                                            </div>
+                                            <div class="gs-card-actions">
+                                                @if (IsAdmin)
+                                                {
+                                                    <RadzenButton Icon="edit" ButtonStyle="ButtonStyle.Light"
+                                                                  Size="ButtonSize.ExtraSmall" Class="groups-icon-button"
+                                                                  Click="@(() => StartSettingEdit(groupedSetting))" />
+                                                    <RadzenButton Icon="delete_outline" ButtonStyle="ButtonStyle.Danger"
+                                                                  Size="ButtonSize.ExtraSmall" Class="groups-icon-button"
+                                                                  Click="@(() => RemoveGroupedSetting(groupedSetting))" />
+                                                }
+                                            </div>
+                                        </div>
+                                    }
+
+                                    <div class="source-settings-section">
+                                        <div class="source-settings-top">
+                                            <div class="source-settings-label">Source Settings (@groupedSetting.SourceSettings.Count)</div>
+                                        </div>
+
+                                        <div class="source-settings-list">
+                                            @for (var index = 0; index < groupedSetting.SourceSettings.Count; index++)
                                             {
-                                                <span class="category-dot" style="background-color: @(gs.CategoryColor ?? "transparent");"></span>
-                                                @gs.CategoryName
-                                            }
-                                            else
-                                            {
-                                                <span style="opacity: 0.4; font-style: italic;">No category</span>
+                                                var currentIndex = index;
+                                                var sourceSetting = groupedSetting.SourceSettings[currentIndex];
+
+                                                <div class="source-setting-chip">
+                                                    <div class="source-setting-chip-leading">
+                                                        <span class="source-setting-order">@(currentIndex + 1)</span>
+                                                    </div>
+                                                    <div class="source-setting-chip-body">
+                                                        <div class="source-setting-chip-title">
+                                                            <span class="client-name">@sourceSetting.ClientName</span>
+                                                            <span class="arrow">→</span>
+                                                            <span class="setting-name">@sourceSetting.SettingName</span>
+                                                        </div>
+                                                    </div>
+                                                    @if (IsAdmin)
+                                                    {
+                                                        <div class="source-setting-actions">
+                                                            <RadzenButton Icon="arrow_upward" ButtonStyle="ButtonStyle.Light"
+                                                                          Size="ButtonSize.ExtraSmall" Class="groups-icon-button"
+                                                                          Disabled="@(currentIndex == 0)"
+                                                                          Click="@(() => MoveSourceSettingUp(groupedSetting, currentIndex))" />
+                                                            <RadzenButton Icon="arrow_downward" ButtonStyle="ButtonStyle.Light"
+                                                                          Size="ButtonSize.ExtraSmall" Class="groups-icon-button"
+                                                                          Disabled="@(currentIndex == groupedSetting.SourceSettings.Count - 1)"
+                                                                          Click="@(() => MoveSourceSettingDown(groupedSetting, currentIndex))" />
+                                                            <RadzenButton Icon="close" ButtonStyle="ButtonStyle.Light"
+                                                                          Size="ButtonSize.ExtraSmall" Class="groups-icon-button"
+                                                                          Click="@(() => RemoveSourceSetting(groupedSetting, sourceSetting))" />
+                                                        </div>
+                                                    }
+                                                </div>
                                             }
                                         </div>
-                                    </div>
-                                    <div class="gs-card-actions">
+
                                         @if (IsAdmin)
                                         {
-                                            <RadzenButton Icon="edit" ButtonStyle="ButtonStyle.Light"
-                                                          Size="ButtonSize.ExtraSmall" Variant="Variant.Text"
-                                                          Click="@(() => StartSettingEdit(gs))"
-                                                          MouseEnter="@(args => ShowTooltip(args, "Edit setting"))" />
-                                            <RadzenButton Icon="delete_outline" ButtonStyle="ButtonStyle.Danger"
-                                                          Size="ButtonSize.ExtraSmall" Variant="Variant.Text"
-                                                          Click="@(() => RemoveGroupedSetting(gs))"
-                                                          MouseEnter="@(args => ShowTooltip(args, "Remove grouped setting"))" />
+                                            <RadzenButton Text="Add Source Setting" Icon="add_circle_outline" ButtonStyle="ButtonStyle.Secondary"
+                                                          Size="ButtonSize.ExtraSmall" Class="add-source-button"
+                                                          Click="@(() => AddSourceSetting(groupedSetting))" />
                                         }
                                     </div>
                                 </div>
-                            }
-
-                            @* ── Source Settings (always visible) ── *@
-                            <div class="source-settings-section">
-                                <div class="source-settings-label">Source Settings (@gs.SourceSettings.Count)</div>
-                                @foreach (var ss in gs.SourceSettings)
-                                {
-                                    <div class="source-setting-chip">
-                                        <RadzenIcon Icon="settings" Style="font-size: 14px; margin-right: 6px; color: rgba(255,255,255,0.35);" />
-                                        <span class="client-name">@ss.ClientName</span>
-                                        <span class="arrow">→</span>
-                                        <span class="setting-name" style="flex: 1;">@ss.SettingName</span>
-                                        @if (IsAdmin)
-                                        {
-                                            <RadzenButton Icon="close" ButtonStyle="ButtonStyle.Light"
-                                                          Size="ButtonSize.ExtraSmall" Variant="Variant.Text"
-                                                          Click="@(() => RemoveSourceSetting(gs, ss))"
-                                                          MouseEnter="@(args => ShowTooltip(args, "Remove source setting"))" />
-                                        }
-                                    </div>
-                                }
-                                @if (IsAdmin)
-                                {
-                                    <RadzenButton Text="Add Source Setting" Icon="add_circle_outline" ButtonStyle="ButtonStyle.Secondary"
-                                                  Size="ButtonSize.ExtraSmall" Style="margin-top: 4px;"
-                                                  Click="@(() => AddSourceSetting(gs))" />
-                                }
+                            </RadzenCard>
+                        }
+                    </div>
+                }
+                else
+                {
+                    <div class="empty-state-settings">
+                        <div class="empty-card compact">
+                            <div class="empty-icon">
+                                <RadzenIcon Icon="tune" Style="font-size: 2rem;" />
                             </div>
+                            <div class="empty-title">No grouped settings yet</div>
+                            <div class="empty-subtitle">Add a grouped setting to start composing shared values from source settings.</div>
                         </div>
-                    </RadzenCard>
-                }
-            }
-            else
-            {
-                <div class="empty-state-settings">
-                    <RadzenIcon Icon="folder_open" Style="font-size: 48px;" />
-                    <p>No grouped settings yet. Click "Add Grouped Setting" to start.</p>
-                </div>
-            }
-
-            @* ── Footer Metadata ── *@
-            <div class="group-footer">
-                @if (_selectedGroup.CreatedAt != default)
-                {
-                    <span>Created: @_selectedGroup.CreatedAt.ToLocalTime().ToString("g")</span>
-                }
-                @if (!string.IsNullOrWhiteSpace(_selectedGroup.LastModifiedBy))
-                {
-                    <span>Last modified by: @_selectedGroup.LastModifiedBy</span>
+                    </div>
                 }
             </div>
+
         }
         else
         {
             <div class="empty-state">
-                <div>
-                    <RadzenIcon Icon="group_work" Style="font-size: 64px;" />
-                    <p>Select a group or create a new one</p>
+                <div class="empty-card">
+                    <div class="empty-icon">
+                        <RadzenIcon Icon="group_work" Style="font-size: 2rem;" />
+                    </div>
+                    <div class="empty-title">Select a group</div>
+                    <div class="empty-subtitle">Choose a group from the left to edit grouped settings, reorder source settings, and save changes.</div>
                 </div>
             </div>
         }
-    </div>
+    </section>
 </div>

--- a/src/web/Fig.Web/Pages/Groups.razor
+++ b/src/web/Fig.Web/Pages/Groups.razor
@@ -1,0 +1,197 @@
+@page "/groups"
+@using Microsoft.AspNetCore.Authorization
+@attribute [Authorize]
+@using Fig.Contracts.SettingGroups
+@using Fig.Web.Facades
+@using Fig.Web.Pages.Dialogs
+@using Fig.Web.Services
+
+<PageTitle>Fig - Groups</PageTitle>
+
+<div style="display: flex; height: calc(100vh - 80px);">
+    @* Left Panel - Group List *@
+    <div style="width: 25%; min-width: 200px; border-right: 1px solid var(--rz-base-300); overflow-y: auto; padding: 10px;">
+        <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
+            <h4 style="margin: 0;">Groups</h4>
+            @if (IsAdmin)
+            {
+                <RadzenButton Icon="add" ButtonStyle="ButtonStyle.Primary" Size="ButtonSize.Small"
+                              Click="@AddGroup" title="Add Group" />
+            }
+        </div>
+
+        <RadzenTextBox Placeholder="Filter groups..." @bind-Value="_filterText"
+                       Style="width: 100%; margin-bottom: 10px;"
+                       Change="@(_ => StateHasChanged())" />
+
+        @if (_loading)
+        {
+            <RadzenProgressBarCircular ShowValue="false" Mode="ProgressBarMode.Indeterminate" Size="ProgressBarCircularSize.Medium" />
+        }
+        else
+        {
+            @foreach (var group in FilteredGroups)
+            {
+                <div style="padding: 8px 12px; cursor: pointer; border-radius: 4px; margin-bottom: 4px;
+                            background: @(group.Id == _selectedGroup?.Id ? "var(--rz-primary-lighter)" : "transparent");"
+                     @onclick="() => SelectGroup(group)">
+                    <div style="font-weight: 500;">@group.Name</div>
+                    <div style="font-size: 0.85em; color: var(--rz-text-tertiary-color);">
+                        @group.GroupedSettings.Count setting(s)
+                    </div>
+                </div>
+            }
+
+            @if (!FilteredGroups.Any())
+            {
+                <div style="padding: 20px; text-align: center; color: var(--rz-text-tertiary-color);">
+                    @if (_groups.Any())
+                    {
+                        <span>No groups match filter</span>
+                    }
+                    else
+                    {
+                        <span>No groups defined</span>
+                    }
+                </div>
+            }
+        }
+    </div>
+
+    @* Right Panel - Group Details *@
+    <div style="flex: 1; overflow-y: auto; padding: 20px;">
+        @if (_selectedGroup != null)
+        {
+            <div style="display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 20px;">
+                <div style="flex: 1;">
+                    @if (IsAdmin)
+                    {
+                        <RadzenTextBox @bind-Value="_selectedGroup.Name" Placeholder="Group Name"
+                                       Style="font-size: 1.4em; font-weight: 600; width: 100%; margin-bottom: 8px;" />
+                        <RadzenTextArea @bind-Value="_selectedGroup.Description" Placeholder="Group description (optional)"
+                                        Style="width: 100%;" Rows="2" />
+                    }
+                    else
+                    {
+                        <h3 style="margin: 0 0 8px 0;">@_selectedGroup.Name</h3>
+                        @if (!string.IsNullOrWhiteSpace(_selectedGroup.Description))
+                        {
+                            <p style="color: var(--rz-text-secondary-color); margin: 0;">@_selectedGroup.Description</p>
+                        }
+                    }
+                </div>
+                @if (IsAdmin)
+                {
+                    <div style="display: flex; gap: 8px; margin-left: 16px;">
+                        <RadzenButton Text="Save" Icon="save" ButtonStyle="ButtonStyle.Primary"
+                                      Click="@SaveGroup" />
+                        <RadzenButton Text="Delete" Icon="delete" ButtonStyle="ButtonStyle.Danger"
+                                      Click="@DeleteGroup" />
+                    </div>
+                }
+            </div>
+
+            <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px;">
+                <h4 style="margin: 0;">Grouped Settings</h4>
+                @if (IsAdmin)
+                {
+                    <RadzenButton Text="Add Grouped Setting" Icon="add" ButtonStyle="ButtonStyle.Light"
+                                  Size="ButtonSize.Small" Click="@AddGroupedSetting" />
+                }
+            </div>
+
+            @if (_selectedGroup.GroupedSettings.Any())
+            {
+                @foreach (var gs in _selectedGroup.GroupedSettings)
+                {
+                    <RadzenCard Style="margin-bottom: 12px;">
+                        <div style="display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 8px;">
+                            <div style="flex: 1;">
+                                @if (IsAdmin)
+                                {
+                                    <RadzenTextBox @bind-Value="gs.Name" Placeholder="Setting name"
+                                                   Style="font-weight: 500; margin-bottom: 4px; width: 100%;" />
+                                    <RadzenTextBox @bind-Value="gs.Description" Placeholder="Description (optional)"
+                                                   Style="font-size: 0.9em; width: 100%;" />
+                                }
+                                else
+                                {
+                                    <div style="font-weight: 500;">@gs.Name</div>
+                                    @if (!string.IsNullOrWhiteSpace(gs.Description))
+                                    {
+                                        <div style="font-size: 0.9em; color: var(--rz-text-secondary-color);">@gs.Description</div>
+                                    }
+                                }
+                            </div>
+                            <div style="display: flex; align-items: center; gap: 8px; margin-left: 12px;">
+                                <RadzenBadge Text="@gs.ValueType" IsPill="true" />
+                                @if (IsAdmin)
+                                {
+                                    <RadzenButton Icon="delete_outline" ButtonStyle="ButtonStyle.Danger"
+                                                  Size="ButtonSize.ExtraSmall" Variant="Variant.Text"
+                                                  Click="@(() => RemoveGroupedSetting(gs))" title="Remove grouped setting" />
+                                }
+                            </div>
+                        </div>
+
+                        <div style="margin-top: 8px;">
+                            <div style="font-size: 0.85em; font-weight: 500; color: var(--rz-text-secondary-color); margin-bottom: 4px;">
+                                Source Settings (@gs.SourceSettings.Count)
+                            </div>
+                            @foreach (var ss in gs.SourceSettings)
+                            {
+                                <div style="display: flex; align-items: center; padding: 4px 8px; margin-bottom: 2px;
+                                            background: var(--rz-base-200); border-radius: 4px;">
+                                    <RadzenIcon Icon="settings" Style="font-size: 14px; margin-right: 6px; color: var(--rz-text-tertiary-color);" />
+                                    <span style="flex: 1;">
+                                        <strong>@ss.ClientName</strong> &rarr; @ss.SettingName
+                                    </span>
+                                    @if (IsAdmin)
+                                    {
+                                        <RadzenButton Icon="close" ButtonStyle="ButtonStyle.Light"
+                                                      Size="ButtonSize.ExtraSmall" Variant="Variant.Text"
+                                                      Click="@(() => RemoveSourceSetting(gs, ss))" title="Remove" />
+                                    }
+                                </div>
+                            }
+                            @if (IsAdmin)
+                            {
+                                <RadzenButton Text="Add Source Setting" Icon="add" ButtonStyle="ButtonStyle.Light"
+                                              Size="ButtonSize.ExtraSmall" Style="margin-top: 4px;"
+                                              Click="@(() => AddSourceSetting(gs))" />
+                            }
+                        </div>
+                    </RadzenCard>
+                }
+            }
+            else
+            {
+                <div style="text-align: center; padding: 40px; color: var(--rz-text-tertiary-color);">
+                    <RadzenIcon Icon="folder_open" Style="font-size: 48px;" />
+                    <p>No grouped settings yet. Add some to get started.</p>
+                </div>
+            }
+
+            <div style="margin-top: 16px; font-size: 0.85em; color: var(--rz-text-tertiary-color);">
+                @if (_selectedGroup.CreatedAt != default)
+                {
+                    <span>Created: @_selectedGroup.CreatedAt.ToLocalTime().ToString("g")</span>
+                }
+                @if (!string.IsNullOrWhiteSpace(_selectedGroup.LastModifiedBy))
+                {
+                    <span style="margin-left: 16px;">Last modified by: @_selectedGroup.LastModifiedBy</span>
+                }
+            </div>
+        }
+        else
+        {
+            <div style="display: flex; align-items: center; justify-content: center; height: 100%;
+                        color: var(--rz-text-tertiary-color);">
+                <div style="text-align: center;">
+                    <RadzenIcon Icon="group_work" Style="font-size: 64px;" />
+                    <p>Select a group from the list or create a new one</p>
+                </div>
+            </div>
+        }
+    </div>
+</div>

--- a/src/web/Fig.Web/Pages/Groups.razor
+++ b/src/web/Fig.Web/Pages/Groups.razor
@@ -15,8 +15,9 @@
             <h4>Groups</h4>
             @if (IsAdmin)
             {
-                <RadzenButton Icon="add" ButtonStyle="ButtonStyle.Primary" Size="ButtonSize.Small"
-                              Click="@AddGroup" title="Add Group" />
+                <RadzenButton Icon="add_circle_outline" ButtonStyle="ButtonStyle.Secondary" Size="ButtonSize.Small"
+                              Click="@AddGroup"
+                              MouseEnter="@(args => ShowTooltip(args, "Add Group"))" />
             }
         </div>
 
@@ -39,11 +40,17 @@
                     @{
                         var g = (SettingGroupDataContract)context;
                     }
-                    <div class="group-list-item">
-                        <RadzenIcon Icon="folder" Size="1.2rem" class="group-icon" />
-                        <div class="group-list-item-info">
-                            <div class="group-list-item-name">@g.Name</div>
-                            <div class="group-list-item-count">@g.GroupedSettings.Count setting(s)</div>
+                    <div class="d-flex group-list-item">
+                        <div class="p-1">
+                            <RadzenIcon Icon="folder" Size="1.2rem" class="group-icon"
+                                        Style="color: var(--rz-text-color); opacity: 0.8;" />
+                        </div>
+                        <div class="p-1">
+                            <RadzenBadge Text="@g.GroupedSettings.Count.ToString()"
+                                         IsPill="true" BadgeStyle="BadgeStyle.Success" />
+                        </div>
+                        <div class="flex-grow-1 p-1 group-list-item-text">
+                            <div class="group-name">@g.Name</div>
                         </div>
                     </div>
                 </Template>
@@ -89,12 +96,15 @@
                             {
                                 <RadzenButton Icon="edit" ButtonStyle="ButtonStyle.Light"
                                               Size="ButtonSize.Small" Variant="Variant.Text"
-                                              Click="@StartHeaderEdit" title="Edit name and description" />
-                                <RadzenButton Icon="save" ButtonStyle="ButtonStyle.Primary"
-                                              Size="ButtonSize.Small" Click="@SaveGroup" title="Save group" />
+                                              Click="@StartHeaderEdit"
+                                              MouseEnter="@(args => ShowTooltip(args, "Edit name and description"))" />
+                                <RadzenButton Icon="save" ButtonStyle="ButtonStyle.Success"
+                                              Size="ButtonSize.Small" Click="@SaveGroup"
+                                              MouseEnter="@(args => ShowTooltip(args, "Save group"))" />
                                 <RadzenButton Icon="delete" ButtonStyle="ButtonStyle.Danger"
                                               Size="ButtonSize.Small" Variant="Variant.Text"
-                                              Click="@DeleteGroup" title="Delete group" />
+                                              Click="@DeleteGroup"
+                                              MouseEnter="@(args => ShowTooltip(args, "Delete group"))" />
                             }
                         </div>
                     </div>
@@ -106,7 +116,7 @@
                 <h4>Grouped Settings</h4>
                 @if (IsAdmin)
                 {
-                    <RadzenButton Text="Add Grouped Setting" Icon="add" ButtonStyle="ButtonStyle.Light"
+                    <RadzenButton Text="Add Grouped Setting" Icon="add_circle_outline" ButtonStyle="ButtonStyle.Secondary"
                                   Size="ButtonSize.Small" Click="@AddGroupedSetting" />
                 }
             </div>
@@ -147,7 +157,7 @@
                                                      style="background-color: @(string.IsNullOrWhiteSpace(_gsEditCategoryColor) ? "#00000000" : _gsEditCategoryColor);">
                                                 </div>
                                                 <RadzenColorPicker @bind-Value="_gsEditCategoryColor"
-                                                                   ShowHSV="false" ShowRGBA="false" ShowColors="true" ShowButton="false"
+                                                                   ShowHSV="true" ShowRGBA="true" ShowColors="true" ShowButton="true"
                                                                    Style="display: inline-block;" />
                                             </div>
                                         </div>
@@ -170,23 +180,29 @@
                                         {
                                             <div class="gs-display-description">@gs.Description</div>
                                         }
-                                        @if (!string.IsNullOrWhiteSpace(gs.CategoryName))
-                                        {
-                                            <div class="gs-display-category">
+                                        <div class="gs-display-category">
+                                            @if (!string.IsNullOrWhiteSpace(gs.CategoryName))
+                                            {
                                                 <span class="category-dot" style="background-color: @(gs.CategoryColor ?? "transparent");"></span>
                                                 @gs.CategoryName
-                                            </div>
-                                        }
+                                            }
+                                            else
+                                            {
+                                                <span style="opacity: 0.4; font-style: italic;">No category</span>
+                                            }
+                                        </div>
                                     </div>
                                     <div class="gs-card-actions">
                                         @if (IsAdmin)
                                         {
                                             <RadzenButton Icon="edit" ButtonStyle="ButtonStyle.Light"
                                                           Size="ButtonSize.ExtraSmall" Variant="Variant.Text"
-                                                          Click="@(() => StartSettingEdit(gs))" title="Edit setting" />
+                                                          Click="@(() => StartSettingEdit(gs))"
+                                                          MouseEnter="@(args => ShowTooltip(args, "Edit setting"))" />
                                             <RadzenButton Icon="delete_outline" ButtonStyle="ButtonStyle.Danger"
                                                           Size="ButtonSize.ExtraSmall" Variant="Variant.Text"
-                                                          Click="@(() => RemoveGroupedSetting(gs))" title="Remove" />
+                                                          Click="@(() => RemoveGroupedSetting(gs))"
+                                                          MouseEnter="@(args => ShowTooltip(args, "Remove grouped setting"))" />
                                         }
                                     </div>
                                 </div>
@@ -206,13 +222,14 @@
                                         {
                                             <RadzenButton Icon="close" ButtonStyle="ButtonStyle.Light"
                                                           Size="ButtonSize.ExtraSmall" Variant="Variant.Text"
-                                                          Click="@(() => RemoveSourceSetting(gs, ss))" title="Remove" />
+                                                          Click="@(() => RemoveSourceSetting(gs, ss))"
+                                                          MouseEnter="@(args => ShowTooltip(args, "Remove source setting"))" />
                                         }
                                     </div>
                                 }
                                 @if (IsAdmin)
                                 {
-                                    <RadzenButton Text="Add Source Setting" Icon="add" ButtonStyle="ButtonStyle.Light"
+                                    <RadzenButton Text="Add Source Setting" Icon="add_circle_outline" ButtonStyle="ButtonStyle.Secondary"
                                                   Size="ButtonSize.ExtraSmall" Style="margin-top: 4px;"
                                                   Click="@(() => AddSourceSetting(gs))" />
                                 }

--- a/src/web/Fig.Web/Pages/Groups.razor
+++ b/src/web/Fig.Web/Pages/Groups.razor
@@ -10,24 +10,23 @@
 
 <div class="groups-container">
     <aside class="groups-list-panel">
-        <div class="groups-list-header">
-            <div>
-                <h4>Groups</h4>
-                <p class="groups-list-subtitle">
-                    @(_groups.Count == 0
-                        ? "Create a group to organize shared settings."
-                        : $"{_groups.Count} group{(_groups.Count == 1 ? string.Empty : "s")}")
-                </p>
-            </div>
-            @if (IsAdmin)
-            {
-                <RadzenButton Icon="add_circle_outline" ButtonStyle="ButtonStyle.Secondary" Size="ButtonSize.Small"
-                              Class="groups-header-button"
-                              Click="@AddGroup" />
-            }
-        </div>
-
         <div class="groups-list-shell">
+            <div class="groups-list-toolbar">
+                <label class="groups-filter-shell" aria-label="Filter groups">
+                    <RadzenIcon Icon="search" class="groups-filter-icon" />
+                    <input class="rz-textbox groups-filter-input"
+                           placeholder="Filter groups"
+                           @bind="_groupFilterText"
+                           @bind:event="oninput" />
+                </label>
+                @if (IsAdmin)
+                {
+                    <RadzenButton Icon="add_circle_outline" ButtonStyle="ButtonStyle.Secondary" Size="ButtonSize.Small"
+                                  Class="groups-header-button"
+                                  Click="@AddGroup" />
+                }
+            </div>
+
             @if (_loading)
             {
                 <div class="groups-loading-state">
@@ -35,45 +34,54 @@
                                                Size="ProgressBarCircularSize.Medium" />
                 </div>
             }
-            else if (_groups.Any())
+            else if (FilteredGroups.Any())
             {
-                <RadzenListBox AllowFiltering="true" @bind-Value="_selectedGroup"
-                               FilterCaseSensitivity="FilterCaseSensitivity.CaseInsensitive"
-                               TValue="SettingGroupDataContract" Data="@_groups"
-                               TextProperty="Name"
-                               Class="groups-listbox"
-                               Change="@OnGroupSelected">
-                    <Template>
-                        @{
-                            var group = (SettingGroupDataContract)context;
-                            var groupedSettingCount = group.GroupedSettings.Count;
-                        }
-                        <div class="group-list-item">
-                            <div class="group-list-icon-shell">
-                                <RadzenIcon Icon="folder" Size="1.2rem" class="group-icon"
-                                            Style="color: var(--rz-text-color); opacity: 0.85;" />
-                            </div>
-                            <div class="group-list-item-content">
-                                <div class="group-list-item-top">
+                <div class="groups-list-body">
+                    <RadzenListBox @bind-Value="_selectedGroup"
+                                   TValue="SettingGroupDataContract" Data="@FilteredGroups"
+                                   TextProperty="Name"
+                                   Class="groups-listbox"
+                                   Style="height: 100%; width: 100%;"
+                                   Change="@OnGroupSelected">
+                        <Template>
+                            @{
+                                var group = (SettingGroupDataContract)context;
+                                var groupedSettingCount = group.GroupedSettings.Count;
+                            }
+                            <div class="group-list-item">
+                                <div class="group-list-icon-shell">
+                                    <RadzenIcon Icon="folder" Size="1.2rem" class="group-icon"
+                                                Style="color: var(--rz-text-color); opacity: 0.85;" />
+                                </div>
+                                <div class="group-list-item-content">
                                     <div class="group-name">@group.Name</div>
+                                    @if (!string.IsNullOrWhiteSpace(group.Description))
+                                    {
+                                        <div class="group-list-item-description">@group.Description</div>
+                                    }
+                                    else
+                                    {
+                                        <div class="group-list-item-meta">
+                                            @groupedSettingCount grouped setting@(groupedSettingCount == 1 ? string.Empty : "s")
+                                        </div>
+                                    }
+                                </div>
+                                <div class="group-list-item-badge">
                                     <RadzenBadge Text="@groupedSettingCount.ToString()"
                                                  IsPill="true"
                                                  BadgeStyle="BadgeStyle.Success" />
                                 </div>
-                                @if (!string.IsNullOrWhiteSpace(group.Description))
-                                {
-                                    <div class="group-list-item-description">@group.Description</div>
-                                }
-                                else
-                                {
-                                    <div class="group-list-item-meta">
-                                        @groupedSettingCount grouped setting@(groupedSettingCount == 1 ? string.Empty : "s")
-                                    </div>
-                                }
                             </div>
-                        </div>
-                    </Template>
-                </RadzenListBox>
+                        </Template>
+                    </RadzenListBox>
+                </div>
+            }
+            else if (_groups.Any())
+            {
+                <div class="sidebar-empty-state">
+                    <RadzenIcon Icon="manage_search" Style="font-size: 2rem;" />
+                    <p>No groups match your filter.</p>
+                </div>
             }
             else
             {
@@ -111,7 +119,6 @@
                 <div class="group-overview-card">
                     <div class="group-overview-header">
                         <div class="group-overview-copy">
-                            <div class="group-overview-eyebrow">Setting Group</div>
                             <h2>@_selectedGroup.Name</h2>
                             <p>
                                 @if (!string.IsNullOrWhiteSpace(_selectedGroup.Description))
@@ -169,6 +176,7 @@
                             var isEditing = ReferenceEquals(_editingGroupedSetting, groupedSetting);
 
                             <RadzenCard class="grouped-setting-card custom-card">
+                                <div class="grouped-setting-accent" style="background-color: @(groupedSetting.CategoryColor ?? "transparent");"></div>
                                 <div class="card-inner">
                                     @if (isEditing)
                                     {
@@ -203,39 +211,30 @@
                                                 {
                                                     <div class="gs-display-description">@groupedSetting.Description</div>
                                                 }
-                                                <div class="gs-metadata-row">
-                                                    @if (!string.IsNullOrWhiteSpace(groupedSetting.CategoryName))
+                                            </div>
+                                            <div class="gs-header-right">
+                                                @if (!string.IsNullOrWhiteSpace(groupedSetting.CategoryName))
+                                                {
+                                                    <div class="gs-category-label" style="color: @(groupedSetting.CategoryColor ?? "rgba(255, 255, 255, 0.62)");">
+                                                        @groupedSetting.CategoryName
+                                                    </div>
+                                                }
+                                                <div class="gs-card-actions">
+                                                    @if (IsAdmin)
                                                     {
-                                                        <span class="category-chip">
-                                                            <span class="category-dot" style="background-color: @(groupedSetting.CategoryColor ?? "transparent");"></span>
-                                                            @groupedSetting.CategoryName
-                                                        </span>
-                                                    }
-                                                    else
-                                                    {
-                                                        <span class="category-chip muted">No category</span>
+                                                        <RadzenButton Icon="edit" ButtonStyle="ButtonStyle.Light"
+                                                                      Size="ButtonSize.Small" Class="groups-icon-button"
+                                                                      Click="@(() => StartSettingEdit(groupedSetting))" />
+                                                        <RadzenButton Icon="delete_outline" ButtonStyle="ButtonStyle.Danger"
+                                                                      Size="ButtonSize.Small" Class="groups-icon-button"
+                                                                      Click="@(() => RemoveGroupedSetting(groupedSetting))" />
                                                     }
                                                 </div>
-                                            </div>
-                                            <div class="gs-card-actions">
-                                                @if (IsAdmin)
-                                                {
-                                                    <RadzenButton Icon="edit" ButtonStyle="ButtonStyle.Light"
-                                                                  Size="ButtonSize.ExtraSmall" Class="groups-icon-button"
-                                                                  Click="@(() => StartSettingEdit(groupedSetting))" />
-                                                    <RadzenButton Icon="delete_outline" ButtonStyle="ButtonStyle.Danger"
-                                                                  Size="ButtonSize.ExtraSmall" Class="groups-icon-button"
-                                                                  Click="@(() => RemoveGroupedSetting(groupedSetting))" />
-                                                }
                                             </div>
                                         </div>
                                     }
 
                                     <div class="source-settings-section">
-                                        <div class="source-settings-top">
-                                            <div class="source-settings-label">Source Settings (@groupedSetting.SourceSettings.Count)</div>
-                                        </div>
-
                                         <div class="source-settings-list">
                                             @for (var index = 0; index < groupedSetting.SourceSettings.Count; index++)
                                             {
@@ -271,12 +270,12 @@
                                                     }
                                                 </div>
                                             }
-                                        </div>
+                                            </div>
 
                                         @if (IsAdmin)
                                         {
                                             <RadzenButton Text="Add Source Setting" Icon="add_circle_outline" ButtonStyle="ButtonStyle.Secondary"
-                                                          Size="ButtonSize.ExtraSmall" Class="add-source-button"
+                                                          Size="ButtonSize.Small" Class="add-source-button"
                                                           Click="@(() => AddSourceSetting(groupedSetting))" />
                                         }
                                     </div>

--- a/src/web/Fig.Web/Pages/Groups.razor
+++ b/src/web/Fig.Web/Pages/Groups.razor
@@ -1,5 +1,6 @@
 @page "/groups"
 @using Microsoft.AspNetCore.Authorization
+@using Microsoft.AspNetCore.Components.Routing
 @attribute [Authorize]
 @using Fig.Contracts.SettingGroups
 @using Fig.Web.Facades
@@ -7,6 +8,7 @@
 @using Fig.Web.Services
 
 <PageTitle>Fig - Groups</PageTitle>
+<NavigationLock ConfirmExternalNavigation="false" OnBeforeInternalNavigation="OnBeforeInternalNavigation" />
 
 <div class="groups-container">
     <aside class="groups-list-panel">
@@ -36,12 +38,12 @@
             else if (FilteredGroups.Any())
             {
                 <div class="groups-list-body">
-                    <RadzenListBox @bind-Value="_selectedGroup"
-                                   TValue="SettingGroupDataContract" Data="@FilteredGroups"
-                                   TextProperty="Name"
-                                   Class="groups-listbox"
-                                   Style="height: 100%; width: 100%;"
-                                   Change="@OnGroupSelected">
+                    <RadzenListBox Value="@_selectedGroup"
+                                    TValue="SettingGroupDataContract" Data="@FilteredGroups"
+                                    TextProperty="Name"
+                                    Class="groups-listbox"
+                                    Style="height: 100%; width: 100%;"
+                                    Change="@(value => OnGroupSelectionChanged(value as SettingGroupDataContract))">
                         <Template>
                             @{
                                 var group = (SettingGroupDataContract)context;
@@ -67,8 +69,12 @@
                                 </div>
                                 <div class="group-list-item-badge">
                                     <RadzenBadge Text="@groupedSettingCount.ToString()"
-                                                 IsPill="true"
-                                                 BadgeStyle="BadgeStyle.Success" />
+                                                  IsPill="true"
+                                                  BadgeStyle="BadgeStyle.Success" />
+                                    @if (IsGroupDirty(group))
+                                    {
+                                        <span class="group-pending-indicator" title="This group has unsaved changes"></span>
+                                    }
                                 </div>
                             </div>
                         </Template>
@@ -119,9 +125,9 @@
                     <div class="group-overview-header">
                         <div class="group-overview-copy">
                             <h2>@_selectedGroup.Name</h2>
-                            <p>
-                                @if (!string.IsNullOrWhiteSpace(_selectedGroup.Description))
-                                {
+                             <p>
+                                 @if (!string.IsNullOrWhiteSpace(_selectedGroup.Description))
+                                 {
                                     @_selectedGroup.Description
                                 }
                                 else
@@ -130,32 +136,39 @@
                                 }
                             </p>
                         </div>
-                        <div class="group-header-actions">
-                            @if (IsAdmin)
-                            {
-                                <RadzenButton Icon="edit" ButtonStyle="ButtonStyle.Light"
-                                              Size="ButtonSize.Small" Class="groups-icon-button"
-                                              Click="@StartHeaderEdit" />
-                                <RadzenButton Icon="save" ButtonStyle="ButtonStyle.Success"
-                                              Size="ButtonSize.Small" Class="groups-icon-button"
-                                              Click="@SaveGroup" />
-                                <RadzenButton Icon="delete" ButtonStyle="ButtonStyle.Danger"
-                                              Size="ButtonSize.Small" Class="groups-icon-button"
-                                              Click="@DeleteGroup" />
+                         <div class="group-header-actions">
+                             @if (IsAdmin)
+                             {
+                                 <RadzenButton Icon="edit" ButtonStyle="ButtonStyle.Light"
+                                               Size="ButtonSize.Small" Class="groups-icon-button"
+                                               Click="@StartHeaderEdit" />
+                                 <RadzenButton Text="@GetSaveButtonText()" Icon="save"
+                                               ButtonStyle="@(HasPendingChanges ? ButtonStyle.Warning : ButtonStyle.Success)"
+                                               Size="ButtonSize.Small" Class="group-save-button"
+                                               Disabled="@(!HasPendingChanges)"
+                                               Click="@SaveGroup" />
+                                 <RadzenButton Icon="delete" ButtonStyle="ButtonStyle.Danger"
+                                               Size="ButtonSize.Small" Class="groups-icon-button"
+                                               Click="@DeleteGroup" />
                             }
                         </div>
                     </div>
 
-                    <div class="group-overview-stats">
-                        <span class="meta-chip">
-                            @_selectedGroup.GroupedSettings.Count grouped setting@(_selectedGroup.GroupedSettings.Count == 1 ? string.Empty : "s")
+                     <div class="group-overview-stats">
+                         <span class="meta-chip">
+                             @_selectedGroup.GroupedSettings.Count grouped setting@(_selectedGroup.GroupedSettings.Count == 1 ? string.Empty : "s")
                         </span>
-                        <span class="meta-chip">
-                            @GetTotalSourceSettingCount(_selectedGroup) source setting@(GetTotalSourceSettingCount(_selectedGroup) == 1 ? string.Empty : "s")
-                        </span>
-                    </div>
-                </div>
-            }
+                         <span class="meta-chip">
+                             @GetTotalSourceSettingCount(_selectedGroup) source setting@(GetTotalSourceSettingCount(_selectedGroup) == 1 ? string.Empty : "s")
+                         </span>
+                         <span class="meta-chip @(HasPendingChanges ? "meta-chip-pending" : "meta-chip-clean")">
+                             <RadzenIcon Icon="@(HasPendingChanges ? "edit" : "check_circle")"
+                                         Style="font-size: 1rem; margin-right: 6px;" />
+                             @(HasPendingChanges ? GetPendingChangeSummary() : "No unsaved changes")
+                         </span>
+                     </div>
+                 </div>
+             }
 
             <div class="grouped-settings-section-shell">
                 <div class="grouped-settings-header">

--- a/src/web/Fig.Web/Pages/Groups.razor
+++ b/src/web/Fig.Web/Pages/Groups.razor
@@ -8,11 +8,11 @@
 
 <PageTitle>Fig - Groups</PageTitle>
 
-<div style="display: flex; height: calc(100vh - 80px);">
-    @* Left Panel - Group List *@
-    <div style="width: 25%; min-width: 200px; border-right: 1px solid var(--rz-base-300); overflow-y: auto; padding: 10px;">
-        <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px;">
-            <h4 style="margin: 0;">Groups</h4>
+<div class="groups-container">
+    @* Left Panel — Group List (RadzenListBox with instant filtering) *@
+    <div class="groups-list-panel">
+        <div class="groups-list-header">
+            <h4>Groups</h4>
             @if (IsAdmin)
             {
                 <RadzenButton Icon="add" ButtonStyle="ButtonStyle.Primary" Size="ButtonSize.Small"
@@ -20,79 +20,90 @@
             }
         </div>
 
-        <RadzenTextBox Placeholder="Filter groups..." @bind-Value="_filterText"
-                       Style="width: 100%; margin-bottom: 10px;"
-                       Change="@(_ => StateHasChanged())" />
-
         @if (_loading)
         {
-            <RadzenProgressBarCircular ShowValue="false" Mode="ProgressBarMode.Indeterminate" Size="ProgressBarCircularSize.Medium" />
+            <div style="padding: 24px; text-align: center;">
+                <RadzenProgressBarCircular ShowValue="false" Mode="ProgressBarMode.Indeterminate"
+                                           Size="ProgressBarCircularSize.Medium" />
+            </div>
         }
         else
         {
-            @foreach (var group in FilteredGroups)
-            {
-                <div style="padding: 8px 12px; cursor: pointer; border-radius: 4px; margin-bottom: 4px;
-                            background: @(group.Id == _selectedGroup?.Id ? "var(--rz-primary-lighter)" : "transparent");"
-                     @onclick="() => SelectGroup(group)">
-                    <div style="font-weight: 500;">@group.Name</div>
-                    <div style="font-size: 0.85em; color: var(--rz-text-tertiary-color);">
-                        @group.GroupedSettings.Count setting(s)
+            <RadzenListBox AllowFiltering="true" @bind-Value="_selectedGroup"
+                           FilterCaseSensitivity="FilterCaseSensitivity.CaseInsensitive"
+                           TValue="SettingGroupDataContract" Data="@_groups"
+                           TextProperty="Name"
+                           Class="groups-listbox"
+                           Change="@OnGroupSelected">
+                <Template>
+                    @{
+                        var g = (SettingGroupDataContract)context;
+                    }
+                    <div class="group-list-item">
+                        <RadzenIcon Icon="folder" Size="1.2rem" class="group-icon" />
+                        <div class="group-list-item-info">
+                            <div class="group-list-item-name">@g.Name</div>
+                            <div class="group-list-item-count">@g.GroupedSettings.Count setting(s)</div>
+                        </div>
                     </div>
-                </div>
-            }
-
-            @if (!FilteredGroups.Any())
-            {
-                <div style="padding: 20px; text-align: center; color: var(--rz-text-tertiary-color);">
-                    @if (_groups.Any())
-                    {
-                        <span>No groups match filter</span>
-                    }
-                    else
-                    {
-                        <span>No groups defined</span>
-                    }
-                </div>
-            }
+                </Template>
+            </RadzenListBox>
         }
     </div>
 
-    @* Right Panel - Group Details *@
-    <div style="flex: 1; overflow-y: auto; padding: 20px;">
+    @* Right Panel — Group Details *@
+    <div class="groups-detail-panel">
         @if (_selectedGroup != null)
         {
-            <div style="display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 20px;">
-                <div style="flex: 1;">
-                    @if (IsAdmin)
-                    {
-                        <RadzenTextBox @bind-Value="_selectedGroup.Name" Placeholder="Group Name"
-                                       Style="font-size: 1.4em; font-weight: 600; width: 100%; margin-bottom: 8px;" />
-                        <RadzenTextArea @bind-Value="_selectedGroup.Description" Placeholder="Group description (optional)"
-                                        Style="width: 100%;" Rows="2" />
-                    }
-                    else
-                    {
-                        <h3 style="margin: 0 0 8px 0;">@_selectedGroup.Name</h3>
-                        @if (!string.IsNullOrWhiteSpace(_selectedGroup.Description))
-                        {
-                            <p style="color: var(--rz-text-secondary-color); margin: 0;">@_selectedGroup.Description</p>
-                        }
-                    }
-                </div>
-                @if (IsAdmin)
-                {
-                    <div style="display: flex; gap: 8px; margin-left: 16px;">
-                        <RadzenButton Text="Save" Icon="save" ButtonStyle="ButtonStyle.Primary"
-                                      Click="@SaveGroup" />
-                        <RadzenButton Text="Delete" Icon="delete" ButtonStyle="ButtonStyle.Danger"
-                                      Click="@DeleteGroup" />
+            @* ── Group Header ── *@
+            @if (_editingHeader)
+            {
+                <div class="group-header-edit">
+                    <label>Group Name</label>
+                    <RadzenTextBox @bind-Value="_editName" Placeholder="Group name"
+                                   Style="width: 100%; font-size: 1.1rem; font-weight: 600;" />
+                    <label>Description</label>
+                    <RadzenTextArea @bind-Value="_editDescription" Placeholder="Group description (optional)"
+                                    Style="width: 100%;" Rows="2" />
+                    <div class="group-header-edit-actions">
+                        <RadzenButton Text="Save" Icon="check" ButtonStyle="ButtonStyle.Primary"
+                                      Size="ButtonSize.Small" Click="@SaveHeaderEdit" />
+                        <RadzenButton Text="Cancel" Icon="close" ButtonStyle="ButtonStyle.Light"
+                                      Size="ButtonSize.Small" Click="@CancelHeaderEdit" />
                     </div>
-                }
-            </div>
+                </div>
+            }
+            else
+            {
+                <div class="group-header-display">
+                    <div style="display: flex; justify-content: space-between; align-items: flex-start;">
+                        <div style="flex: 1;">
+                            <h2>@_selectedGroup.Name</h2>
+                            @if (!string.IsNullOrWhiteSpace(_selectedGroup.Description))
+                            {
+                                <p>@_selectedGroup.Description</p>
+                            }
+                        </div>
+                        <div class="group-header-actions">
+                            @if (IsAdmin)
+                            {
+                                <RadzenButton Icon="edit" ButtonStyle="ButtonStyle.Light"
+                                              Size="ButtonSize.Small" Variant="Variant.Text"
+                                              Click="@StartHeaderEdit" title="Edit name and description" />
+                                <RadzenButton Icon="save" ButtonStyle="ButtonStyle.Primary"
+                                              Size="ButtonSize.Small" Click="@SaveGroup" title="Save group" />
+                                <RadzenButton Icon="delete" ButtonStyle="ButtonStyle.Danger"
+                                              Size="ButtonSize.Small" Variant="Variant.Text"
+                                              Click="@DeleteGroup" title="Delete group" />
+                            }
+                        </div>
+                    </div>
+                </div>
+            }
 
-            <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px;">
-                <h4 style="margin: 0;">Grouped Settings</h4>
+            @* ── Grouped Settings ── *@
+            <div class="grouped-settings-header">
+                <h4>Grouped Settings</h4>
                 @if (IsAdmin)
                 {
                     <RadzenButton Text="Add Grouped Setting" Icon="add" ButtonStyle="ButtonStyle.Light"
@@ -104,92 +115,138 @@
             {
                 @foreach (var gs in _selectedGroup.GroupedSettings)
                 {
-                    <RadzenCard Style="margin-bottom: 12px;">
-                        <div style="display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 8px;">
-                            <div style="flex: 1;">
-                                @if (IsAdmin)
-                                {
-                                    <RadzenTextBox @bind-Value="gs.Name" Placeholder="Setting name"
-                                                   Style="font-weight: 500; margin-bottom: 4px; width: 100%;" />
-                                    <RadzenTextBox @bind-Value="gs.Description" Placeholder="Description (optional)"
-                                                   Style="font-size: 0.9em; width: 100%;" />
-                                }
-                                else
-                                {
-                                    <div style="font-weight: 500;">@gs.Name</div>
-                                    @if (!string.IsNullOrWhiteSpace(gs.Description))
-                                    {
-                                        <div style="font-size: 0.9em; color: var(--rz-text-secondary-color);">@gs.Description</div>
-                                    }
-                                }
-                            </div>
-                            <div style="display: flex; align-items: center; gap: 8px; margin-left: 12px;">
-                                <RadzenBadge Text="@gs.ValueType" IsPill="true" />
-                                @if (IsAdmin)
-                                {
-                                    <RadzenButton Icon="delete_outline" ButtonStyle="ButtonStyle.Danger"
-                                                  Size="ButtonSize.ExtraSmall" Variant="Variant.Text"
-                                                  Click="@(() => RemoveGroupedSetting(gs))" title="Remove grouped setting" />
-                                }
-                            </div>
-                        </div>
+                    var isEditing = ReferenceEquals(_editingGroupedSetting, gs);
+                    var cardColor = !string.IsNullOrWhiteSpace(gs.CategoryColor) && gs.CategoryColor != "#00000000"
+                        ? gs.CategoryColor
+                        : "var(--rz-primary)";
 
-                        <div style="margin-top: 8px;">
-                            <div style="font-size: 0.85em; font-weight: 500; color: var(--rz-text-secondary-color); margin-bottom: 4px;">
-                                Source Settings (@gs.SourceSettings.Count)
-                            </div>
-                            @foreach (var ss in gs.SourceSettings)
+                    <RadzenCard class="grouped-setting-card">
+                        <div class="colored-line" style="background-color: @cardColor;"></div>
+                        <div class="card-inner">
+
+                            @if (isEditing)
                             {
-                                <div style="display: flex; align-items: center; padding: 4px 8px; margin-bottom: 2px;
-                                            background: var(--rz-base-200); border-radius: 4px;">
-                                    <RadzenIcon Icon="settings" Style="font-size: 14px; margin-right: 6px; color: var(--rz-text-tertiary-color);" />
-                                    <span style="flex: 1;">
-                                        <strong>@ss.ClientName</strong> &rarr; @ss.SettingName
-                                    </span>
-                                    @if (IsAdmin)
-                                    {
-                                        <RadzenButton Icon="close" ButtonStyle="ButtonStyle.Light"
-                                                      Size="ButtonSize.ExtraSmall" Variant="Variant.Text"
-                                                      Click="@(() => RemoveSourceSetting(gs, ss))" title="Remove" />
-                                    }
+                                @* ── Edit mode ── *@
+                                <div class="gs-edit-form">
+                                    <label>Setting Name</label>
+                                    <RadzenTextBox @bind-Value="_gsEditName" Placeholder="Setting name"
+                                                   Style="width: 100%;" />
+                                    <label>Description</label>
+                                    <RadzenTextBox @bind-Value="_gsEditDescription" Placeholder="Description (optional)"
+                                                   Style="width: 100%;" />
+                                    <div class="gs-edit-row">
+                                        <div>
+                                            <label>Category</label>
+                                            <RadzenTextBox @bind-Value="_gsEditCategoryName" Placeholder="Category"
+                                                           Style="width: 100%;" />
+                                        </div>
+                                        <div>
+                                            <label>Category Color</label>
+                                            <div class="color-picker-row">
+                                                <div class="color-preview"
+                                                     style="background-color: @(string.IsNullOrWhiteSpace(_gsEditCategoryColor) ? "#00000000" : _gsEditCategoryColor);">
+                                                </div>
+                                                <RadzenColorPicker @bind-Value="_gsEditCategoryColor"
+                                                                   ShowHSV="false" ShowRGBA="false" ShowColors="true" ShowButton="false"
+                                                                   Style="display: inline-block;" />
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="gs-edit-actions">
+                                        <RadzenButton Text="Save" Icon="check" ButtonStyle="ButtonStyle.Primary"
+                                                      Size="ButtonSize.Small" Click="@SaveSettingEdit" />
+                                        <RadzenButton Text="Cancel" Icon="close" ButtonStyle="ButtonStyle.Light"
+                                                      Size="ButtonSize.Small" Click="@CancelSettingEdit" />
+                                    </div>
                                 </div>
                             }
-                            @if (IsAdmin)
+                            else
                             {
-                                <RadzenButton Text="Add Source Setting" Icon="add" ButtonStyle="ButtonStyle.Light"
-                                              Size="ButtonSize.ExtraSmall" Style="margin-top: 4px;"
-                                              Click="@(() => AddSourceSetting(gs))" />
+                                @* ── Display mode ── *@
+                                <div class="gs-display-header">
+                                    <div style="flex: 1;">
+                                        <div class="gs-display-name">@gs.Name</div>
+                                        @if (!string.IsNullOrWhiteSpace(gs.Description))
+                                        {
+                                            <div class="gs-display-description">@gs.Description</div>
+                                        }
+                                        @if (!string.IsNullOrWhiteSpace(gs.CategoryName))
+                                        {
+                                            <div class="gs-display-category">
+                                                <span class="category-dot" style="background-color: @(gs.CategoryColor ?? "transparent");"></span>
+                                                @gs.CategoryName
+                                            </div>
+                                        }
+                                    </div>
+                                    <div class="gs-card-actions">
+                                        @if (IsAdmin)
+                                        {
+                                            <RadzenButton Icon="edit" ButtonStyle="ButtonStyle.Light"
+                                                          Size="ButtonSize.ExtraSmall" Variant="Variant.Text"
+                                                          Click="@(() => StartSettingEdit(gs))" title="Edit setting" />
+                                            <RadzenButton Icon="delete_outline" ButtonStyle="ButtonStyle.Danger"
+                                                          Size="ButtonSize.ExtraSmall" Variant="Variant.Text"
+                                                          Click="@(() => RemoveGroupedSetting(gs))" title="Remove" />
+                                        }
+                                    </div>
+                                </div>
                             }
+
+                            @* ── Source Settings (always visible) ── *@
+                            <div class="source-settings-section">
+                                <div class="source-settings-label">Source Settings (@gs.SourceSettings.Count)</div>
+                                @foreach (var ss in gs.SourceSettings)
+                                {
+                                    <div class="source-setting-chip">
+                                        <RadzenIcon Icon="settings" Style="font-size: 14px; margin-right: 6px; color: rgba(255,255,255,0.35);" />
+                                        <span class="client-name">@ss.ClientName</span>
+                                        <span class="arrow">→</span>
+                                        <span class="setting-name" style="flex: 1;">@ss.SettingName</span>
+                                        @if (IsAdmin)
+                                        {
+                                            <RadzenButton Icon="close" ButtonStyle="ButtonStyle.Light"
+                                                          Size="ButtonSize.ExtraSmall" Variant="Variant.Text"
+                                                          Click="@(() => RemoveSourceSetting(gs, ss))" title="Remove" />
+                                        }
+                                    </div>
+                                }
+                                @if (IsAdmin)
+                                {
+                                    <RadzenButton Text="Add Source Setting" Icon="add" ButtonStyle="ButtonStyle.Light"
+                                                  Size="ButtonSize.ExtraSmall" Style="margin-top: 4px;"
+                                                  Click="@(() => AddSourceSetting(gs))" />
+                                }
+                            </div>
                         </div>
                     </RadzenCard>
                 }
             }
             else
             {
-                <div style="text-align: center; padding: 40px; color: var(--rz-text-tertiary-color);">
+                <div class="empty-state-settings">
                     <RadzenIcon Icon="folder_open" Style="font-size: 48px;" />
-                    <p>No grouped settings yet. Add some to get started.</p>
+                    <p>No grouped settings yet. Click "Add Grouped Setting" to start.</p>
                 </div>
             }
 
-            <div style="margin-top: 16px; font-size: 0.85em; color: var(--rz-text-tertiary-color);">
+            @* ── Footer Metadata ── *@
+            <div class="group-footer">
                 @if (_selectedGroup.CreatedAt != default)
                 {
                     <span>Created: @_selectedGroup.CreatedAt.ToLocalTime().ToString("g")</span>
                 }
                 @if (!string.IsNullOrWhiteSpace(_selectedGroup.LastModifiedBy))
                 {
-                    <span style="margin-left: 16px;">Last modified by: @_selectedGroup.LastModifiedBy</span>
+                    <span>Last modified by: @_selectedGroup.LastModifiedBy</span>
                 }
             </div>
         }
         else
         {
-            <div style="display: flex; align-items: center; justify-content: center; height: 100%;
-                        color: var(--rz-text-tertiary-color);">
-                <div style="text-align: center;">
+            <div class="empty-state">
+                <div>
                     <RadzenIcon Icon="group_work" Style="font-size: 64px;" />
-                    <p>Select a group from the list or create a new one</p>
+                    <p>Select a group or create a new one</p>
                 </div>
             </div>
         }

--- a/src/web/Fig.Web/Pages/Groups.razor
+++ b/src/web/Fig.Web/Pages/Groups.razor
@@ -13,8 +13,7 @@
         <div class="groups-list-shell">
             <div class="groups-list-toolbar">
                 <label class="groups-filter-shell" aria-label="Filter groups">
-                    <RadzenIcon Icon="search" class="groups-filter-icon" />
-                    <input class="rz-textbox groups-filter-input"
+                    <input class="groups-filter-input"
                            placeholder="Filter groups"
                            @bind="_groupFilterText"
                            @bind:event="oninput" />

--- a/src/web/Fig.Web/Pages/Groups.razor.cs
+++ b/src/web/Fig.Web/Pages/Groups.razor.cs
@@ -26,6 +26,7 @@ public partial class Groups : ComponentBase
     private List<SettingGroupDataContract> _groups = new();
     private SettingGroupDataContract? _selectedGroup;
     private bool _loading = true;
+    private string _groupFilterText = string.Empty;
 
     // Header edit state
     private bool _editingHeader;
@@ -38,6 +39,10 @@ public partial class Groups : ComponentBase
     private string _gsEditDescription = string.Empty;
 
     private bool IsAdmin => AccountService.AuthenticatedUser?.Role == Role.Administrator;
+    private IEnumerable<SettingGroupDataContract> FilteredGroups => string.IsNullOrWhiteSpace(_groupFilterText)
+        ? _groups
+        : _groups.Where(group =>
+            group.Name.Contains(_groupFilterText, StringComparison.OrdinalIgnoreCase));
 
     protected override async Task OnInitializedAsync()
     {

--- a/src/web/Fig.Web/Pages/Groups.razor.cs
+++ b/src/web/Fig.Web/Pages/Groups.razor.cs
@@ -1,6 +1,7 @@
 using Fig.Contracts.Authentication;
 using Fig.Contracts.SettingGroups;
 using Fig.Web.Facades;
+using Fig.Web.Models.Setting;
 using Fig.Web.Pages.Dialogs;
 using Fig.Web.Services;
 using Microsoft.AspNetCore.Components;
@@ -10,6 +11,8 @@ namespace Fig.Web.Pages;
 
 public partial class Groups : ComponentBase
 {
+    private const string TransparentColor = "#00000000";
+
     [Inject] private IGroupsFacade GroupsFacade { get; set; } = null!;
 
     [Inject] private ISettingClientFacade SettingClientFacade { get; set; } = null!;
@@ -19,8 +22,6 @@ public partial class Groups : ComponentBase
     [Inject] private DialogService DialogService { get; set; } = null!;
 
     [Inject] private NotificationService NotificationService { get; set; } = null!;
-
-    [Inject] private TooltipService TooltipService { get; set; } = null!;
 
     private List<SettingGroupDataContract> _groups = new();
     private SettingGroupDataContract? _selectedGroup;
@@ -35,8 +36,6 @@ public partial class Groups : ComponentBase
     private GroupedSettingDataContract? _editingGroupedSetting;
     private string _gsEditName = string.Empty;
     private string _gsEditDescription = string.Empty;
-    private string _gsEditCategoryName = string.Empty;
-    private string _gsEditCategoryColor = string.Empty;
 
     private bool IsAdmin => AccountService.AuthenticatedUser?.Role == Role.Administrator;
 
@@ -57,6 +56,7 @@ public partial class Groups : ComponentBase
         try
         {
             _groups = await GroupsFacade.GetAllGroups();
+            NormalizeGroups(_groups);
             _groups = _groups.OrderBy(g => g.Name).ToList();
 
             if (_selectedGroup != null)
@@ -73,7 +73,6 @@ public partial class Groups : ComponentBase
 
     private void OnGroupSelected()
     {
-        // Reset edit states when selecting a different group
         _editingHeader = false;
         _editingGroupedSetting = null;
     }
@@ -109,7 +108,10 @@ public partial class Groups : ComponentBase
 
     private async Task SaveGroup()
     {
-        if (_selectedGroup == null) return;
+        if (_selectedGroup == null)
+            return;
+
+        NormalizeGroup(_selectedGroup);
 
         var result = await GroupsFacade.UpdateGroup(_selectedGroup);
         if (result != null)
@@ -127,7 +129,8 @@ public partial class Groups : ComponentBase
 
     private async Task DeleteGroup()
     {
-        if (_selectedGroup?.Id == null) return;
+        if (_selectedGroup?.Id == null)
+            return;
 
         var confirm = await DialogService.Confirm(
             $"Are you sure you want to delete the group '{_selectedGroup.Name}'? Settings will retain their values but will no longer be grouped.",
@@ -160,7 +163,9 @@ public partial class Groups : ComponentBase
 
     private void SaveHeaderEdit()
     {
-        if (_selectedGroup == null) return;
+        if (_selectedGroup == null)
+            return;
+
         _selectedGroup.Name = _editName;
         _selectedGroup.Description = _editDescription;
         _editingHeader = false;
@@ -173,23 +178,26 @@ public partial class Groups : ComponentBase
 
     // ── Grouped setting edit mode ──
 
-    private void StartSettingEdit(GroupedSettingDataContract gs)
+    private void StartSettingEdit(GroupedSettingDataContract groupedSetting)
     {
-        _editingGroupedSetting = gs;
-        _gsEditName = gs.Name;
-        _gsEditDescription = gs.Description ?? string.Empty;
-        _gsEditCategoryName = gs.CategoryName ?? string.Empty;
-        _gsEditCategoryColor = gs.CategoryColor ?? string.Empty;
+        _editingGroupedSetting = groupedSetting;
+        _gsEditName = groupedSetting.Name;
+        _gsEditDescription = groupedSetting.Description ?? string.Empty;
     }
 
     private void SaveSettingEdit()
     {
-        if (_editingGroupedSetting == null) return;
+        if (_editingGroupedSetting == null)
+            return;
 
-        _editingGroupedSetting.Name = _gsEditName;
-        _editingGroupedSetting.Description = string.IsNullOrWhiteSpace(_gsEditDescription) ? null : _gsEditDescription;
-        _editingGroupedSetting.CategoryName = string.IsNullOrWhiteSpace(_gsEditCategoryName) ? null : _gsEditCategoryName;
-        _editingGroupedSetting.CategoryColor = string.IsNullOrWhiteSpace(_gsEditCategoryColor) ? null : _gsEditCategoryColor;
+        var primarySourceName = GetSourceDerivedName(_editingGroupedSetting.SourceSettings.FirstOrDefault());
+        _editingGroupedSetting.Name = string.IsNullOrWhiteSpace(_gsEditName)
+            ? primarySourceName
+            : _gsEditName.Trim();
+        _editingGroupedSetting.Description = string.IsNullOrWhiteSpace(_gsEditDescription)
+            ? null
+            : _gsEditDescription.Trim();
+        ApplyGroupedSettingDerivedMetadata(_editingGroupedSetting);
         _editingGroupedSetting = null;
     }
 
@@ -202,21 +210,21 @@ public partial class Groups : ComponentBase
 
     private async Task AddGroupedSetting()
     {
-        if (_selectedGroup == null) return;
+        if (_selectedGroup == null)
+            return;
 
-        // Step 1: open source setting selection first
         var allGroupedSourceSettings = _groups
             .SelectMany(g => g.GroupedSettings)
-            .SelectMany(s => s.SourceSettings)
-            .Select(s => $"{s.ClientName}|{s.SettingName}")
+            .SelectMany(setting => setting.SourceSettings)
+            .Select(setting => $"{setting.ClientName}|{setting.SettingName}")
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
         var availableSettings = SettingClientFacade.SettingClients
-            .Where(c => !c.IsGroup && c.Instance == null)
-            .SelectMany(c => c.Settings.Select(s => new SourceSettingDataContract(c.Name, s.Name)))
-            .Where(s => !allGroupedSourceSettings.Contains($"{s.ClientName}|{s.SettingName}"))
-            .OrderBy(s => s.ClientName)
-            .ThenBy(s => s.SettingName)
+            .Where(client => !client.IsGroup && client.Instance == null)
+            .SelectMany(client => client.Settings.Select(setting => new SourceSettingDataContract(client.Name, setting.Name)))
+            .Where(setting => !allGroupedSourceSettings.Contains($"{setting.ClientName}|{setting.SettingName}"))
+            .OrderBy(setting => setting.ClientName)
+            .ThenBy(setting => setting.SettingName)
             .ToList();
 
         if (!availableSettings.Any())
@@ -245,51 +253,48 @@ public partial class Groups : ComponentBase
         if (selected is not List<SourceSettingDataContract> selectedSettings || !selectedSettings.Any())
             return;
 
-        // Step 2: auto-populate from first source setting
         var firstSource = selectedSettings.First();
         var templateSetting = FindSetting(firstSource.ClientName, firstSource.SettingName);
+        var valueType = settingValueTypes.TryGetValue($"{firstSource.ClientName}|{firstSource.SettingName}", out var discoveredValueType)
+            ? discoveredValueType
+            : "System.String";
 
-        var valueType = settingValueTypes.TryGetValue($"{firstSource.ClientName}|{firstSource.SettingName}", out var vt)
-            ? vt : "System.String";
-
-        var newGs = new GroupedSettingDataContract(
+        var groupedSetting = new GroupedSettingDataContract(
             templateSetting?.Name ?? firstSource.SettingName,
             templateSetting?.RawDescription,
             valueType,
-            selectedSettings)
-        {
-            CategoryName = templateSetting?.CategoryName,
-            CategoryColor = templateSetting?.CategoryColor
-        };
+            selectedSettings);
 
-        _selectedGroup.GroupedSettings.Add(newGs);
+        ApplyGroupedSettingDerivedMetadata(groupedSetting, forceNameFromPrimarySource: true);
+        _selectedGroup.GroupedSettings.Add(groupedSetting);
         StateHasChanged();
     }
 
-    private void RemoveGroupedSetting(GroupedSettingDataContract gs)
+    private void RemoveGroupedSetting(GroupedSettingDataContract groupedSetting)
     {
-        _selectedGroup?.GroupedSettings.Remove(gs);
-        if (_editingGroupedSetting == gs)
+        _selectedGroup?.GroupedSettings.Remove(groupedSetting);
+        if (_editingGroupedSetting == groupedSetting)
             _editingGroupedSetting = null;
         StateHasChanged();
     }
 
-    private async Task AddSourceSetting(GroupedSettingDataContract gs)
+    private async Task AddSourceSetting(GroupedSettingDataContract groupedSetting)
     {
-        if (_selectedGroup == null) return;
+        if (_selectedGroup == null)
+            return;
 
         var allGroupedSourceSettings = _groups
             .SelectMany(g => g.GroupedSettings)
-            .SelectMany(s => s.SourceSettings)
-            .Select(s => $"{s.ClientName}|{s.SettingName}")
+            .SelectMany(setting => setting.SourceSettings)
+            .Select(setting => $"{setting.ClientName}|{setting.SettingName}")
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
         var availableSettings = SettingClientFacade.SettingClients
-            .Where(c => !c.IsGroup && c.Instance == null)
-            .SelectMany(c => c.Settings.Select(s => new SourceSettingDataContract(c.Name, s.Name)))
-            .Where(s => !allGroupedSourceSettings.Contains($"{s.ClientName}|{s.SettingName}"))
-            .OrderBy(s => s.ClientName)
-            .ThenBy(s => s.SettingName)
+            .Where(client => !client.IsGroup && client.Instance == null)
+            .SelectMany(client => client.Settings.Select(setting => new SourceSettingDataContract(client.Name, setting.Name)))
+            .Where(setting => !allGroupedSourceSettings.Contains($"{setting.ClientName}|{setting.SettingName}"))
+            .OrderBy(setting => setting.ClientName)
+            .ThenBy(setting => setting.SettingName)
             .ToList();
 
         if (!availableSettings.Any())
@@ -310,46 +315,33 @@ public partial class Groups : ComponentBase
             new Dictionary<string, object>
             {
                 { "AvailableSettings", availableSettings },
-                { "ValueTypeFilter", gs.SourceSettings.Any() ? gs.ValueType : null! },
+                { "ValueTypeFilter", groupedSetting.SourceSettings.Any() ? groupedSetting.ValueType : null! },
                 { "SettingValueTypes", settingValueTypes }
             },
             new DialogOptions { Width = "600px", Height = "500px" });
 
-        if (selected is List<SourceSettingDataContract> selectedSettings)
+        if (selected is not List<SourceSettingDataContract> selectedSettings || !selectedSettings.Any())
+            return;
+
+        var previousPrimaryName = GetSourceDerivedName(groupedSetting.SourceSettings.FirstOrDefault());
+
+        foreach (var setting in selectedSettings)
         {
-            foreach (var setting in selectedSettings)
+            if (!groupedSetting.SourceSettings.Any(existing =>
+                    string.Equals(existing.ClientName, setting.ClientName, StringComparison.OrdinalIgnoreCase) &&
+                    string.Equals(existing.SettingName, setting.SettingName, StringComparison.Ordinal)))
             {
-                if (!gs.SourceSettings.Any(s =>
-                        string.Equals(s.ClientName, setting.ClientName, StringComparison.OrdinalIgnoreCase) &&
-                        string.Equals(s.SettingName, setting.SettingName, StringComparison.Ordinal)))
-                {
-                    gs.SourceSettings.Add(setting);
-                }
+                groupedSetting.SourceSettings.Add(setting);
             }
-
-            // Auto-populate name/description/category from first source if this is the first time
-            if (gs.SourceSettings.Count == selectedSettings.Count)
-            {
-                var first = gs.SourceSettings.First();
-                var tmpl = FindSetting(first.ClientName, first.SettingName);
-                if (tmpl != null)
-                {
-                    gs.Name = tmpl.Name;
-                    gs.Description = tmpl.RawDescription;
-                    if (settingValueTypes.TryGetValue($"{first.ClientName}|{first.SettingName}", out var fvt))
-                        gs.ValueType = fvt;
-                    gs.CategoryName ??= tmpl.CategoryName;
-                    gs.CategoryColor ??= tmpl.CategoryColor;
-                }
-            }
-
-            StateHasChanged();
         }
+
+        ApplyGroupedSettingDerivedMetadata(groupedSetting, previousPrimaryName);
+        StateHasChanged();
     }
 
-    private void RemoveSourceSetting(GroupedSettingDataContract gs, SourceSettingDataContract ss)
+    private void RemoveSourceSetting(GroupedSettingDataContract groupedSetting, SourceSettingDataContract sourceSetting)
     {
-        if (gs.SourceSettings.Count <= 1)
+        if (groupedSetting.SourceSettings.Count <= 1)
         {
             NotificationService.Notify(new NotificationMessage
             {
@@ -360,40 +352,162 @@ public partial class Groups : ComponentBase
             return;
         }
 
-        gs.SourceSettings.Remove(ss);
+        var previousPrimaryName = GetSourceDerivedName(groupedSetting.SourceSettings.FirstOrDefault());
+        var removedPrimarySource = MatchesSourceSetting(groupedSetting.SourceSettings.First(), sourceSetting);
+
+        groupedSetting.SourceSettings.Remove(sourceSetting);
+
+        if (removedPrimarySource)
+        {
+            ApplyGroupedSettingDerivedMetadata(groupedSetting, previousPrimaryName);
+        }
+        else
+        {
+            ApplyGroupedSettingDerivedMetadata(groupedSetting);
+        }
+
+        StateHasChanged();
+    }
+
+    private void MoveSourceSettingUp(GroupedSettingDataContract groupedSetting, int index)
+    {
+        MoveSourceSetting(groupedSetting, index, -1);
+    }
+
+    private void MoveSourceSettingDown(GroupedSettingDataContract groupedSetting, int index)
+    {
+        MoveSourceSetting(groupedSetting, index, 1);
+    }
+
+    private void MoveSourceSetting(GroupedSettingDataContract groupedSetting, int index, int offset)
+    {
+        var targetIndex = index + offset;
+        if (targetIndex < 0 || targetIndex >= groupedSetting.SourceSettings.Count)
+            return;
+
+        var previousPrimaryName = GetSourceDerivedName(groupedSetting.SourceSettings.FirstOrDefault());
+        MoveItem(groupedSetting.SourceSettings, index, targetIndex);
+        ApplyGroupedSettingDerivedMetadata(groupedSetting, previousPrimaryName);
         StateHasChanged();
     }
 
     // ── Helpers ──
 
-    private Models.Setting.ISetting? FindSetting(string clientName, string settingName)
+    private static int GetTotalSourceSettingCount(SettingGroupDataContract group)
+    {
+        return group.GroupedSettings.Sum(groupedSetting => groupedSetting.SourceSettings.Count);
+    }
+
+    private void NormalizeGroups(IEnumerable<SettingGroupDataContract> groups)
+    {
+        foreach (var group in groups)
+        {
+            NormalizeGroup(group);
+        }
+    }
+
+    private void NormalizeGroup(SettingGroupDataContract group)
+    {
+        foreach (var groupedSetting in group.GroupedSettings)
+        {
+            ApplyGroupedSettingDerivedMetadata(groupedSetting);
+        }
+    }
+
+    private void ApplyGroupedSettingDerivedMetadata(
+        GroupedSettingDataContract groupedSetting,
+        string? previousDerivedName = null,
+        bool forceNameFromPrimarySource = false)
+    {
+        if (!groupedSetting.SourceSettings.Any())
+            return;
+
+        var firstSource = groupedSetting.SourceSettings.First();
+        var templateSetting = FindSetting(firstSource.ClientName, firstSource.SettingName);
+        var derivedName = templateSetting?.Name ?? firstSource.SettingName;
+
+        if (forceNameFromPrimarySource ||
+            string.IsNullOrWhiteSpace(groupedSetting.Name) ||
+            (!string.IsNullOrWhiteSpace(previousDerivedName) &&
+             string.Equals(groupedSetting.Name, previousDerivedName, StringComparison.Ordinal)))
+        {
+            groupedSetting.Name = derivedName;
+        }
+
+        if (forceNameFromPrimarySource &&
+            string.IsNullOrWhiteSpace(groupedSetting.Description) &&
+            !string.IsNullOrWhiteSpace(templateSetting?.RawDescription))
+        {
+            groupedSetting.Description = templateSetting.RawDescription;
+        }
+
+        groupedSetting.CategoryName = string.IsNullOrWhiteSpace(templateSetting?.CategoryName)
+            ? null
+            : templateSetting.CategoryName;
+        groupedSetting.CategoryColor = NormalizeDerivedColor(templateSetting?.CategoryColor);
+
+        SyncSettingEditState(groupedSetting);
+    }
+
+    private string GetSourceDerivedName(SourceSettingDataContract? sourceSetting)
+    {
+        if (sourceSetting == null)
+            return string.Empty;
+
+        return FindSetting(sourceSetting.ClientName, sourceSetting.SettingName)?.Name ?? sourceSetting.SettingName;
+    }
+
+    private void SyncSettingEditState(GroupedSettingDataContract groupedSetting)
+    {
+        if (!ReferenceEquals(_editingGroupedSetting, groupedSetting))
+            return;
+
+        _gsEditName = groupedSetting.Name;
+        _gsEditDescription = groupedSetting.Description ?? string.Empty;
+    }
+
+    private static string? NormalizeDerivedColor(string? color)
+    {
+        return string.IsNullOrWhiteSpace(color) || color == TransparentColor
+            ? null
+            : color;
+    }
+
+    private static bool MatchesSourceSetting(SourceSettingDataContract left, SourceSettingDataContract right)
+    {
+        return string.Equals(left.ClientName, right.ClientName, StringComparison.OrdinalIgnoreCase) &&
+               string.Equals(left.SettingName, right.SettingName, StringComparison.Ordinal);
+    }
+
+    private static void MoveItem<T>(IList<T> items, int fromIndex, int toIndex)
+    {
+        if (fromIndex == toIndex)
+            return;
+
+        var item = items[fromIndex];
+        items.RemoveAt(fromIndex);
+        items.Insert(toIndex, item);
+    }
+
+    private ISetting? FindSetting(string clientName, string settingName)
     {
         var client = SettingClientFacade.SettingClients
             .FirstOrDefault(c => string.Equals(c.Name, clientName, StringComparison.OrdinalIgnoreCase)
                                  && c.Instance == null && !c.IsGroup);
-        return client?.Settings.FirstOrDefault(s =>
-            string.Equals(s.Name, settingName, StringComparison.Ordinal));
+        return client?.Settings.FirstOrDefault(setting =>
+            string.Equals(setting.Name, settingName, StringComparison.Ordinal));
     }
 
     private Dictionary<string, string> BuildSettingValueTypeLookup()
     {
         return SettingClientFacade.SettingClients
-            .Where(c => !c.IsGroup && c.Instance == null)
-            .SelectMany(c => c.Settings.Select(s => new
+            .Where(client => !client.IsGroup && client.Instance == null)
+            .SelectMany(client => client.Settings.Select(setting => new
             {
-                Key = $"{c.Name}|{s.Name}",
-                ValueType = s.ValueType?.FullName ?? "System.String"
+                Key = $"{client.Name}|{setting.Name}",
+                ValueType = setting.ValueType?.FullName ?? "System.String"
             }))
-            .GroupBy(x => x.Key)
-            .ToDictionary(g => g.Key, g => g.First().ValueType, StringComparer.OrdinalIgnoreCase);
-    }
-
-    private void ShowTooltip(ElementReference element, string text)
-    {
-        TooltipService.Open(element, text, new TooltipOptions
-        {
-            Position = TooltipPosition.Top,
-            Duration = 3000
-        });
+            .GroupBy(item => item.Key)
+            .ToDictionary(grouping => grouping.Key, grouping => grouping.First().ValueType, StringComparer.OrdinalIgnoreCase);
     }
 }

--- a/src/web/Fig.Web/Pages/Groups.razor.cs
+++ b/src/web/Fig.Web/Pages/Groups.razor.cs
@@ -1,0 +1,216 @@
+using Fig.Contracts.Authentication;
+using Fig.Contracts.SettingGroups;
+using Fig.Web.Facades;
+using Fig.Web.Pages.Dialogs;
+using Fig.Web.Services;
+using Microsoft.AspNetCore.Components;
+using Radzen;
+
+namespace Fig.Web.Pages;
+
+public partial class Groups : ComponentBase
+{
+    [Inject] private IGroupsFacade GroupsFacade { get; set; } = null!;
+
+    [Inject] private ISettingClientFacade SettingClientFacade { get; set; } = null!;
+
+    [Inject] private IAccountService AccountService { get; set; } = null!;
+
+    [Inject] private DialogService DialogService { get; set; } = null!;
+
+    [Inject] private NotificationService NotificationService { get; set; } = null!;
+
+    private List<SettingGroupDataContract> _groups = new();
+    private SettingGroupDataContract? _selectedGroup;
+    private string _filterText = string.Empty;
+    private bool _loading = true;
+
+    private bool IsAdmin => AccountService.AuthenticatedUser?.Role == Role.Administrator;
+
+    private IEnumerable<SettingGroupDataContract> FilteredGroups =>
+        string.IsNullOrWhiteSpace(_filterText)
+            ? _groups
+            : _groups.Where(g => g.Name.Contains(_filterText, StringComparison.OrdinalIgnoreCase));
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadGroups();
+        await base.OnInitializedAsync();
+    }
+
+    private async Task LoadGroups()
+    {
+        _loading = true;
+        StateHasChanged();
+
+        try
+        {
+            _groups = await GroupsFacade.GetAllGroups();
+            _groups = _groups.OrderBy(g => g.Name).ToList();
+
+            if (_selectedGroup != null)
+            {
+                _selectedGroup = _groups.FirstOrDefault(g => g.Id == _selectedGroup.Id);
+            }
+        }
+        finally
+        {
+            _loading = false;
+            StateHasChanged();
+        }
+    }
+
+    private void SelectGroup(SettingGroupDataContract group)
+    {
+        _selectedGroup = group;
+    }
+
+    private async Task AddGroup()
+    {
+        var name = await DialogService.OpenAsync<TextPromptDialog>("New Group",
+            new Dictionary<string, object> { { "Prompt", "Enter group name:" } },
+            new DialogOptions { Width = "400px" });
+
+        if (name is string groupName && !string.IsNullOrWhiteSpace(groupName))
+        {
+            var newGroup = new SettingGroupDataContract(
+                null, groupName, null, new List<GroupedSettingDataContract>());
+
+            var created = await GroupsFacade.CreateGroup(newGroup);
+            if (created != null)
+            {
+                NotificationService.Notify(new NotificationMessage
+                {
+                    Severity = NotificationSeverity.Success,
+                    Summary = "Group Created",
+                    Detail = $"Group '{groupName}' created successfully"
+                });
+                await LoadGroups();
+                _selectedGroup = _groups.FirstOrDefault(g => g.Id == created.Id);
+            }
+        }
+    }
+
+    private async Task SaveGroup()
+    {
+        if (_selectedGroup == null) return;
+
+        var result = await GroupsFacade.UpdateGroup(_selectedGroup);
+        if (result != null)
+        {
+            NotificationService.Notify(new NotificationMessage
+            {
+                Severity = NotificationSeverity.Success,
+                Summary = "Group Saved",
+                Detail = $"Group '{_selectedGroup.Name}' saved successfully"
+            });
+            await LoadGroups();
+        }
+    }
+
+    private async Task DeleteGroup()
+    {
+        if (_selectedGroup?.Id == null) return;
+
+        var confirm = await DialogService.Confirm(
+            $"Are you sure you want to delete the group '{_selectedGroup.Name}'? Settings will retain their values but will no longer be grouped.",
+            "Delete Group",
+            new ConfirmOptions { OkButtonText = "Delete", CancelButtonText = "Cancel" });
+
+        if (confirm == true)
+        {
+            await GroupsFacade.DeleteGroup(_selectedGroup.Id.Value);
+            NotificationService.Notify(new NotificationMessage
+            {
+                Severity = NotificationSeverity.Success,
+                Summary = "Group Deleted",
+                Detail = $"Group '{_selectedGroup.Name}' deleted"
+            });
+            _selectedGroup = null;
+            await LoadGroups();
+        }
+    }
+
+    private void AddGroupedSetting()
+    {
+        if (_selectedGroup == null) return;
+
+        _selectedGroup.GroupedSettings.Add(new GroupedSettingDataContract(
+            "New Setting", null, "System.String", new List<SourceSettingDataContract>()));
+        StateHasChanged();
+    }
+
+    private void RemoveGroupedSetting(GroupedSettingDataContract gs)
+    {
+        _selectedGroup?.GroupedSettings.Remove(gs);
+        StateHasChanged();
+    }
+
+    private async Task AddSourceSetting(GroupedSettingDataContract gs)
+    {
+        if (_selectedGroup == null) return;
+
+        var allGroupedSourceSettings = _groups
+            .SelectMany(g => g.GroupedSettings)
+            .SelectMany(s => s.SourceSettings)
+            .Select(s => $"{s.ClientName}|{s.SettingName}")
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var availableSettings = SettingClientFacade.SettingClients
+            .Where(c => !c.IsGroup && c.Instance == null)
+            .SelectMany(c => c.Settings.Select(s => new SourceSettingDataContract(c.Name, s.Name)))
+            .Where(s => !allGroupedSourceSettings.Contains($"{s.ClientName}|{s.SettingName}"))
+            .OrderBy(s => s.ClientName)
+            .ThenBy(s => s.SettingName)
+            .ToList();
+
+        if (!availableSettings.Any())
+        {
+            NotificationService.Notify(new NotificationMessage
+            {
+                Severity = NotificationSeverity.Info,
+                Summary = "No Available Settings",
+                Detail = "All settings are already assigned to groups."
+            });
+            return;
+        }
+
+        // Build a lookup of setting value types for type filtering in the dialog
+        var settingValueTypes = SettingClientFacade.SettingClients
+            .Where(c => !c.IsGroup && c.Instance == null)
+            .SelectMany(c => c.Settings.Select(s => new { Key = $"{c.Name}|{s.Name}", ValueType = s.ValueType?.FullName ?? "System.String" }))
+            .GroupBy(x => x.Key)
+            .ToDictionary(g => g.Key, g => g.First().ValueType, StringComparer.OrdinalIgnoreCase);
+
+        var selected = await DialogService.OpenAsync<SourceSettingSelectionDialog>(
+            "Select Source Settings",
+            new Dictionary<string, object>
+            {
+                { "AvailableSettings", availableSettings },
+                { "ValueTypeFilter", gs.SourceSettings.Any() ? gs.ValueType : null! },
+                { "SettingValueTypes", settingValueTypes }
+            },
+            new DialogOptions { Width = "600px", Height = "500px" });
+
+        if (selected is List<SourceSettingDataContract> selectedSettings)
+        {
+            foreach (var setting in selectedSettings)
+            {
+                if (!gs.SourceSettings.Any(s =>
+                        string.Equals(s.ClientName, setting.ClientName, StringComparison.OrdinalIgnoreCase) &&
+                        string.Equals(s.SettingName, setting.SettingName, StringComparison.Ordinal)))
+                {
+                    gs.SourceSettings.Add(setting);
+                }
+            }
+
+            StateHasChanged();
+        }
+    }
+
+    private void RemoveSourceSetting(GroupedSettingDataContract gs, SourceSettingDataContract ss)
+    {
+        gs.SourceSettings.Remove(ss);
+        StateHasChanged();
+    }
+}

--- a/src/web/Fig.Web/Pages/Groups.razor.cs
+++ b/src/web/Fig.Web/Pages/Groups.razor.cs
@@ -107,6 +107,7 @@ public partial class Groups : ComponentBase
                 SettingClientFacade.MarkGroupsChanged();
                 await LoadGroups();
                 _selectedGroup = _groups.FirstOrDefault(g => g.Id == created.Id);
+                OnGroupSelected();
             }
         }
     }
@@ -169,6 +170,9 @@ public partial class Groups : ComponentBase
     private void SaveHeaderEdit()
     {
         if (_selectedGroup == null)
+            return;
+
+        if (string.IsNullOrWhiteSpace(_editName))
             return;
 
         _selectedGroup.Name = _editName;

--- a/src/web/Fig.Web/Pages/Groups.razor.cs
+++ b/src/web/Fig.Web/Pages/Groups.razor.cs
@@ -20,6 +20,8 @@ public partial class Groups : ComponentBase
 
     [Inject] private NotificationService NotificationService { get; set; } = null!;
 
+    [Inject] private TooltipService TooltipService { get; set; } = null!;
+
     private List<SettingGroupDataContract> _groups = new();
     private SettingGroupDataContract? _selectedGroup;
     private bool _loading = true;
@@ -384,5 +386,14 @@ public partial class Groups : ComponentBase
             }))
             .GroupBy(x => x.Key)
             .ToDictionary(g => g.Key, g => g.First().ValueType, StringComparer.OrdinalIgnoreCase);
+    }
+
+    private void ShowTooltip(ElementReference element, string text)
+    {
+        TooltipService.Open(element, text, new TooltipOptions
+        {
+            Position = TooltipPosition.Top,
+            Duration = 3000
+        });
     }
 }

--- a/src/web/Fig.Web/Pages/Groups.razor.cs
+++ b/src/web/Fig.Web/Pages/Groups.razor.cs
@@ -5,6 +5,8 @@ using Fig.Web.Models.Setting;
 using Fig.Web.Pages.Dialogs;
 using Fig.Web.Services;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Routing;
+using Newtonsoft.Json;
 using Radzen;
 
 namespace Fig.Web.Pages;
@@ -12,12 +14,16 @@ namespace Fig.Web.Pages;
 public partial class Groups : ComponentBase
 {
     private const string TransparentColor = "#00000000";
+    private const string SavePendingChangesResult = "save";
+    private const string DiscardPendingChangesResult = "discard";
 
     [Inject] private IGroupsFacade GroupsFacade { get; set; } = null!;
 
     [Inject] private ISettingClientFacade SettingClientFacade { get; set; } = null!;
 
     [Inject] private IAccountService AccountService { get; set; } = null!;
+
+    [Inject] private NavigationManager NavigationManager { get; set; } = null!;
 
     [Inject] private DialogService DialogService { get; set; } = null!;
 
@@ -37,8 +43,13 @@ public partial class Groups : ComponentBase
     private GroupedSettingDataContract? _editingGroupedSetting;
     private string _gsEditName = string.Empty;
     private string _gsEditDescription = string.Empty;
+    private readonly HashSet<string> _dirtyGroupKeys = new(StringComparer.Ordinal);
+    private Dictionary<string, string> _baselineGroupSnapshots = new(StringComparer.Ordinal);
+    private bool _allowNextNavigation;
 
     private bool IsAdmin => AccountService.AuthenticatedUser?.Role == Role.Administrator;
+    private bool HasPendingChanges => _dirtyGroupKeys.Count > 0 || HasPendingEditorChanges;
+    private bool HasPendingEditorChanges => HasPendingHeaderEdits() || HasPendingGroupedSettingEdits();
     private IEnumerable<SettingGroupDataContract> FilteredGroups => string.IsNullOrWhiteSpace(_groupFilterText)
         ? _groups
         : _groups.Where(group =>
@@ -53,21 +64,22 @@ public partial class Groups : ComponentBase
         await base.OnInitializedAsync();
     }
 
-    private async Task LoadGroups()
+    private async Task LoadGroups(Guid? selectedGroupId = null)
     {
         _loading = true;
         StateHasChanged();
 
         try
         {
+            var restoreSelectionId = selectedGroupId ?? _selectedGroup?.Id;
             _groups = await GroupsFacade.GetAllGroups();
             NormalizeGroups(_groups);
             _groups = _groups.OrderBy(g => g.Name).ToList();
-
-            if (_selectedGroup != null)
-            {
-                _selectedGroup = _groups.FirstOrDefault(g => g.Id == _selectedGroup.Id);
-            }
+            _selectedGroup = restoreSelectionId == null
+                ? null
+                : _groups.FirstOrDefault(g => g.Id == restoreSelectionId);
+            ResetEditModes();
+            CaptureBaseline();
         }
         finally
         {
@@ -76,7 +88,7 @@ public partial class Groups : ComponentBase
         }
     }
 
-    private void OnGroupSelected()
+    private void ResetEditModes()
     {
         _editingHeader = false;
         _editingGroupedSetting = null;
@@ -86,8 +98,11 @@ public partial class Groups : ComponentBase
 
     private async Task AddGroup()
     {
+        if (!await ResolvePendingChanges())
+            return;
+
         var name = await DialogService.OpenAsync<TextPromptDialog>("New Group",
-            new Dictionary<string, object> { { "Prompt", "Enter group name:" } },
+            new Dictionary<string, object?> { { "Prompt", "Enter group name:" } },
             new DialogOptions { Width = "400px" });
 
         if (name is string groupName && !string.IsNullOrWhiteSpace(groupName))
@@ -105,32 +120,44 @@ public partial class Groups : ComponentBase
                     Detail = $"Group '{groupName}' created successfully"
                 });
                 SettingClientFacade.MarkGroupsChanged();
-                await LoadGroups();
-                _selectedGroup = _groups.FirstOrDefault(g => g.Id == created.Id);
-                OnGroupSelected();
+                await LoadGroups(created.Id);
             }
         }
     }
 
     private async Task SaveGroup()
     {
+        await SaveGroupInternal();
+    }
+
+    private async Task<bool> SaveGroupInternal()
+    {
         if (_selectedGroup == null)
-            return;
+            return false;
+
+        if (!TryApplyPendingEditorChanges())
+            return false;
 
         NormalizeGroup(_selectedGroup);
+        RefreshPendingChangeState();
 
+        if (!HasPendingChanges)
+            return true;
+
+        var selectedGroupId = _selectedGroup.Id;
         var result = await GroupsFacade.UpdateGroup(_selectedGroup);
-        if (result != null)
+        if (result == null)
+            return false;
+
+        NotificationService.Notify(new NotificationMessage
         {
-            NotificationService.Notify(new NotificationMessage
-            {
-                Severity = NotificationSeverity.Success,
-                Summary = "Group Saved",
-                Detail = $"Group '{_selectedGroup.Name}' saved successfully"
-            });
-            SettingClientFacade.MarkGroupsChanged();
-            await LoadGroups();
-        }
+            Severity = NotificationSeverity.Success,
+            Summary = "Group Saved",
+            Detail = $"Group '{_selectedGroup.Name}' saved successfully"
+        });
+        SettingClientFacade.MarkGroupsChanged();
+        await LoadGroups(result.Id ?? selectedGroupId);
+        return true;
     }
 
     private async Task DeleteGroup()
@@ -169,15 +196,10 @@ public partial class Groups : ComponentBase
 
     private void SaveHeaderEdit()
     {
-        if (_selectedGroup == null)
+        if (!TryApplyPendingHeaderEdit())
             return;
 
-        if (string.IsNullOrWhiteSpace(_editName))
-            return;
-
-        _selectedGroup.Name = _editName;
-        _selectedGroup.Description = _editDescription;
-        _editingHeader = false;
+        RefreshPendingChangeState();
     }
 
     private void CancelHeaderEdit()
@@ -196,18 +218,8 @@ public partial class Groups : ComponentBase
 
     private void SaveSettingEdit()
     {
-        if (_editingGroupedSetting == null)
-            return;
-
-        var primarySourceName = GetSourceDerivedName(_editingGroupedSetting.SourceSettings.FirstOrDefault());
-        _editingGroupedSetting.Name = string.IsNullOrWhiteSpace(_gsEditName)
-            ? primarySourceName
-            : _gsEditName.Trim();
-        _editingGroupedSetting.Description = string.IsNullOrWhiteSpace(_gsEditDescription)
-            ? null
-            : _gsEditDescription.Trim();
-        ApplyGroupedSettingDerivedMetadata(_editingGroupedSetting);
-        _editingGroupedSetting = null;
+        ApplyPendingGroupedSettingEdit();
+        RefreshPendingChangeState();
     }
 
     private void CancelSettingEdit()
@@ -251,10 +263,10 @@ public partial class Groups : ComponentBase
 
         var selected = await DialogService.OpenAsync<SourceSettingSelectionDialog>(
             "Select Source Settings for New Grouped Setting",
-            new Dictionary<string, object>
+            new Dictionary<string, object?>
             {
                 { "AvailableSettings", availableSettings },
-                { "ValueTypeFilter", null! },
+                { "ValueTypeFilter", null },
                 { "SettingValueTypes", settingValueTypes }
             },
             new DialogOptions { Width = "600px", Height = "500px" });
@@ -276,6 +288,7 @@ public partial class Groups : ComponentBase
 
         ApplyGroupedSettingDerivedMetadata(groupedSetting, forceNameFromPrimarySource: true);
         _selectedGroup.GroupedSettings.Add(groupedSetting);
+        RefreshPendingChangeState();
         StateHasChanged();
     }
 
@@ -284,6 +297,7 @@ public partial class Groups : ComponentBase
         _selectedGroup?.GroupedSettings.Remove(groupedSetting);
         if (_editingGroupedSetting == groupedSetting)
             _editingGroupedSetting = null;
+        RefreshPendingChangeState();
         StateHasChanged();
     }
 
@@ -321,10 +335,10 @@ public partial class Groups : ComponentBase
 
         var selected = await DialogService.OpenAsync<SourceSettingSelectionDialog>(
             "Select Source Settings",
-            new Dictionary<string, object>
+            new Dictionary<string, object?>
             {
                 { "AvailableSettings", availableSettings },
-                { "ValueTypeFilter", groupedSetting.SourceSettings.Any() ? groupedSetting.ValueType : null! },
+                { "ValueTypeFilter", groupedSetting.SourceSettings.Any() ? groupedSetting.ValueType : null },
                 { "SettingValueTypes", settingValueTypes }
             },
             new DialogOptions { Width = "600px", Height = "500px" });
@@ -345,6 +359,7 @@ public partial class Groups : ComponentBase
         }
 
         ApplyGroupedSettingDerivedMetadata(groupedSetting, previousPrimaryName);
+        RefreshPendingChangeState();
         StateHasChanged();
     }
 
@@ -375,6 +390,7 @@ public partial class Groups : ComponentBase
             ApplyGroupedSettingDerivedMetadata(groupedSetting);
         }
 
+        RefreshPendingChangeState();
         StateHasChanged();
     }
 
@@ -397,7 +413,44 @@ public partial class Groups : ComponentBase
         var previousPrimaryName = GetSourceDerivedName(groupedSetting.SourceSettings.FirstOrDefault());
         MoveItem(groupedSetting.SourceSettings, index, targetIndex);
         ApplyGroupedSettingDerivedMetadata(groupedSetting, previousPrimaryName);
+        RefreshPendingChangeState();
         StateHasChanged();
+    }
+
+    private async Task OnGroupSelectionChanged(SettingGroupDataContract? targetGroup)
+    {
+        if (targetGroup == null || targetGroup.Id == _selectedGroup?.Id)
+            return;
+
+        if (!await ResolvePendingChanges())
+        {
+            await InvokeAsync(StateHasChanged);
+            return;
+        }
+
+        _selectedGroup = _groups.FirstOrDefault(group => group.Id == targetGroup.Id);
+        ResetEditModes();
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private async Task OnBeforeInternalNavigation(LocationChangingContext context)
+    {
+        if (_allowNextNavigation)
+        {
+            _allowNextNavigation = false;
+            return;
+        }
+
+        if (!HasPendingChanges || !IsLeavingGroupsPage(context.TargetLocation))
+            return;
+
+        context.PreventNavigation();
+
+        if (!await ResolvePendingChanges())
+            return;
+
+        _allowNextNavigation = true;
+        NavigationManager.NavigateTo(context.TargetLocation);
     }
 
     // ── Helpers ──
@@ -405,6 +458,43 @@ public partial class Groups : ComponentBase
     private static int GetTotalSourceSettingCount(SettingGroupDataContract group)
     {
         return group.GroupedSettings.Sum(groupedSetting => groupedSetting.SourceSettings.Count);
+    }
+
+    private bool IsGroupDirty(SettingGroupDataContract group)
+    {
+        var isSelectedGroupWithPendingEditorChanges =
+            _selectedGroup != null &&
+            group.Id == _selectedGroup.Id &&
+            HasPendingEditorChanges;
+
+        return _dirtyGroupKeys.Contains(GetGroupKey(group)) || isSelectedGroupWithPendingEditorChanges;
+    }
+
+    private string GetPendingChangeSummary()
+    {
+        var pendingGroupCount = GetPendingGroupCount();
+        return pendingGroupCount == 1
+            ? "1 group has unsaved changes"
+            : $"{pendingGroupCount} groups have unsaved changes";
+    }
+
+    private string GetSaveButtonText()
+    {
+        var pendingGroupCount = GetPendingGroupCount();
+        return pendingGroupCount > 0 ? $"Save ({pendingGroupCount})" : "Save";
+    }
+
+    private int GetPendingGroupCount()
+    {
+        var pendingGroupCount = _dirtyGroupKeys.Count;
+        if (_selectedGroup != null &&
+            HasPendingEditorChanges &&
+            !_dirtyGroupKeys.Contains(GetGroupKey(_selectedGroup)))
+        {
+            pendingGroupCount++;
+        }
+
+        return pendingGroupCount;
     }
 
     private void NormalizeGroups(IEnumerable<SettingGroupDataContract> groups)
@@ -420,6 +510,129 @@ public partial class Groups : ComponentBase
         foreach (var groupedSetting in group.GroupedSettings)
         {
             ApplyGroupedSettingDerivedMetadata(groupedSetting);
+        }
+    }
+
+    private async Task<bool> ResolvePendingChanges()
+    {
+        if (!HasPendingChanges)
+            return true;
+
+        var result = await DialogService.OpenAsync<UnsavedChangesDialog>(
+            "Unsaved Changes",
+            new Dictionary<string, object?>
+            {
+                { "Message", "You have unsaved changes on this page. Save before leaving?" }
+            },
+            new DialogOptions { Width = "460px", CloseDialogOnOverlayClick = false, CloseDialogOnEsc = true });
+
+        if (result is not string action)
+            return false;
+
+        switch (action)
+        {
+            case SavePendingChangesResult:
+                return await SaveGroupInternal();
+            case DiscardPendingChangesResult:
+                await LoadGroups();
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private bool TryApplyPendingEditorChanges()
+    {
+        if (!TryApplyPendingHeaderEdit())
+            return false;
+
+        ApplyPendingGroupedSettingEdit();
+        return true;
+    }
+
+    private bool TryApplyPendingHeaderEdit()
+    {
+        if (!_editingHeader || _selectedGroup == null)
+            return true;
+
+        var normalizedName = _editName.Trim();
+        if (string.IsNullOrWhiteSpace(normalizedName))
+        {
+            NotificationService.Notify(new NotificationMessage
+            {
+                Severity = NotificationSeverity.Warning,
+                Summary = "Group Name Required",
+                Detail = "Enter a group name before saving."
+            });
+            return false;
+        }
+
+        _selectedGroup.Name = normalizedName;
+        _selectedGroup.Description = NormalizeOptionalText(_editDescription);
+        _editingHeader = false;
+        return true;
+    }
+
+    private void ApplyPendingGroupedSettingEdit()
+    {
+        if (_editingGroupedSetting == null)
+            return;
+
+        var primarySourceName = GetSourceDerivedName(_editingGroupedSetting.SourceSettings.FirstOrDefault());
+        _editingGroupedSetting.Name = string.IsNullOrWhiteSpace(_gsEditName)
+            ? primarySourceName
+            : _gsEditName.Trim();
+        _editingGroupedSetting.Description = GetEditedGroupedSettingDescription(_editingGroupedSetting);
+        ApplyGroupedSettingDerivedMetadata(_editingGroupedSetting);
+        _editingGroupedSetting = null;
+    }
+
+    private bool HasPendingHeaderEdits()
+    {
+        if (!_editingHeader || _selectedGroup == null)
+            return false;
+
+        var normalizedName = _editName.Trim();
+        var normalizedDescription = NormalizeOptionalText(_editDescription);
+        return !string.Equals(_selectedGroup.Name, normalizedName, StringComparison.Ordinal) ||
+               !string.Equals(_selectedGroup.Description, normalizedDescription, StringComparison.Ordinal);
+    }
+
+    private bool HasPendingGroupedSettingEdits()
+    {
+        if (_editingGroupedSetting == null)
+            return false;
+
+        var primarySourceName = GetSourceDerivedName(_editingGroupedSetting.SourceSettings.FirstOrDefault());
+        var updatedName = string.IsNullOrWhiteSpace(_gsEditName)
+            ? primarySourceName
+            : _gsEditName.Trim();
+        var updatedDescription = GetEditedGroupedSettingDescription(_editingGroupedSetting);
+
+        return !string.Equals(_editingGroupedSetting.Name, updatedName, StringComparison.Ordinal) ||
+               !string.Equals(_editingGroupedSetting.Description, updatedDescription, StringComparison.Ordinal);
+    }
+
+    private void CaptureBaseline()
+    {
+        _baselineGroupSnapshots = CreateGroupSnapshots(_groups);
+        _dirtyGroupKeys.Clear();
+    }
+
+    private void RefreshPendingChangeState()
+    {
+        var currentSnapshots = CreateGroupSnapshots(_groups);
+        _dirtyGroupKeys.Clear();
+
+        foreach (var group in _groups)
+        {
+            var key = GetGroupKey(group);
+            if (currentSnapshots.TryGetValue(key, out var currentSnapshot) &&
+                (!_baselineGroupSnapshots.TryGetValue(key, out var baselineSnapshot) ||
+                 !string.Equals(currentSnapshot, baselineSnapshot, StringComparison.Ordinal)))
+            {
+                _dirtyGroupKeys.Add(key);
+            }
         }
     }
 
@@ -518,5 +731,42 @@ public partial class Groups : ComponentBase
             }))
             .GroupBy(item => item.Key)
             .ToDictionary(grouping => grouping.Key, grouping => grouping.First().ValueType, StringComparer.OrdinalIgnoreCase);
+    }
+
+    private Dictionary<string, string> CreateGroupSnapshots(IEnumerable<SettingGroupDataContract> groups)
+    {
+        var clonedGroups = JsonConvert.DeserializeObject<List<SettingGroupDataContract>>(
+                               JsonConvert.SerializeObject(groups))
+                           ?? new List<SettingGroupDataContract>();
+
+        NormalizeGroups(clonedGroups);
+        return clonedGroups.ToDictionary(GetGroupKey, JsonConvert.SerializeObject, StringComparer.Ordinal);
+    }
+
+    private static string GetGroupKey(SettingGroupDataContract group)
+    {
+        return group.Id?.ToString() ?? group.Name;
+    }
+
+    private static string? NormalizeOptionalText(string? value)
+    {
+        var trimmed = value?.Trim();
+        return string.IsNullOrWhiteSpace(trimmed) ? null : trimmed;
+    }
+
+    private string? GetEditedGroupedSettingDescription(GroupedSettingDataContract groupedSetting)
+    {
+        var trimmed = _gsEditDescription.Trim();
+        if (!string.IsNullOrWhiteSpace(trimmed))
+            return trimmed;
+
+        return groupedSetting.Description == null ? null : string.Empty;
+    }
+
+    private bool IsLeavingGroupsPage(string targetLocation)
+    {
+        var relativePath = NavigationManager.ToBaseRelativePath(targetLocation);
+        var path = relativePath.Split('?', '#')[0].Trim('/');
+        return !string.Equals(path, "groups", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/web/Fig.Web/Pages/Groups.razor.cs
+++ b/src/web/Fig.Web/Pages/Groups.razor.cs
@@ -22,18 +22,27 @@ public partial class Groups : ComponentBase
 
     private List<SettingGroupDataContract> _groups = new();
     private SettingGroupDataContract? _selectedGroup;
-    private string _filterText = string.Empty;
     private bool _loading = true;
+
+    // Header edit state
+    private bool _editingHeader;
+    private string _editName = string.Empty;
+    private string _editDescription = string.Empty;
+
+    // Grouped setting edit state — tracked by reference, not index
+    private GroupedSettingDataContract? _editingGroupedSetting;
+    private string _gsEditName = string.Empty;
+    private string _gsEditDescription = string.Empty;
+    private string _gsEditCategoryName = string.Empty;
+    private string _gsEditCategoryColor = string.Empty;
 
     private bool IsAdmin => AccountService.AuthenticatedUser?.Role == Role.Administrator;
 
-    private IEnumerable<SettingGroupDataContract> FilteredGroups =>
-        string.IsNullOrWhiteSpace(_filterText)
-            ? _groups
-            : _groups.Where(g => g.Name.Contains(_filterText, StringComparison.OrdinalIgnoreCase));
-
     protected override async Task OnInitializedAsync()
     {
+        // Ensure settings clients are loaded so source setting selection works
+        // even when user navigates directly to /groups
+        await SettingClientFacade.LoadAllClients();
         await LoadGroups();
         await base.OnInitializedAsync();
     }
@@ -60,10 +69,14 @@ public partial class Groups : ComponentBase
         }
     }
 
-    private void SelectGroup(SettingGroupDataContract group)
+    private void OnGroupSelected()
     {
-        _selectedGroup = group;
+        // Reset edit states when selecting a different group
+        _editingHeader = false;
+        _editingGroupedSetting = null;
     }
+
+    // ── Group CRUD ──
 
     private async Task AddGroup()
     {
@@ -85,6 +98,7 @@ public partial class Groups : ComponentBase
                     Summary = "Group Created",
                     Detail = $"Group '{groupName}' created successfully"
                 });
+                SettingClientFacade.MarkGroupsChanged();
                 await LoadGroups();
                 _selectedGroup = _groups.FirstOrDefault(g => g.Id == created.Id);
             }
@@ -104,6 +118,7 @@ public partial class Groups : ComponentBase
                 Summary = "Group Saved",
                 Detail = $"Group '{_selectedGroup.Name}' saved successfully"
             });
+            SettingClientFacade.MarkGroupsChanged();
             await LoadGroups();
         }
     }
@@ -126,23 +141,134 @@ public partial class Groups : ComponentBase
                 Summary = "Group Deleted",
                 Detail = $"Group '{_selectedGroup.Name}' deleted"
             });
+            SettingClientFacade.MarkGroupsChanged();
             _selectedGroup = null;
             await LoadGroups();
         }
     }
 
-    private void AddGroupedSetting()
+    // ── Header edit mode ──
+
+    private void StartHeaderEdit()
+    {
+        _editName = _selectedGroup?.Name ?? string.Empty;
+        _editDescription = _selectedGroup?.Description ?? string.Empty;
+        _editingHeader = true;
+    }
+
+    private void SaveHeaderEdit()
+    {
+        if (_selectedGroup == null) return;
+        _selectedGroup.Name = _editName;
+        _selectedGroup.Description = _editDescription;
+        _editingHeader = false;
+    }
+
+    private void CancelHeaderEdit()
+    {
+        _editingHeader = false;
+    }
+
+    // ── Grouped setting edit mode ──
+
+    private void StartSettingEdit(GroupedSettingDataContract gs)
+    {
+        _editingGroupedSetting = gs;
+        _gsEditName = gs.Name;
+        _gsEditDescription = gs.Description ?? string.Empty;
+        _gsEditCategoryName = gs.CategoryName ?? string.Empty;
+        _gsEditCategoryColor = gs.CategoryColor ?? string.Empty;
+    }
+
+    private void SaveSettingEdit()
+    {
+        if (_editingGroupedSetting == null) return;
+
+        _editingGroupedSetting.Name = _gsEditName;
+        _editingGroupedSetting.Description = string.IsNullOrWhiteSpace(_gsEditDescription) ? null : _gsEditDescription;
+        _editingGroupedSetting.CategoryName = string.IsNullOrWhiteSpace(_gsEditCategoryName) ? null : _gsEditCategoryName;
+        _editingGroupedSetting.CategoryColor = string.IsNullOrWhiteSpace(_gsEditCategoryColor) ? null : _gsEditCategoryColor;
+        _editingGroupedSetting = null;
+    }
+
+    private void CancelSettingEdit()
+    {
+        _editingGroupedSetting = null;
+    }
+
+    // ── Grouped setting management ──
+
+    private async Task AddGroupedSetting()
     {
         if (_selectedGroup == null) return;
 
-        _selectedGroup.GroupedSettings.Add(new GroupedSettingDataContract(
-            "New Setting", null, "System.String", new List<SourceSettingDataContract>()));
+        // Step 1: open source setting selection first
+        var allGroupedSourceSettings = _groups
+            .SelectMany(g => g.GroupedSettings)
+            .SelectMany(s => s.SourceSettings)
+            .Select(s => $"{s.ClientName}|{s.SettingName}")
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var availableSettings = SettingClientFacade.SettingClients
+            .Where(c => !c.IsGroup && c.Instance == null)
+            .SelectMany(c => c.Settings.Select(s => new SourceSettingDataContract(c.Name, s.Name)))
+            .Where(s => !allGroupedSourceSettings.Contains($"{s.ClientName}|{s.SettingName}"))
+            .OrderBy(s => s.ClientName)
+            .ThenBy(s => s.SettingName)
+            .ToList();
+
+        if (!availableSettings.Any())
+        {
+            NotificationService.Notify(new NotificationMessage
+            {
+                Severity = NotificationSeverity.Info,
+                Summary = "No Available Settings",
+                Detail = "All settings are already assigned to groups."
+            });
+            return;
+        }
+
+        var settingValueTypes = BuildSettingValueTypeLookup();
+
+        var selected = await DialogService.OpenAsync<SourceSettingSelectionDialog>(
+            "Select Source Settings for New Grouped Setting",
+            new Dictionary<string, object>
+            {
+                { "AvailableSettings", availableSettings },
+                { "ValueTypeFilter", null! },
+                { "SettingValueTypes", settingValueTypes }
+            },
+            new DialogOptions { Width = "600px", Height = "500px" });
+
+        if (selected is not List<SourceSettingDataContract> selectedSettings || !selectedSettings.Any())
+            return;
+
+        // Step 2: auto-populate from first source setting
+        var firstSource = selectedSettings.First();
+        var templateSetting = FindSetting(firstSource.ClientName, firstSource.SettingName);
+
+        var valueType = settingValueTypes.TryGetValue($"{firstSource.ClientName}|{firstSource.SettingName}", out var vt)
+            ? vt : "System.String";
+
+        var newGs = new GroupedSettingDataContract(
+            templateSetting?.Name ?? firstSource.SettingName,
+            templateSetting?.RawDescription,
+            valueType,
+            selectedSettings)
+        {
+            CategoryName = templateSetting?.CategoryName,
+            CategoryColor = templateSetting?.CategoryColor
+        };
+
+        _selectedGroup.GroupedSettings.Add(newGs);
         StateHasChanged();
     }
 
     private void RemoveGroupedSetting(GroupedSettingDataContract gs)
     {
         _selectedGroup?.GroupedSettings.Remove(gs);
+        if (_editingGroupedSetting == gs)
+            _editingGroupedSetting = null;
         StateHasChanged();
     }
 
@@ -175,12 +301,7 @@ public partial class Groups : ComponentBase
             return;
         }
 
-        // Build a lookup of setting value types for type filtering in the dialog
-        var settingValueTypes = SettingClientFacade.SettingClients
-            .Where(c => !c.IsGroup && c.Instance == null)
-            .SelectMany(c => c.Settings.Select(s => new { Key = $"{c.Name}|{s.Name}", ValueType = s.ValueType?.FullName ?? "System.String" }))
-            .GroupBy(x => x.Key)
-            .ToDictionary(g => g.Key, g => g.First().ValueType, StringComparer.OrdinalIgnoreCase);
+        var settingValueTypes = BuildSettingValueTypeLookup();
 
         var selected = await DialogService.OpenAsync<SourceSettingSelectionDialog>(
             "Select Source Settings",
@@ -204,13 +325,64 @@ public partial class Groups : ComponentBase
                 }
             }
 
+            // Auto-populate name/description/category from first source if this is the first time
+            if (gs.SourceSettings.Count == selectedSettings.Count)
+            {
+                var first = gs.SourceSettings.First();
+                var tmpl = FindSetting(first.ClientName, first.SettingName);
+                if (tmpl != null)
+                {
+                    gs.Name = tmpl.Name;
+                    gs.Description = tmpl.RawDescription;
+                    if (settingValueTypes.TryGetValue($"{first.ClientName}|{first.SettingName}", out var fvt))
+                        gs.ValueType = fvt;
+                    gs.CategoryName ??= tmpl.CategoryName;
+                    gs.CategoryColor ??= tmpl.CategoryColor;
+                }
+            }
+
             StateHasChanged();
         }
     }
 
     private void RemoveSourceSetting(GroupedSettingDataContract gs, SourceSettingDataContract ss)
     {
+        if (gs.SourceSettings.Count <= 1)
+        {
+            NotificationService.Notify(new NotificationMessage
+            {
+                Severity = NotificationSeverity.Warning,
+                Summary = "Cannot Remove",
+                Detail = "A grouped setting must have at least one source setting. Remove the grouped setting instead."
+            });
+            return;
+        }
+
         gs.SourceSettings.Remove(ss);
         StateHasChanged();
+    }
+
+    // ── Helpers ──
+
+    private Models.Setting.ISetting? FindSetting(string clientName, string settingName)
+    {
+        var client = SettingClientFacade.SettingClients
+            .FirstOrDefault(c => string.Equals(c.Name, clientName, StringComparison.OrdinalIgnoreCase)
+                                 && c.Instance == null && !c.IsGroup);
+        return client?.Settings.FirstOrDefault(s =>
+            string.Equals(s.Name, settingName, StringComparison.Ordinal));
+    }
+
+    private Dictionary<string, string> BuildSettingValueTypeLookup()
+    {
+        return SettingClientFacade.SettingClients
+            .Where(c => !c.IsGroup && c.Instance == null)
+            .SelectMany(c => c.Settings.Select(s => new
+            {
+                Key = $"{c.Name}|{s.Name}",
+                ValueType = s.ValueType?.FullName ?? "System.String"
+            }))
+            .GroupBy(x => x.Key)
+            .ToDictionary(g => g.Key, g => g.First().ValueType, StringComparer.OrdinalIgnoreCase);
     }
 }

--- a/src/web/Fig.Web/Pages/Groups.razor.css
+++ b/src/web/Fig.Web/Pages/Groups.razor.css
@@ -23,7 +23,7 @@
     background: transparent;
 }
 
-.groups-header-button {
+::deep .groups-header-button {
     flex-shrink: 0;
     align-self: center;
     width: 2.5rem;
@@ -45,10 +45,6 @@
     box-shadow: 0 10px 28px rgba(0, 0, 0, 0.24);
 }
 
-.groups-list-shell:focus-within {
-    border-color: rgba(33, 150, 243, 0.55);
-    box-shadow: 0 0 0 1px rgba(33, 150, 243, 0.2), 0 10px 28px rgba(0, 0, 0, 0.24);
-}
 
 .groups-list-toolbar {
     display: flex;
@@ -58,38 +54,48 @@
 }
 
 .groups-filter-shell {
-    display: block;
     position: relative;
     flex: 1;
     min-width: 0;
     margin: 0;
+    height: 2.5rem;
 }
 
 .groups-filter-icon {
     position: absolute;
     top: 50%;
-    left: 12px;
+    left: 10px;
     transform: translateY(-50%);
     font-size: 1.1rem;
+    line-height: 1;
     color: rgba(255, 255, 255, 0.5);
     pointer-events: none;
+    z-index: 1;
+    user-select: none;
 }
 
 .groups-filter-input {
+    position: relative;
     display: block;
     width: 100%;
     height: 2.5rem;
-    padding: 0.5rem 0.85rem 0.5rem 2.35rem !important;
+    padding: 0 0.85rem 0 2.2rem !important;
     border-radius: 12px;
     border: 1px solid rgba(255, 255, 255, 0.1);
     background: rgba(255, 255, 255, 0.04);
     color: var(--rz-text-color);
+    font-family: var(--rz-body-font-family, inherit);
+    font-size: var(--rz-body-font-size, 0.875rem);
+    line-height: 2.5rem;
+    box-shadow: none;
+    outline: none;
 }
 
-.groups-filter-input:focus {
-    outline: none;
-    border-color: rgba(255, 255, 255, 0.1);
-    box-shadow: none;
+.groups-filter-input:focus,
+.groups-filter-input:focus-visible {
+    outline: none !important;
+    border-color: rgba(255, 255, 255, 0.1) !important;
+    box-shadow: none !important;
 }
 
 .groups-list-body {
@@ -115,6 +121,13 @@
     border: none;
     background: transparent;
     padding: 0 16px 16px;
+}
+
+::deep .groups-listbox:focus,
+::deep .groups-listbox:focus-within {
+    outline: none !important;
+    border: none !important;
+    box-shadow: none !important;
 }
 
 ::deep .groups-listbox .rz-listbox-list {
@@ -445,6 +458,7 @@
     display: flex;
     flex-direction: column;
     gap: 8px;
+    margin-bottom: 8px;
 }
 
 .source-setting-chip {
@@ -514,8 +528,8 @@
 }
 
 .add-source-button {
-    margin-top: 16px;
-    margin-bottom: 4px;
+    margin-top: 14px;
+    margin-bottom: 10px;
 }
 
 .empty-state {

--- a/src/web/Fig.Web/Pages/Groups.razor.css
+++ b/src/web/Fig.Web/Pages/Groups.razor.css
@@ -1,397 +1,651 @@
-/* Groups page scoped styles — matches SettingCard / Settings page design language */
-
-/* ===== Layout ===== */
 .groups-container {
     display: flex;
+    gap: 1.5rem;
     height: calc(100vh - 80px);
+    min-height: 0;
+    padding-left: 0.75rem;
 }
 
 .groups-list-panel {
-    width: 25%;
-    min-width: 220px;
-    overflow-y: auto;
+    width: 28%;
+    max-width: 420px;
+    min-width: 280px;
+    min-height: 0;
     display: flex;
     flex-direction: column;
+}
+
+.groups-detail-panel {
+    flex: 1;
+    min-width: 0;
+    overflow-y: auto;
+    padding: 0 24px 24px 0;
+    background: transparent;
 }
 
 .groups-list-header {
     display: flex;
     justify-content: space-between;
-    align-items: center;
-    padding: 10px 12px 4px 12px;
+    gap: 12px;
+    align-items: flex-start;
+    padding: 4px 4px 14px;
 }
 
 .groups-list-header h4 {
     margin: 0;
-    font-size: 1rem;
-    font-weight: 500;
-    color: rgba(255, 255, 255, 0.9);
-}
-
-.groups-detail-panel {
-    flex: 1;
-    overflow-y: auto;
-    padding: 20px 24px;
-}
-
-/* ===== Group header (display mode) ===== */
-.group-header-display {
-    margin-bottom: 20px;
-    animation: fadeIn 0.2s ease;
-}
-
-.group-header-display h2 {
-    margin: 0 0 4px 0;
-    font-size: 1.3rem;
+    font-size: 1.05rem;
     font-weight: 600;
     color: rgba(255, 255, 255, 0.95);
 }
 
-.group-header-display p {
-    margin: 0;
-    font-size: 0.9rem;
-    color: rgba(255, 255, 255, 0.6);
-    line-height: 1.4;
+.groups-list-subtitle {
+    margin: 6px 0 0;
+    font-size: 0.82rem;
+    line-height: 1.35;
+    color: rgba(255, 255, 255, 0.58);
 }
 
-.group-header-actions {
-    display: flex;
-    gap: 8px;
-    align-items: center;
-}
-
-/* ===== Group header (edit mode) ===== */
-.group-header-edit {
-    margin-bottom: 20px;
-    padding: 16px;
-    background: var(--rz-base-200);
-    border-radius: 6px;
-    border: 1px solid var(--rz-base-300);
-    animation: fadeIn 0.2s ease;
-}
-
-.group-header-edit label {
-    display: block;
-    font-size: 0.8rem;
-    font-weight: 500;
-    color: rgba(255, 255, 255, 0.6);
-    margin-bottom: 4px;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-}
-
-.group-header-edit-actions {
-    display: flex;
-    gap: 8px;
-    margin-top: 12px;
-}
-
-/* ===== Grouped settings section header ===== */
-.grouped-settings-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 12px;
-}
-
-.grouped-settings-header h4 {
-    margin: 0;
-    font-size: 0.95rem;
-    font-weight: 500;
-    color: rgba(255, 255, 255, 0.8);
-}
-
-/* ===== Grouped setting card ===== */
-.grouped-setting-card {
-    position: relative;
-    margin-bottom: 16px;
-    border-radius: 6px;
-    overflow: hidden;
-    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.grouped-setting-card:hover {
-    transform: translateY(-1px);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
-}
-
-.colored-line {
-    position: absolute;
-    left: 0;
-    top: 0;
-    bottom: 0;
-    width: 4px;
-    opacity: 0.8;
-}
-
-.card-inner {
-    padding: 12px 16px 12px 20px;
-}
-
-/* ===== Card display mode ===== */
-.gs-display-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-}
-
-.gs-display-name {
-    margin: 0;
-    font-size: 1rem;
-    font-weight: 500;
-    color: rgba(255, 255, 255, 0.9);
-    line-height: 1.2;
-}
-
-.gs-display-description {
-    font-size: 0.85rem;
-    color: rgba(255, 255, 255, 0.6);
-    margin-top: 2px;
-    line-height: 1.3;
-}
-
-.gs-display-category {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    margin-top: 6px;
-    font-size: 0.8rem;
-    color: rgba(255, 255, 255, 0.5);
-}
-
-.gs-display-category .category-dot {
-    width: 10px;
-    height: 10px;
-    border-radius: 50%;
-    display: inline-block;
+.groups-header-button {
     flex-shrink: 0;
 }
 
-.gs-card-actions {
+.groups-list-shell {
     display: flex;
-    align-items: center;
-    gap: 4px;
-    margin-left: 12px;
-    flex-shrink: 0;
-}
-
-/* ===== Card edit mode ===== */
-.gs-edit-form {
-    animation: fadeIn 0.15s ease;
-}
-
-.gs-edit-form label {
-    display: block;
-    font-size: 0.75rem;
-    font-weight: 500;
-    color: rgba(255, 255, 255, 0.5);
-    margin-bottom: 2px;
-    margin-top: 8px;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-}
-
-.gs-edit-form label:first-child {
-    margin-top: 0;
-}
-
-.gs-edit-row {
-    display: flex;
-    gap: 12px;
-    align-items: flex-end;
-}
-
-.gs-edit-row > div {
+    flex-direction: column;
     flex: 1;
+    min-height: 0;
+    overflow: hidden;
+    border-radius: 18px;
+    border: 1px solid rgba(33, 150, 243, 0.42);
+    background: rgba(255, 255, 255, 0.03);
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.24);
 }
 
-.gs-edit-actions {
+.groups-loading-state,
+.sidebar-empty-state {
+    flex: 1;
     display: flex;
-    gap: 8px;
-    margin-top: 12px;
-}
-
-/* ===== Source settings list ===== */
-.source-settings-section {
-    margin-top: 10px;
-    padding-top: 8px;
-    border-top: 1px solid rgba(255, 255, 255, 0.06);
-}
-
-.source-settings-label {
-    font-size: 0.78rem;
-    font-weight: 500;
-    color: rgba(255, 255, 255, 0.45);
-    margin-bottom: 4px;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-}
-
-.source-setting-chip {
-    display: flex;
-    align-items: center;
-    padding: 5px 10px;
-    margin-bottom: 3px;
-    background: rgba(255, 255, 255, 0.06);
-    border-radius: 4px;
-    transition: background 0.15s ease;
-}
-
-.source-setting-chip:hover {
-    background: rgba(255, 255, 255, 0.10);
-}
-
-.source-setting-chip .client-name {
-    font-weight: 600;
-    color: rgba(255, 255, 255, 0.85);
-    font-size: 0.85rem;
-}
-
-.source-setting-chip .setting-name {
-    color: rgba(255, 255, 255, 0.65);
-    font-size: 0.85rem;
-    margin-left: 4px;
-}
-
-.source-setting-chip .arrow {
-    color: rgba(255, 255, 255, 0.3);
-    margin: 0 6px;
-    font-size: 0.8rem;
-}
-
-/* ===== Empty state ===== */
-.empty-state {
-    display: flex;
+    flex-direction: column;
     align-items: center;
     justify-content: center;
-    height: 100%;
-    color: rgba(255, 255, 255, 0.4);
+    gap: 10px;
+    padding: 24px;
+    color: rgba(255, 255, 255, 0.45);
     text-align: center;
 }
 
-.empty-state p {
-    margin-top: 12px;
-    font-size: 0.95rem;
-}
-
-.empty-state-settings {
-    text-align: center;
-    padding: 30px;
-    color: rgba(255, 255, 255, 0.4);
-}
-
-.empty-state-settings p {
-    margin-top: 8px;
-    font-size: 0.9rem;
-}
-
-/* ===== Footer metadata ===== */
-.group-footer {
-    margin-top: 16px;
-    font-size: 0.8rem;
-    color: rgba(255, 255, 255, 0.35);
-    display: flex;
-    gap: 16px;
-}
-
-/* ===== Color picker row ===== */
-.color-picker-row {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-}
-
-.color-preview {
-    width: 28px;
-    height: 28px;
-    border-radius: 4px;
-    border: 1px solid rgba(255, 255, 255, 0.15);
-    cursor: pointer;
-    transition: transform 0.15s ease;
-}
-
-.color-preview:hover {
-    transform: scale(1.1);
-}
-
-/* ===== ListBox overrides (matches Settings page) ===== */
 ::deep .groups-listbox {
     height: 100%;
-    min-height: calc(100vh - 160px);
-    background: transparent;
     border: none;
+    background: transparent;
+    padding: 16px;
 }
 
 ::deep .groups-listbox .rz-listbox-filter {
-    margin: 8px 12px;
+    margin: 0 0 16px;
+}
+
+::deep .groups-listbox .rz-textbox {
+    border-radius: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    background: rgba(255, 255, 255, 0.04);
 }
 
 ::deep .groups-listbox .rz-listbox-list {
-    padding: 0 8px;
+    padding: 0;
 }
 
 ::deep .groups-listbox .rz-listbox-item {
-    padding: 0.1rem 0.5rem !important;
-    border-radius: 6px;
-    margin-bottom: 2px;
-    transition: background 0.15s ease;
+    padding: 0.35rem !important;
+    margin-bottom: 10px;
+    border-radius: 14px;
+    transition: transform 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
 }
 
 ::deep .groups-listbox .rz-listbox-item:hover {
     background: rgba(255, 255, 255, 0.05);
+    transform: translateY(-1px);
 }
 
 ::deep .groups-listbox .rz-state-highlight {
-    background: var(--rz-primary) !important;
+    background: rgba(99, 102, 241, 0.2) !important;
+    border: 1px solid rgba(99, 102, 241, 0.38);
     color: white;
+    box-shadow: none;
 }
 
-/* ===== Group list item template (matches Settings page client-row) ===== */
 .group-list-item {
     display: flex;
-    align-items: center;
-    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-    position: relative;
+    gap: 12px;
+    align-items: flex-start;
+    padding: 8px 10px;
 }
 
-.group-list-item .p-1 {
-    padding: 0.1rem !important;
-}
-
-.group-list-item .group-icon {
-    opacity: 0.8;
+.group-list-icon-shell {
+    width: 38px;
+    height: 38px;
+    border-radius: 12px;
+    display: grid;
+    place-items: center;
+    background: rgba(255, 255, 255, 0.08);
     flex-shrink: 0;
 }
 
-.group-list-item-text {
+.group-list-item-content {
     flex: 1;
     min-width: 0;
-    padding: 0.1rem !important;
 }
 
-.group-list-item-text .group-name {
-    font-size: 0.95rem;
-    font-weight: 500;
-    line-height: 1.1;
-    color: rgba(255, 255, 255, 0.9);
+.group-list-item-top {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    justify-content: space-between;
+}
+
+.group-name {
+    min-width: 0;
+    font-size: 0.96rem;
+    font-weight: 600;
+    line-height: 1.2;
+    color: rgba(255, 255, 255, 0.94);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
 }
 
-/* ===== Animations ===== */
-@keyframes fadeIn {
-    from { opacity: 0; transform: translateY(-4px); }
-    to   { opacity: 1; transform: translateY(0); }
+.group-list-item-description,
+.group-list-item-meta {
+    margin-top: 5px;
+    font-size: 0.8rem;
+    line-height: 1.35;
+    color: rgba(255, 255, 255, 0.58);
 }
 
-/* Subtle card enter animation */
+.group-list-item-description {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.group-overview-card {
+    margin-bottom: 26px;
+    padding: 24px;
+    border-radius: 20px;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow: 0 12px 28px rgba(0, 0, 0, 0.24);
+}
+
+.group-overview-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 16px;
+}
+
+.group-overview-copy {
+    flex: 1;
+    min-width: 0;
+}
+
+.group-overview-eyebrow {
+    font-size: 0.74rem;
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.56);
+    margin-bottom: 10px;
+}
+
+.group-overview-copy h2 {
+    margin: 0;
+    font-size: 1.45rem;
+    font-weight: 700;
+    color: rgba(255, 255, 255, 0.97);
+}
+
+.group-overview-copy p {
+    margin: 10px 0 0;
+    font-size: 0.92rem;
+    line-height: 1.5;
+    color: rgba(255, 255, 255, 0.72);
+}
+
+.group-header-actions {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-shrink: 0;
+}
+
+.group-overview-stats {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 18px;
+}
+
+.meta-chip {
+    display: inline-flex;
+    align-items: center;
+    padding: 7px 12px;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    color: rgba(255, 255, 255, 0.82);
+    font-size: 0.82rem;
+    font-weight: 500;
+}
+
+.group-header-edit {
+    margin-bottom: 24px;
+    padding: 20px 22px;
+    border-radius: 20px;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow: 0 10px 24px rgba(0, 0, 0, 0.22);
+    animation: fadeIn 0.2s ease;
+}
+
+.group-header-edit label,
+.gs-edit-form label {
+    display: block;
+    margin-bottom: 6px;
+    margin-top: 14px;
+    font-size: 0.76rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: rgba(255, 255, 255, 0.52);
+}
+
+.group-header-edit label:first-child,
+.gs-edit-form label:first-child {
+    margin-top: 0;
+}
+
+.group-header-edit-actions,
+.gs-edit-actions {
+    display: flex;
+    gap: 8px;
+    margin-top: 16px;
+}
+
+.grouped-settings-section-shell {
+    background: transparent;
+}
+
+.grouped-settings-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    gap: 16px;
+    margin-bottom: 20px;
+    padding-left: 2px;
+}
+
+.grouped-settings-header h4 {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 600;
+    color: rgba(255, 255, 255, 0.9);
+}
+
+.grouped-settings-list {
+    display: flex;
+    flex-direction: column;
+    gap: 22px;
+}
+
 .grouped-setting-card {
+    position: relative;
+    margin-bottom: 0 !important;
+    border-radius: 18px;
+    overflow: hidden;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.24);
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
     animation: cardEnter 0.2s ease;
 }
 
+.grouped-setting-card:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 14px 32px rgba(0, 0, 0, 0.28);
+    background: rgba(255, 255, 255, 0.07);
+}
+
+.card-inner {
+    padding: 22px 24px;
+}
+
+.gs-display-header {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+    align-items: flex-start;
+}
+
+.gs-display-copy {
+    flex: 1;
+    min-width: 0;
+}
+
+.gs-display-name {
+    font-size: 1.08rem;
+    font-weight: 600;
+    line-height: 1.25;
+    color: rgba(255, 255, 255, 0.94);
+}
+
+.gs-display-description {
+    margin-top: 8px;
+    font-size: 0.88rem;
+    line-height: 1.45;
+    color: rgba(255, 255, 255, 0.66);
+}
+
+.gs-metadata-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 14px;
+}
+
+.category-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 12px;
+    border-radius: 999px;
+    font-size: 0.8rem;
+    line-height: 1.2;
+}
+
+.category-chip {
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    background: rgba(255, 255, 255, 0.06);
+    color: rgba(255, 255, 255, 0.82);
+}
+
+.category-chip.muted {
+    color: rgba(255, 255, 255, 0.5);
+}
+
+.category-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.gs-card-actions,
+.source-setting-actions {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-shrink: 0;
+}
+
+.groups-icon-button {
+    width: 2rem;
+    min-width: 2rem;
+    height: 2rem;
+    padding: 0;
+    border-radius: 10px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: none;
+}
+
+::deep .groups-icon-button .rz-button-text {
+    display: none;
+}
+
+::deep .groups-icon-button .rz-icon {
+    font-size: 1rem;
+    line-height: 1;
+}
+
+.groups-icon-button:hover:not(.rz-state-disabled) {
+    transform: translateY(-1px);
+}
+
+.gs-derived-note {
+    display: flex;
+    gap: 10px;
+    align-items: flex-start;
+    margin-top: 14px;
+    padding: 12px 14px;
+    border-radius: 14px;
+    background: rgba(99, 102, 241, 0.1);
+    border: 1px solid rgba(99, 102, 241, 0.2);
+    color: rgba(255, 255, 255, 0.72);
+    font-size: 0.84rem;
+    line-height: 1.4;
+}
+
+.source-settings-section {
+    margin-top: 20px;
+    padding-top: 18px;
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.source-settings-top {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    align-items: flex-end;
+    margin-bottom: 10px;
+}
+
+.source-settings-label {
+    font-size: 0.76rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.5);
+}
+
+.source-settings-list {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.source-setting-chip {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 11px 13px;
+    margin-bottom: 0;
+    border-radius: 14px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: rgba(255, 255, 255, 0.03);
+    transition: transform 0.18s ease, background 0.18s ease, border-color 0.18s ease;
+}
+
+.source-setting-chip:hover {
+    transform: translateY(-1px);
+    background: rgba(255, 255, 255, 0.06);
+}
+
+.source-setting-chip-leading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.source-setting-order {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    display: grid;
+    place-items: center;
+    background: rgba(255, 255, 255, 0.08);
+    color: rgba(255, 255, 255, 0.88);
+    font-size: 0.82rem;
+    font-weight: 700;
+}
+
+.source-setting-chip-body {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
+}
+
+.source-setting-chip-title {
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-wrap: wrap;
+}
+
+.source-setting-chip .client-name {
+    font-weight: 600;
+    color: rgba(255, 255, 255, 0.9);
+}
+
+.source-setting-chip .setting-name {
+    color: rgba(255, 255, 255, 0.72);
+    word-break: break-word;
+}
+
+.source-setting-chip .arrow {
+    color: rgba(255, 255, 255, 0.32);
+}
+
+.add-source-button {
+    margin-top: 14px;
+}
+
+.empty-state {
+    min-height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.empty-state-settings {
+    padding: 12px 0;
+}
+
+.empty-card {
+    max-width: 560px;
+    width: 100%;
+    margin: 0 auto;
+    padding: 28px;
+    border-radius: 20px;
+    background: linear-gradient(135deg, rgba(99, 102, 241, 0.12), rgba(16, 185, 129, 0.12));
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.28);
+    text-align: center;
+    animation: floaty 6s ease-in-out infinite;
+}
+
+.empty-card.compact {
+    max-width: 100%;
+    padding: 24px;
+    animation: none;
+}
+
+.empty-icon {
+    width: 76px;
+    height: 76px;
+    margin: 0 auto 14px;
+    display: grid;
+    place-items: center;
+    border-radius: 20px;
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid rgba(255, 255, 255, 0.16);
+    box-shadow: inset 0 0 0 2px rgba(0, 0, 0, 0.2), 0 8px 18px rgba(0, 0, 0, 0.35);
+}
+
+.empty-title {
+    font-size: 1.2rem;
+    font-weight: 700;
+    color: rgba(255, 255, 255, 0.94);
+}
+
+.empty-subtitle {
+    margin-top: 8px;
+    font-size: 0.92rem;
+    line-height: 1.45;
+    color: rgba(255, 255, 255, 0.68);
+}
+
+@keyframes fadeIn {
+    from {
+        opacity: 0;
+        transform: translateY(-4px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
 @keyframes cardEnter {
-    from { opacity: 0; transform: translateY(8px); }
-    to   { opacity: 1; transform: translateY(0); }
+    from {
+        opacity: 0;
+        transform: translateY(8px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes floaty {
+    0% {
+        transform: translateY(0);
+    }
+
+    50% {
+        transform: translateY(-4px);
+    }
+
+    100% {
+        transform: translateY(0);
+    }
+}
+
+@media (max-width: 1100px) {
+    .groups-container {
+        flex-direction: column;
+        height: auto;
+        padding-left: 0;
+    }
+
+    .groups-list-panel {
+        width: 100%;
+        max-width: none;
+        min-height: 320px;
+    }
+
+    .groups-detail-panel {
+        padding: 0 0 20px;
+    }
+
+    .group-overview-header,
+    .grouped-settings-header,
+    .gs-display-header {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .group-header-actions,
+    .gs-card-actions,
+    .source-setting-actions {
+        justify-content: flex-start;
+        flex-wrap: wrap;
+    }
 }

--- a/src/web/Fig.Web/Pages/Groups.razor.css
+++ b/src/web/Fig.Web/Pages/Groups.razor.css
@@ -1,0 +1,395 @@
+/* Groups page scoped styles — matches SettingCard / Settings page design language */
+
+/* ===== Layout ===== */
+.groups-container {
+    display: flex;
+    height: calc(100vh - 80px);
+}
+
+.groups-list-panel {
+    width: 25%;
+    min-width: 220px;
+    border-right: 1px solid var(--rz-base-300);
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+}
+
+.groups-list-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 10px 12px 4px 12px;
+}
+
+.groups-list-header h4 {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 500;
+    color: rgba(255, 255, 255, 0.9);
+}
+
+.groups-detail-panel {
+    flex: 1;
+    overflow-y: auto;
+    padding: 20px 24px;
+}
+
+/* ===== Group header (display mode) ===== */
+.group-header-display {
+    margin-bottom: 20px;
+    animation: fadeIn 0.2s ease;
+}
+
+.group-header-display h2 {
+    margin: 0 0 4px 0;
+    font-size: 1.3rem;
+    font-weight: 600;
+    color: rgba(255, 255, 255, 0.95);
+}
+
+.group-header-display p {
+    margin: 0;
+    font-size: 0.9rem;
+    color: rgba(255, 255, 255, 0.6);
+    line-height: 1.4;
+}
+
+.group-header-actions {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+}
+
+/* ===== Group header (edit mode) ===== */
+.group-header-edit {
+    margin-bottom: 20px;
+    padding: 16px;
+    background: var(--rz-base-200);
+    border-radius: 6px;
+    border: 1px solid var(--rz-base-300);
+    animation: fadeIn 0.2s ease;
+}
+
+.group-header-edit label {
+    display: block;
+    font-size: 0.8rem;
+    font-weight: 500;
+    color: rgba(255, 255, 255, 0.6);
+    margin-bottom: 4px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.group-header-edit-actions {
+    display: flex;
+    gap: 8px;
+    margin-top: 12px;
+}
+
+/* ===== Grouped settings section header ===== */
+.grouped-settings-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 12px;
+}
+
+.grouped-settings-header h4 {
+    margin: 0;
+    font-size: 0.95rem;
+    font-weight: 500;
+    color: rgba(255, 255, 255, 0.8);
+}
+
+/* ===== Grouped setting card ===== */
+.grouped-setting-card {
+    position: relative;
+    margin-bottom: 10px;
+    border-radius: 6px;
+    overflow: hidden;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.grouped-setting-card:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+
+.colored-line {
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 4px;
+    opacity: 0.8;
+}
+
+.card-inner {
+    padding: 12px 16px 12px 20px;
+}
+
+/* ===== Card display mode ===== */
+.gs-display-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+}
+
+.gs-display-name {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 500;
+    color: rgba(255, 255, 255, 0.9);
+    line-height: 1.2;
+}
+
+.gs-display-description {
+    font-size: 0.85rem;
+    color: rgba(255, 255, 255, 0.6);
+    margin-top: 2px;
+    line-height: 1.3;
+}
+
+.gs-display-category {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-top: 6px;
+    font-size: 0.8rem;
+    color: rgba(255, 255, 255, 0.5);
+}
+
+.gs-display-category .category-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    display: inline-block;
+    flex-shrink: 0;
+}
+
+.gs-card-actions {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    margin-left: 12px;
+    flex-shrink: 0;
+}
+
+/* ===== Card edit mode ===== */
+.gs-edit-form {
+    animation: fadeIn 0.15s ease;
+}
+
+.gs-edit-form label {
+    display: block;
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: rgba(255, 255, 255, 0.5);
+    margin-bottom: 2px;
+    margin-top: 8px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.gs-edit-form label:first-child {
+    margin-top: 0;
+}
+
+.gs-edit-row {
+    display: flex;
+    gap: 12px;
+    align-items: flex-end;
+}
+
+.gs-edit-row > div {
+    flex: 1;
+}
+
+.gs-edit-actions {
+    display: flex;
+    gap: 8px;
+    margin-top: 12px;
+}
+
+/* ===== Source settings list ===== */
+.source-settings-section {
+    margin-top: 10px;
+    padding-top: 8px;
+    border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.source-settings-label {
+    font-size: 0.78rem;
+    font-weight: 500;
+    color: rgba(255, 255, 255, 0.45);
+    margin-bottom: 4px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.source-setting-chip {
+    display: flex;
+    align-items: center;
+    padding: 5px 10px;
+    margin-bottom: 3px;
+    background: rgba(255, 255, 255, 0.06);
+    border-radius: 4px;
+    transition: background 0.15s ease;
+}
+
+.source-setting-chip:hover {
+    background: rgba(255, 255, 255, 0.10);
+}
+
+.source-setting-chip .client-name {
+    font-weight: 600;
+    color: rgba(255, 255, 255, 0.85);
+    font-size: 0.85rem;
+}
+
+.source-setting-chip .setting-name {
+    color: rgba(255, 255, 255, 0.65);
+    font-size: 0.85rem;
+    margin-left: 4px;
+}
+
+.source-setting-chip .arrow {
+    color: rgba(255, 255, 255, 0.3);
+    margin: 0 6px;
+    font-size: 0.8rem;
+}
+
+/* ===== Empty state ===== */
+.empty-state {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    color: rgba(255, 255, 255, 0.4);
+    text-align: center;
+}
+
+.empty-state p {
+    margin-top: 12px;
+    font-size: 0.95rem;
+}
+
+.empty-state-settings {
+    text-align: center;
+    padding: 30px;
+    color: rgba(255, 255, 255, 0.4);
+}
+
+.empty-state-settings p {
+    margin-top: 8px;
+    font-size: 0.9rem;
+}
+
+/* ===== Footer metadata ===== */
+.group-footer {
+    margin-top: 16px;
+    font-size: 0.8rem;
+    color: rgba(255, 255, 255, 0.35);
+    display: flex;
+    gap: 16px;
+}
+
+/* ===== Color picker row ===== */
+.color-picker-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.color-preview {
+    width: 28px;
+    height: 28px;
+    border-radius: 4px;
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    cursor: pointer;
+    transition: transform 0.15s ease;
+}
+
+.color-preview:hover {
+    transform: scale(1.1);
+}
+
+/* ===== ListBox overrides ===== */
+::deep .groups-listbox {
+    height: 100%;
+    min-height: calc(100vh - 160px);
+    background: transparent;
+    border: none;
+}
+
+::deep .groups-listbox .rz-listbox-filter {
+    margin: 8px 12px;
+}
+
+::deep .groups-listbox .rz-listbox-list {
+    padding: 0 8px;
+}
+
+::deep .groups-listbox .rz-listbox-item {
+    padding: 8px 12px;
+    border-radius: 6px;
+    margin-bottom: 2px;
+    transition: background 0.15s ease;
+}
+
+::deep .groups-listbox .rz-listbox-item:hover {
+    background: rgba(255, 255, 255, 0.05);
+}
+
+::deep .groups-listbox .rz-state-highlight {
+    background: var(--rz-primary) !important;
+    color: white;
+}
+
+/* ===== Group list item template ===== */
+.group-list-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.group-list-item .group-icon {
+    opacity: 0.7;
+    flex-shrink: 0;
+}
+
+.group-list-item-info {
+    flex: 1;
+    min-width: 0;
+}
+
+.group-list-item-name {
+    font-weight: 500;
+    font-size: 0.9rem;
+    color: rgba(255, 255, 255, 0.9);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.group-list-item-count {
+    font-size: 0.78rem;
+    color: rgba(255, 255, 255, 0.5);
+}
+
+/* ===== Animations ===== */
+@keyframes fadeIn {
+    from { opacity: 0; transform: translateY(-4px); }
+    to   { opacity: 1; transform: translateY(0); }
+}
+
+/* Subtle card enter animation */
+.grouped-setting-card {
+    animation: cardEnter 0.2s ease;
+}
+
+@keyframes cardEnter {
+    from { opacity: 0; transform: translateY(8px); }
+    to   { opacity: 1; transform: translateY(0); }
+}

--- a/src/web/Fig.Web/Pages/Groups.razor.css
+++ b/src/web/Fig.Web/Pages/Groups.razor.css
@@ -23,30 +23,14 @@
     background: transparent;
 }
 
-.groups-list-header {
-    display: flex;
-    justify-content: space-between;
-    gap: 12px;
-    align-items: flex-start;
-    padding: 4px 4px 14px;
-}
-
-.groups-list-header h4 {
-    margin: 0;
-    font-size: 1.05rem;
-    font-weight: 600;
-    color: rgba(255, 255, 255, 0.95);
-}
-
-.groups-list-subtitle {
-    margin: 6px 0 0;
-    font-size: 0.82rem;
-    line-height: 1.35;
-    color: rgba(255, 255, 255, 0.58);
-}
-
 .groups-header-button {
     flex-shrink: 0;
+    align-self: center;
+    width: 2.5rem;
+    min-width: 2.5rem;
+    height: 2.5rem;
+    padding: 0;
+    border-radius: 12px;
 }
 
 .groups-list-shell {
@@ -56,9 +40,61 @@
     min-height: 0;
     overflow: hidden;
     border-radius: 18px;
-    border: 1px solid rgba(33, 150, 243, 0.42);
+    border: 1px solid rgba(255, 255, 255, 0.1);
     background: rgba(255, 255, 255, 0.03);
     box-shadow: 0 10px 28px rgba(0, 0, 0, 0.24);
+}
+
+.groups-list-shell:focus-within {
+    border-color: rgba(33, 150, 243, 0.55);
+    box-shadow: 0 0 0 1px rgba(33, 150, 243, 0.2), 0 10px 28px rgba(0, 0, 0, 0.24);
+}
+
+.groups-list-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 16px 16px 12px;
+}
+
+.groups-filter-shell {
+    display: block;
+    position: relative;
+    flex: 1;
+    min-width: 0;
+    margin: 0;
+}
+
+.groups-filter-icon {
+    position: absolute;
+    top: 50%;
+    left: 12px;
+    transform: translateY(-50%);
+    font-size: 1.1rem;
+    color: rgba(255, 255, 255, 0.5);
+    pointer-events: none;
+}
+
+.groups-filter-input {
+    display: block;
+    width: 100%;
+    height: 2.5rem;
+    padding: 0.5rem 0.85rem 0.5rem 2.35rem !important;
+    border-radius: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    background: rgba(255, 255, 255, 0.04);
+    color: var(--rz-text-color);
+}
+
+.groups-filter-input:focus {
+    outline: none;
+    border-color: rgba(255, 255, 255, 0.1);
+    box-shadow: none;
+}
+
+.groups-list-body {
+    flex: 1;
+    min-height: 0;
 }
 
 .groups-loading-state,
@@ -78,17 +114,7 @@
     height: 100%;
     border: none;
     background: transparent;
-    padding: 16px;
-}
-
-::deep .groups-listbox .rz-listbox-filter {
-    margin: 0 0 16px;
-}
-
-::deep .groups-listbox .rz-textbox {
-    border-radius: 12px;
-    border: 1px solid rgba(255, 255, 255, 0.1);
-    background: rgba(255, 255, 255, 0.04);
+    padding: 0 16px 16px;
 }
 
 ::deep .groups-listbox .rz-listbox-list {
@@ -96,8 +122,8 @@
 }
 
 ::deep .groups-listbox .rz-listbox-item {
-    padding: 0.35rem !important;
-    margin-bottom: 10px;
+    padding: 0.3rem !important;
+    margin-bottom: 8px;
     border-radius: 14px;
     transition: transform 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
 }
@@ -117,7 +143,7 @@
 .group-list-item {
     display: flex;
     gap: 12px;
-    align-items: flex-start;
+    align-items: center;
     padding: 8px 10px;
 }
 
@@ -136,11 +162,11 @@
     min-width: 0;
 }
 
-.group-list-item-top {
+.group-list-item-badge {
     display: flex;
     align-items: center;
-    gap: 12px;
-    justify-content: space-between;
+    align-self: center;
+    flex-shrink: 0;
 }
 
 .group-name {
@@ -170,8 +196,8 @@
 }
 
 .group-overview-card {
-    margin-bottom: 26px;
-    padding: 24px;
+    margin-bottom: 24px;
+    padding: 20px 24px;
     border-radius: 20px;
     background: rgba(255, 255, 255, 0.05);
     border: 1px solid rgba(255, 255, 255, 0.08);
@@ -190,15 +216,6 @@
     min-width: 0;
 }
 
-.group-overview-eyebrow {
-    font-size: 0.74rem;
-    font-weight: 600;
-    letter-spacing: 0.1em;
-    text-transform: uppercase;
-    color: rgba(255, 255, 255, 0.56);
-    margin-bottom: 10px;
-}
-
 .group-overview-copy h2 {
     margin: 0;
     font-size: 1.45rem;
@@ -207,7 +224,7 @@
 }
 
 .group-overview-copy p {
-    margin: 10px 0 0;
+    margin: 8px 0 0;
     font-size: 0.92rem;
     line-height: 1.5;
     color: rgba(255, 255, 255, 0.72);
@@ -224,7 +241,7 @@
     display: flex;
     flex-wrap: wrap;
     gap: 8px;
-    margin-top: 18px;
+    margin-top: 14px;
 }
 
 .meta-chip {
@@ -296,7 +313,7 @@
 .grouped-settings-list {
     display: flex;
     flex-direction: column;
-    gap: 22px;
+    gap: 16px;
 }
 
 .grouped-setting-card {
@@ -316,14 +333,19 @@
     background: rgba(255, 255, 255, 0.07);
 }
 
+.grouped-setting-accent {
+    height: 4px;
+    width: 100%;
+}
+
 .card-inner {
-    padding: 22px 24px;
+    padding: 16px 18px 18px;
 }
 
 .gs-display-header {
     display: flex;
     justify-content: space-between;
-    gap: 16px;
+    gap: 12px;
     align-items: flex-start;
 }
 
@@ -333,51 +355,36 @@
 }
 
 .gs-display-name {
-    font-size: 1.08rem;
+    font-size: 1.04rem;
     font-weight: 600;
     line-height: 1.25;
     color: rgba(255, 255, 255, 0.94);
 }
 
 .gs-display-description {
-    margin-top: 8px;
-    font-size: 0.88rem;
-    line-height: 1.45;
+    margin-top: 6px;
+    font-size: 0.85rem;
+    line-height: 1.4;
     color: rgba(255, 255, 255, 0.66);
 }
 
-.gs-metadata-row {
+.gs-header-right {
     display: flex;
-    flex-wrap: wrap;
-    gap: 8px;
-    margin-top: 14px;
-}
-
-.category-chip {
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-    padding: 6px 12px;
-    border-radius: 999px;
-    font-size: 0.8rem;
-    line-height: 1.2;
-}
-
-.category-chip {
-    border: 1px solid rgba(255, 255, 255, 0.12);
-    background: rgba(255, 255, 255, 0.06);
-    color: rgba(255, 255, 255, 0.82);
-}
-
-.category-chip.muted {
-    color: rgba(255, 255, 255, 0.5);
-}
-
-.category-dot {
-    width: 10px;
-    height: 10px;
-    border-radius: 50%;
+    align-items: flex-start;
+    gap: 10px;
+    margin-left: auto;
     flex-shrink: 0;
+}
+
+.gs-category-label {
+    max-width: 220px;
+    padding-top: 2px;
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    line-height: 1.2;
+    text-align: right;
+    text-transform: uppercase;
 }
 
 .gs-card-actions,
@@ -417,7 +424,7 @@
     display: flex;
     gap: 10px;
     align-items: flex-start;
-    margin-top: 14px;
+    margin-top: 12px;
     padding: 12px 14px;
     border-radius: 14px;
     background: rgba(99, 102, 241, 0.1);
@@ -428,40 +435,25 @@
 }
 
 .source-settings-section {
-    margin-top: 20px;
-    padding-top: 18px;
+    margin-top: 14px;
+    padding-top: 14px;
+    padding-bottom: 4px;
     border-top: 1px solid rgba(255, 255, 255, 0.08);
-}
-
-.source-settings-top {
-    display: flex;
-    justify-content: space-between;
-    gap: 12px;
-    align-items: flex-end;
-    margin-bottom: 10px;
-}
-
-.source-settings-label {
-    font-size: 0.76rem;
-    font-weight: 700;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    color: rgba(255, 255, 255, 0.5);
 }
 
 .source-settings-list {
     display: flex;
     flex-direction: column;
-    gap: 10px;
+    gap: 8px;
 }
 
 .source-setting-chip {
     display: flex;
     align-items: center;
-    gap: 12px;
-    padding: 11px 13px;
+    gap: 10px;
+    padding: 9px 12px;
     margin-bottom: 0;
-    border-radius: 14px;
+    border-radius: 12px;
     border: 1px solid rgba(255, 255, 255, 0.08);
     background: rgba(255, 255, 255, 0.03);
     transition: transform 0.18s ease, background 0.18s ease, border-color 0.18s ease;
@@ -479,14 +471,14 @@
 }
 
 .source-setting-order {
-    width: 28px;
-    height: 28px;
+    width: 24px;
+    height: 24px;
     border-radius: 50%;
     display: grid;
     place-items: center;
     background: rgba(255, 255, 255, 0.08);
     color: rgba(255, 255, 255, 0.88);
-    font-size: 0.82rem;
+    font-size: 0.76rem;
     font-weight: 700;
 }
 
@@ -522,7 +514,8 @@
 }
 
 .add-source-button {
-    margin-top: 14px;
+    margin-top: 16px;
+    margin-bottom: 4px;
 }
 
 .empty-state {
@@ -647,5 +640,15 @@
     .source-setting-actions {
         justify-content: flex-start;
         flex-wrap: wrap;
+    }
+
+    .gs-header-right {
+        width: 100%;
+        justify-content: space-between;
+    }
+
+    .gs-category-label {
+        max-width: none;
+        text-align: left;
     }
 }

--- a/src/web/Fig.Web/Pages/Groups.razor.css
+++ b/src/web/Fig.Web/Pages/Groups.razor.css
@@ -9,7 +9,6 @@
 .groups-list-panel {
     width: 25%;
     min-width: 220px;
-    border-right: 1px solid var(--rz-base-300);
     overflow-y: auto;
     display: flex;
     flex-direction: column;
@@ -105,15 +104,16 @@
 /* ===== Grouped setting card ===== */
 .grouped-setting-card {
     position: relative;
-    margin-bottom: 10px;
+    margin-bottom: 16px;
     border-radius: 6px;
     overflow: hidden;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
     transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .grouped-setting-card:hover {
     transform: translateY(-1px);
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
 }
 
 .colored-line {
@@ -315,7 +315,7 @@
     transform: scale(1.1);
 }
 
-/* ===== ListBox overrides ===== */
+/* ===== ListBox overrides (matches Settings page) ===== */
 ::deep .groups-listbox {
     height: 100%;
     min-height: calc(100vh - 160px);
@@ -332,7 +332,7 @@
 }
 
 ::deep .groups-listbox .rz-listbox-item {
-    padding: 8px 12px;
+    padding: 0.1rem 0.5rem !important;
     border-radius: 6px;
     margin-bottom: 2px;
     transition: background 0.15s ease;
@@ -347,35 +347,37 @@
     color: white;
 }
 
-/* ===== Group list item template ===== */
+/* ===== Group list item template (matches Settings page client-row) ===== */
 .group-list-item {
     display: flex;
     align-items: center;
-    gap: 8px;
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    position: relative;
+}
+
+.group-list-item .p-1 {
+    padding: 0.1rem !important;
 }
 
 .group-list-item .group-icon {
-    opacity: 0.7;
+    opacity: 0.8;
     flex-shrink: 0;
 }
 
-.group-list-item-info {
+.group-list-item-text {
     flex: 1;
     min-width: 0;
+    padding: 0.1rem !important;
 }
 
-.group-list-item-name {
+.group-list-item-text .group-name {
+    font-size: 0.95rem;
     font-weight: 500;
-    font-size: 0.9rem;
+    line-height: 1.1;
     color: rgba(255, 255, 255, 0.9);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-}
-
-.group-list-item-count {
-    font-size: 0.78rem;
-    color: rgba(255, 255, 255, 0.5);
 }
 
 /* ===== Animations ===== */

--- a/src/web/Fig.Web/Pages/Groups.razor.css
+++ b/src/web/Fig.Web/Pages/Groups.razor.css
@@ -520,7 +520,8 @@
 
 .source-setting-chip .setting-name {
     color: rgba(255, 255, 255, 0.72);
-    word-break: break-word;
+    overflow-wrap: anywhere;
+    word-break: normal;
 }
 
 .source-setting-chip .arrow {

--- a/src/web/Fig.Web/Pages/Groups.razor.css
+++ b/src/web/Fig.Web/Pages/Groups.razor.css
@@ -179,7 +179,16 @@
     display: flex;
     align-items: center;
     align-self: center;
+    gap: 8px;
     flex-shrink: 0;
+}
+
+.group-pending-indicator {
+    width: 10px;
+    height: 10px;
+    border-radius: 999px;
+    background: #f59e0b;
+    box-shadow: 0 0 0 4px rgba(245, 158, 11, 0.18);
 }
 
 .group-name {
@@ -250,6 +259,10 @@
     flex-shrink: 0;
 }
 
+.group-save-button {
+    min-width: 6.5rem;
+}
+
 .group-overview-stats {
     display: flex;
     flex-wrap: wrap;
@@ -267,6 +280,18 @@
     color: rgba(255, 255, 255, 0.82);
     font-size: 0.82rem;
     font-weight: 500;
+}
+
+.meta-chip-pending {
+    background: rgba(245, 158, 11, 0.14);
+    border-color: rgba(245, 158, 11, 0.35);
+    color: rgba(255, 236, 179, 0.95);
+}
+
+.meta-chip-clean {
+    background: rgba(34, 197, 94, 0.12);
+    border-color: rgba(34, 197, 94, 0.3);
+    color: rgba(220, 252, 231, 0.95);
 }
 
 .group-header-edit {

--- a/src/web/Fig.Web/Pages/ImportExport.razor
+++ b/src/web/Fig.Web/Pages/ImportExport.razor
@@ -1,6 +1,7 @@
 ﻿@page "/ImportExport"
 @using Fig.Web.Attributes
 @using Fig.Contracts.ImportExport
+@using Fig.Contracts.SettingGroups
 @using Fig.Web.Models.ImportExport
 @attribute [Administrator]
 
@@ -215,6 +216,52 @@
                                   Click="PerformSettingsReport"/>
                 </div>
 
+            </RadzenCard>
+
+            <RadzenCard class="m-3">
+                <h3 class="h5">Group Export</h3>
+                <p>Export all setting group configurations. This exports group structure only, not setting values.</p>
+
+                <div class="p-2">
+                    <RadzenButton Text="Export" IsBusy="_groupExportInProgress" BusyText="Exporting..."
+                                  Click="PerformGroupExport"/>
+                </div>
+            </RadzenCard>
+
+            <RadzenCard class="m-3">
+                <h3 class="h5">Group Import</h3>
+                <p>Import setting group configurations from a JSON file.</p>
+                <div class="p-2">
+                    <RadzenFileInput TValue="string" Class="w-100" ChooseText="Select File" Accept="application/json"
+                                     Change="@(async (args) => await GroupImportFileChanged(args))" MaxFileSize="int.MaxValue" Error="@(OnGroupImportFileError)"/>
+                </div>
+
+                @if (_groupImportFileProcessing)
+                {
+                    <div class="p-2 text-center">
+                        <RadzenProgressBarCircular ShowValue="false" Mode="ProgressBarMode.Indeterminate" Size="ProgressBarCircularSize.Medium"/>
+                        <p>Processing file...</p>
+                    </div>
+                }
+
+                <div class="p-2">
+                    <RadzenTextArea id="groupImportStatusTextArea" Name="groupImportStatus" @bind-Value="@_groupImportStatus" Disabled="false" ReadOnly="true"
+                                    Class="w-100" Rows="5" Visible="_groupImportInProgress"/>
+                </div>
+                <div class="p-2">
+                    <RadzenDropDown AllowClear="false" TValue="ImportType" Class="w-100"
+                                    AllowFiltering="false"
+                                    Data="@ImportTypes"
+                                    TextProperty="EnumName" ValueProperty="EnumValue"
+                                    @bind-Value="@_groupImportType"
+                                    Visible="_groupImportInProgress"/>
+                </div>
+
+                <div class="p-2">
+                    <RadzenButton Text="Import" IsBusy="_groupImportOperationInProgress" BusyText="Importing..."
+                                  Click="PerformGroupImport" Visible="_groupImportInProgress"
+                                  Disabled="@(_groupImportIsInvalid || _groupImportOperationInProgress)"/>
+                </div>
             </RadzenCard>
 
             <RadzenCard class="m-3">

--- a/src/web/Fig.Web/Pages/ImportExport.razor.cs
+++ b/src/web/Fig.Web/Pages/ImportExport.razor.cs
@@ -4,6 +4,7 @@ using System.Text;
 using Fig.Common.ExtensionMethods;
 using Fig.Common.NetStandard.Json;
 using Fig.Contracts.ImportExport;
+using Fig.Contracts.SettingGroups;
 using Fig.Web.Facades;
 using Fig.Web.Factories;
 using Fig.Web.MarkdownReport;
@@ -50,6 +51,16 @@ public partial class ImportExport : IDisposable
     private bool _splitFiles;
     private bool _splitInitOnly;
 
+    // Group import/export fields
+    private bool _groupExportInProgress;
+    private bool _groupImportInProgress;
+    private bool _groupImportIsInvalid;
+    private bool _groupImportFileProcessing;
+    private bool _groupImportOperationInProgress;
+    private string? _groupImportStatus;
+    private ImportType _groupImportType;
+    private SettingGroupExportDataContract? _groupDataToImport;
+
     private List<DeferredImportClientModel> DeferredClients => DataFacade.DeferredClients;
 
     [Inject] public IDataFacade DataFacade { get; set; } = null!;
@@ -65,6 +76,8 @@ public partial class ImportExport : IDisposable
     [Inject] private IImportTypeFactory ImportTypeFactory { get; set; } = null!;
 
     [Inject] private IOptions<WebSettings> Settings { get; set; } = null!;
+
+    [Inject] private IGroupsFacade GroupsFacade { get; set; } = null!;
 
     private List<ImportTypeEnumerable> ImportTypes { get; } = new();
 
@@ -808,5 +821,118 @@ public partial class ImportExport : IDisposable
     public void Dispose()
     {
         _disposed = true;
+    }
+
+    private async Task PerformGroupExport()
+    {
+        _groupExportInProgress = true;
+        try
+        {
+            var data = await GroupsFacade.ExportGroups();
+            if (data is not null)
+            {
+                var text = JsonConvert.SerializeObject(data, JsonSettings.FigUserFacing);
+                var bytes = Encoding.UTF8.GetBytes(text);
+                var timestamp = DateTime.Now.ToString("yyyy-MM-ddTHH-mm-ss");
+                await FileUtil.SaveAs(JavascriptRuntime, $"FigGroupExport-{timestamp}.json", bytes);
+            }
+        }
+        finally
+        {
+            _groupExportInProgress = false;
+        }
+    }
+
+    private async Task GroupImportFileChanged(string? fileContent)
+    {
+        _groupImportFileProcessing = true;
+        _groupImportIsInvalid = false;
+        _groupImportStatus = null;
+        StateHasChanged();
+
+        try
+        {
+            if (string.IsNullOrWhiteSpace(fileContent))
+            {
+                _groupImportInProgress = false;
+                return;
+            }
+
+            // RadzenFileInput with TValue="string" delivers a data URL (data:...;base64,...)
+            var commaIdx = fileContent.IndexOf(',');
+            if (commaIdx < 0)
+                throw new FormatException("Invalid data URL format.");
+
+            var trimmed = fileContent.Substring(commaIdx + 1);
+            var bytes = Convert.FromBase64String(trimmed);
+            var json = System.Text.Encoding.UTF8.GetString(bytes);
+
+            var data = JsonConvert.DeserializeObject<SettingGroupExportDataContract>(json);
+            if (data?.Groups == null || !data.Groups.Any())
+            {
+                _groupImportStatus = "Invalid file: No groups found in import data.";
+                _groupImportIsInvalid = true;
+            }
+            else
+            {
+                _groupDataToImport = data;
+                _groupImportStatus = $"File loaded successfully. Found {data.Groups.Count} group(s) to import.";
+                foreach (var group in data.Groups)
+                {
+                    _groupImportStatus += $"\n  - {group.Name} ({group.GroupedSettings.Count} grouped setting(s))";
+                }
+            }
+
+            _groupImportInProgress = true;
+        }
+        catch (Exception ex)
+        {
+            _groupImportStatus = $"Error reading file: {ex.Message}";
+            _groupImportIsInvalid = true;
+            _groupImportInProgress = true;
+        }
+        finally
+        {
+            _groupImportFileProcessing = false;
+            StateHasChanged();
+        }
+    }
+
+    private void OnGroupImportFileError(UploadErrorEventArgs args)
+    {
+        _groupImportStatus = $"Error: {args.Message}";
+        _groupImportIsInvalid = true;
+        _groupImportInProgress = true;
+        StateHasChanged();
+    }
+
+    private async Task PerformGroupImport()
+    {
+        if (_groupDataToImport == null) return;
+
+        _groupImportOperationInProgress = true;
+        StateHasChanged();
+
+        try
+        {
+            var result = await GroupsFacade.ImportGroups(_groupDataToImport, _groupImportType);
+            if (result?.ErrorMessage != null)
+            {
+                _groupImportStatus += $"\nImport failed: {result.ErrorMessage}";
+            }
+            else
+            {
+                _groupImportStatus += "\nImport completed successfully.";
+            }
+        }
+        catch (Exception ex)
+        {
+            _groupImportStatus += $"\nImport failed: {ex.Message}";
+        }
+        finally
+        {
+            _groupImportOperationInProgress = false;
+            StateHasChanged();
+        }
     }
 }

--- a/src/web/Fig.Web/Program.cs
+++ b/src/web/Fig.Web/Program.cs
@@ -82,6 +82,7 @@ async Task BuildApplication(WebAssemblyHostBuilder builder)
     builder.Services.AddScoped<IWebHookClientConverter, WebHookClientConverter>();
     builder.Services.AddScoped<IWebHookConverter, WebHookConverter>();
     builder.Services.AddScoped<IConfigurationFacade, ConfigurationFacade>();
+    builder.Services.AddScoped<IGroupsFacade, GroupsFacade>();
     builder.Services.AddScoped<ILookupTablesFacade, LookupTableFacade>();
     builder.Services.AddScoped<ILookupTableConverter, LookupTableConverter>();
     builder.Services.AddScoped<IApiStatusConverter, ApiStatusConverter>();

--- a/src/web/Fig.Web/Shared/MainLayout.razor
+++ b/src/web/Fig.Web/Shared/MainLayout.razor
@@ -47,6 +47,7 @@
                     <NavLink href="scheduling" class="nav-item nav-link">Scheduling</NavLink>
                     <NavLink href="clienthistory" class="nav-item nav-link">Client History</NavLink>
                 }
+                <NavLink href="groups" class="nav-item nav-link">Groups</NavLink>
                 <NavLink href="lookuptables" class="nav-item nav-link">Lookup Tables</NavLink>
                 <div style="padding-bottom: 5px">
                     <RadzenButton Variant="Variant.Text" Click=@(_ => ShowKeybindings()) Text="Shortcuts" ButtonStyle="ButtonStyle.Light" Icon="help" />

--- a/src/web/Fig.Web/Shared/MainLayout.razor
+++ b/src/web/Fig.Web/Shared/MainLayout.razor
@@ -27,6 +27,7 @@
                 </NavLink>
                 <NavLink href="" Match="NavLinkMatch.All" class="nav-item nav-link">Settings</NavLink>
                 <NavLink href="settingstable" class="nav-item nav-link">Settings Table</NavLink>
+                <NavLink href="groups" class="nav-item nav-link">Groups</NavLink>
                 <NavLink href="events" class="nav-item nav-link">Events</NavLink>
                 @if (AccountService?.AuthenticatedUser?.Role == Role.Administrator)
                 {
@@ -47,7 +48,6 @@
                     <NavLink href="scheduling" class="nav-item nav-link">Scheduling</NavLink>
                     <NavLink href="clienthistory" class="nav-item nav-link">Client History</NavLink>
                 }
-                <NavLink href="groups" class="nav-item nav-link">Groups</NavLink>
                 <NavLink href="lookuptables" class="nav-item nav-link">Lookup Tables</NavLink>
                 <div style="padding-bottom: 5px">
                     <RadzenButton Variant="Variant.Text" Click=@(_ => ShowKeybindings()) Text="Shortcuts" ButtonStyle="ButtonStyle.Light" Icon="help" />


### PR DESCRIPTION
## Summary
- add dynamic server-managed setting groups across API, web, migration, and contracts
- overhaul the Groups page UI with edit/display modes, category fields, improved workflow, and styling alignment
- ensure grouped-setting changes refresh Settings data and improve source selection behavior

## Testing
- dotnet build Fig.sln --configuration Release --no-restore
- dotnet test tests/Fig.Unit.Test/Fig.Unit.Test.csproj --configuration Release --no-restore --verbosity minimal
- dotnet test tests/Fig.Integration.Test/Fig.Integration.Test.csproj --configuration Release --no-restore --verbosity minimal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full Groups management UI: create/edit/delete groups, manage grouped settings and source links, selection dialogs, left-panel filtering, and a Groups nav entry.
  * JSON Export/Import for groups with three import modes and migration from legacy group attributes.
  * Audit logging for group operations.

* **Documentation**
  * Added comprehensive Groups docs and migration/usage guidance.

* **Tests**
  * Added integration and unit tests covering CRUD, import/export, metadata, ordering, and audit events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->