### PR TITLE
Skip Fig service registration when disabled

### DIFF
--- a/src/client/Fig.Client/Configuration/FigCommandLine.cs
+++ b/src/client/Fig.Client/Configuration/FigCommandLine.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Fig.Client.Configuration;
+
+internal static class FigCommandLine
+{
+    internal const string DisableFigArg = "--disable-fig=true";
+
+    internal static Func<string[]?> CommandLineArgsProvider { get; set; } = Environment.GetCommandLineArgs;
+
+    internal static bool IsFigDisabled()
+    {
+        return IsFigDisabled(CommandLineArgsProvider?.Invoke());
+    }
+
+    internal static bool IsFigDisabled(IEnumerable<string>? args)
+    {
+        return args?.Contains(DisableFigArg) == true;
+    }
+}

--- a/src/client/Fig.Client/ConfigurationProvider/FigConfigurationBuilder.cs
+++ b/src/client/Fig.Client/ConfigurationProvider/FigConfigurationBuilder.cs
@@ -89,7 +89,7 @@ public class FigConfigurationBuilder : IConfigurationBuilder
 
         bool FigIsDisabled()
         {
-            return _figOptions.CommandLineArgs?.Contains("--disable-fig=true") == true;
+            return FigCommandLine.IsFigDisabled(_figOptions.CommandLineArgs);
         }
 
         bool ShouldLogAppConfigConfiguration()

--- a/src/client/Fig.Client/ExtensionMethods/FigRegistrationExtensions.cs
+++ b/src/client/Fig.Client/ExtensionMethods/FigRegistrationExtensions.cs
@@ -1,4 +1,5 @@
 using Fig.Client.Health;
+using Fig.Client.Configuration;
 using Fig.Client.Workers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -9,6 +10,9 @@ public static class FigRegistrationExtensions
 {
     public static IHostBuilder UseFig<T>(this IHostBuilder builder) where T : SettingsBase
     {
+        if (FigCommandLine.IsFigDisabled())
+            return builder;
+
         builder.ConfigureServices((_, services) =>
         {
             services.AddHealthChecks()

--- a/src/tests/Fig.Unit.Test/Client/FigRegistrationExtensionsTests.cs
+++ b/src/tests/Fig.Unit.Test/Client/FigRegistrationExtensionsTests.cs
@@ -1,0 +1,118 @@
+using System.Collections.Generic;
+using Fig.Client.Configuration;
+using Fig.Client.ExtensionMethods;
+using Fig.Client.Health;
+using Fig.Client.Workers;
+using Fig.Unit.Test.TestInfrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+
+namespace Fig.Unit.Test.Client;
+
+[TestFixture]
+public class FigRegistrationExtensionsTests
+{
+    [Test]
+    public void IsFigDisabled_WithDisableFigArg_ReturnsTrue()
+    {
+        var args = new[] { "app.dll", "--disable-fig=true" };
+
+        Assert.That(FigCommandLine.IsFigDisabled(args), Is.True);
+    }
+
+    [Test]
+    public void IsFigDisabled_WithoutDisableFigArg_ReturnsFalse()
+    {
+        var args = new[] { "app.dll", "--some-other-arg" };
+
+        Assert.That(FigCommandLine.IsFigDisabled(args), Is.False);
+    }
+
+    [Test]
+    public void IsFigDisabled_WithEmptyArgs_ReturnsFalse()
+    {
+        var args = Array.Empty<string>();
+
+        Assert.That(FigCommandLine.IsFigDisabled(args), Is.False);
+    }
+
+    [Test]
+    public void IsFigDisabled_WithDisableFigFalse_ReturnsFalse()
+    {
+        var args = new[] { "app.dll", "--disable-fig=false" };
+
+        Assert.That(FigCommandLine.IsFigDisabled(args), Is.False);
+    }
+
+    [Test]
+    public void IsFigDisabled_WithNullArgs_ReturnsFalse()
+    {
+        Assert.That(FigCommandLine.IsFigDisabled(null), Is.False);
+    }
+
+    [Test]
+    public void UseFig_WhenDisabled_DoesNotRegisterFigServices()
+    {
+        using var host = BuildHost(["app.dll", FigCommandLine.DisableFigArg], out var services);
+
+        AssertHostedServices(services, shouldBeRegistered: false);
+        Assert.That(HasFigHealthCheck(host.Services), Is.False);
+    }
+
+    [Test]
+    public void UseFig_WhenEnabled_RegistersFigServices()
+    {
+        using var host = BuildHost(["app.dll"], out var services);
+
+        AssertHostedServices(services, shouldBeRegistered: true);
+        Assert.That(HasFigHealthCheck(host.Services), Is.True);
+    }
+
+    private static IHost BuildHost(string[]? args, out IServiceCollection services)
+    {
+        var originalProvider = FigCommandLine.CommandLineArgsProvider;
+        IServiceCollection? capturedServices = null;
+
+        try
+        {
+            FigCommandLine.CommandLineArgsProvider = () => args;
+
+            var builder = new HostBuilder();
+            builder.UseFig<SimpleSettings>();
+            builder.ConfigureServices((_, serviceCollection) => capturedServices = serviceCollection);
+
+            return builder.Build();
+        }
+        finally
+        {
+            FigCommandLine.CommandLineArgsProvider = originalProvider;
+            services = capturedServices ?? throw new InvalidOperationException("Service collection was not captured.");
+        }
+    }
+
+    private static bool HasFigHealthCheck(IServiceProvider services)
+    {
+        var options = services.GetRequiredService<IOptions<HealthCheckServiceOptions>>().Value;
+        return options.Registrations.Any(a => a.Name == "Fig configuration");
+    }
+
+    private static void AssertHostedServices(IEnumerable<ServiceDescriptor> services, bool shouldBeRegistered)
+    {
+        AssertHostedService<FigRestartWorker<SimpleSettings>>(services, shouldBeRegistered);
+        AssertHostedService<FigHealthWorker<SimpleSettings>>(services, shouldBeRegistered);
+        AssertHostedService<FigCustomActionWorker<SimpleSettings>>(services, shouldBeRegistered);
+        AssertHostedService<FigLookupWorker<SimpleSettings>>(services, shouldBeRegistered);
+    }
+
+    private static void AssertHostedService<THostedService>(IEnumerable<ServiceDescriptor> services, bool shouldBeRegistered)
+    {
+        var isRegistered = services.Any(a =>
+            a.ServiceType == typeof(IHostedService) &&
+            a.ImplementationType == typeof(THostedService));
+
+        Assert.That(isRegistered, Is.EqualTo(shouldBeRegistered));
+    }
+}


### PR DESCRIPTION
## Summary
- detect `--disable-fig=true` inside `UseFig<T>()` without changing the public signature
- skip registering Fig hosted services when the disable flag is present
- add unit tests for disable flag detection

## Testing
- dotnet build client/Fig.Client/Fig.Client.csproj --configuration Release
- dotnet test tests/Fig.Unit.Test/Fig.Unit.Test.csproj --configuration Release --filter "FullyQualifiedName~FigRegistrationExtensionsTests" --verbosity minimal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * You can disable Fig at startup with --disable-fig=true. When disabled, Fig’s background workers and its configuration health check are not started; by default Fig remains enabled and these services run.

* **Tests**
  * Added unit tests verifying the disable flag behavior and that Fig’s workers and health check are present when enabled and absent when disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->