### PR TITLE
Fix nested complex configuration section overrides

### DIFF
--- a/src/client/Fig.Client.Testing/Integration/ReloadableConfigurationProvider.cs
+++ b/src/client/Fig.Client.Testing/Integration/ReloadableConfigurationProvider.cs
@@ -45,18 +45,9 @@ public class ReloadableConfigurationProvider<T> : Microsoft.Extensions.Configura
         {
             Data[$"{sectionOverride}{kvp.Key}"] = kvp.Value;
 
-            // Add entries for each configuration section if they exist
-            if (configurationSections.TryGetValue(kvp.Key, out var sections) && sections != null)
+            foreach (var sectionValue in ConfigurationSectionOverrideKeyBuilder.BuildEntriesForFlattenedValue(kvp.Key, kvp.Value, configurationSections))
             {
-                foreach (var section in sections)
-                {
-                    if (!string.IsNullOrEmpty(section.SectionName))
-                    {
-                        var settingName = section.SettingNameOverride ?? kvp.Key.Split(':').Last();
-                        // We set both so that the fig property and the target property are both set correctly
-                        Data[$"{section.SectionName}:{settingName}"] = kvp.Value;
-                    }
-                }
+                Data[$"{sectionOverride}{sectionValue.Key}"] = sectionValue.Value;
             }
         }
 

--- a/src/client/Fig.Client/Configuration/ConfigurationSectionOverrideKeyBuilder.cs
+++ b/src/client/Fig.Client/Configuration/ConfigurationSectionOverrideKeyBuilder.cs
@@ -1,0 +1,84 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Configuration;
+
+namespace Fig.Client.Configuration;
+
+internal static class ConfigurationSectionOverrideKeyBuilder
+{
+    public static IEnumerable<KeyValuePair<string, string?>> BuildEntriesForFlattenedValue(
+        string flattenedKey,
+        string? value,
+        Dictionary<string, List<CustomConfigurationSection>> configurationSections)
+    {
+        if (!TryResolveSettingKey(flattenedKey, configurationSections, out var settingKey, out var relativePath, out var sections))
+        {
+            yield break;
+        }
+
+        foreach (var entry in BuildEntriesForSettingValue(settingKey, relativePath, sections, value))
+        {
+            yield return entry;
+        }
+    }
+
+    public static IEnumerable<KeyValuePair<string, string?>> BuildEntriesForSettingValue(
+        string settingKey,
+        string? relativePath,
+        IEnumerable<CustomConfigurationSection> sections,
+        string? value)
+    {
+        var leafSettingName = settingKey.Split(':').Last();
+
+        foreach (var section in sections)
+        {
+            var sectionSettingName = string.IsNullOrWhiteSpace(section.SettingNameOverride)
+                ? leafSettingName
+                : section.SettingNameOverride!;
+
+            var key = string.IsNullOrWhiteSpace(section.SectionName)
+                ? sectionSettingName
+                : ConfigurationPath.Combine(section.SectionName, sectionSettingName);
+
+            if (!string.IsNullOrWhiteSpace(relativePath))
+            {
+                key = ConfigurationPath.Combine(key, relativePath);
+            }
+
+            yield return new KeyValuePair<string, string?>(key, value);
+        }
+    }
+
+    private static bool TryResolveSettingKey(
+        string flattenedKey,
+        Dictionary<string, List<CustomConfigurationSection>> configurationSections,
+        out string settingKey,
+        out string? relativePath,
+        out List<CustomConfigurationSection> sections)
+    {
+        var candidate = flattenedKey;
+
+        while (true)
+        {
+            if (configurationSections.TryGetValue(candidate, out sections))
+            {
+                settingKey = candidate;
+                relativePath = candidate.Length == flattenedKey.Length
+                    ? null
+                    : flattenedKey.Substring(candidate.Length + 1);
+                return true;
+            }
+
+            var separatorIndex = candidate.LastIndexOf(':');
+            if (separatorIndex < 0)
+            {
+                settingKey = string.Empty;
+                relativePath = null;
+                sections = [];
+                return false;
+            }
+
+            candidate = candidate.Substring(0, separatorIndex);
+        }
+    }
+}

--- a/src/client/Fig.Client/ConfigurationProvider/FigConfigurationProvider.cs
+++ b/src/client/Fig.Client/ConfigurationProvider/FigConfigurationProvider.cs
@@ -336,17 +336,9 @@ public class FigConfigurationProvider : Microsoft.Extensions.Configuration.Confi
         {
             result[kvp.Key] = kvp.Value;
 
-            if (normalizedSections.TryGetValue(kvp.Key, out var sections) && sections != null)
+            foreach (var sectionValue in ConfigurationSectionOverrideKeyBuilder.BuildEntriesForFlattenedValue(kvp.Key, kvp.Value, normalizedSections))
             {
-                foreach (var section in sections)
-                {
-                    if (!string.IsNullOrEmpty(section.SectionName))
-                    {
-                        var settingName = section.SettingNameOverride ?? kvp.Key.Split(':').Last();
-                        // If the configuration setting value is set, we set it in both places.
-                        result[$"{section.SectionName}:{settingName}"] = kvp.Value;
-                    }
-                }
+                result[sectionValue.Key] = sectionValue.Value;
             }
         }
 

--- a/src/client/Fig.Client/ExtensionMethods/SettingDataContractExtensionMethods.cs
+++ b/src/client/Fig.Client/ExtensionMethods/SettingDataContractExtensionMethods.cs
@@ -43,17 +43,9 @@ internal static class SettingDataContractExtensionMethods
             // Add entries for each configuration section if they exist
             if (configurationSections.TryGetValue(setting.Name, out var sections) && sections != null)
             {
-                foreach (var section in sections)
+                foreach (var sectionValue in ConfigurationSectionOverrideKeyBuilder.BuildEntriesForSettingValue(joinedName, null, sections, settingValue))
                 {
-                    var sectionSettingName = section.SettingNameOverride ?? simplifiedName;
-                    if (!string.IsNullOrEmpty(section.SectionName))
-                    {
-                        dictionary[$"{section.SectionName}:{sectionSettingName}"] = settingValue;
-                    }
-                    else
-                    {
-                        dictionary[sectionSettingName] = settingValue;
-                    }
+                    dictionary[sectionValue.Key] = sectionValue.Value;
                 }
             }
         }
@@ -61,19 +53,25 @@ internal static class SettingDataContractExtensionMethods
         foreach (var setting in settings.Where(IsDataGrid))
         {
             var value = ((DataGridSettingDataContract)setting.Value!)!.Value;
-            
-            if (value is null)
-            {
-                dictionary[setting.Name] = null;
-                continue;
-            }
-            
+            var settingName = setting.Name.Replace(Constants.SettingPathSeparator, ":");
             var sections = new List<CustomConfigurationSection>();
             if (configurationSections.TryGetValue(setting.Name, out var configSections) && configSections != null)
             {
                 sections = configSections;
             }
-            
+
+            if (value is null)
+            {
+                dictionary[settingName] = null;
+
+                foreach (var sectionValue in ConfigurationSectionOverrideKeyBuilder.BuildEntriesForSettingValue(settingName, null, sections, null))
+                {
+                    dictionary[sectionValue.Key] = sectionValue.Value;
+                }
+
+                continue;
+            }
+
             var rowIndex = 0;
             var isBaseTypeList = value.FirstOrDefault()?.Count == 1 && value.First().First().Key == "Values";
             foreach (var row in value)
@@ -81,49 +79,33 @@ internal static class SettingDataContractExtensionMethods
                 foreach (var kvp in row)
                 {
                     // Add the setting with default path
-                    var settingName = setting.Name.Replace(Constants.SettingPathSeparator, ":");
-                    var path = isBaseTypeList
-                        ? ConfigurationPath.Combine(settingName!, rowIndex.ToString())
-                        : ConfigurationPath.Combine(settingName!, rowIndex.ToString(), kvp.Key);
-                    
+                    var relativePath = isBaseTypeList
+                        ? rowIndex.ToString()
+                        : ConfigurationPath.Combine(rowIndex.ToString(), kvp.Key);
+                    var path = ConfigurationPath.Combine(settingName, relativePath);
+
                     if (kvp.Value is JArray arr)
                     {
                         for (var i = 0; i < arr.Count; i++)
                         {
-                            dictionary[ConfigurationPath.Combine(path, i.ToString())] = arr[i].ToString();
+                            var arrayRelativePath = ConfigurationPath.Combine(relativePath, i.ToString());
+                            var arrayPath = ConfigurationPath.Combine(settingName, arrayRelativePath);
+                            dictionary[arrayPath] = arr[i].ToString();
+
+                            foreach (var sectionValue in ConfigurationSectionOverrideKeyBuilder.BuildEntriesForSettingValue(settingName, arrayRelativePath, sections, arr[i].ToString()))
+                            {
+                                dictionary[sectionValue.Key] = sectionValue.Value;
+                            }
                         }
                     }
                     else
                     {
-                        dictionary[path] = Convert.ToString(kvp.Value, CultureInfo.InvariantCulture)?.ReplaceConstants(ipAddressResolver);
-                    }
-                    
-                    // Add the setting for each configuration section
-                    foreach (var section in sections)
-                    {
-                        if (!string.IsNullOrWhiteSpace(section.SectionName))
+                        var formattedValue = Convert.ToString(kvp.Value, CultureInfo.InvariantCulture)?.ReplaceConstants(ipAddressResolver);
+                        dictionary[path] = formattedValue;
+
+                        foreach (var sectionValue in ConfigurationSectionOverrideKeyBuilder.BuildEntriesForSettingValue(settingName, relativePath, sections, formattedValue))
                         {
-                            var sectionSettingName = !string.IsNullOrWhiteSpace(section.SettingNameOverride)
-                                ? section.SettingNameOverride
-                                : settingName;
-                                
-                            var sectionPath = isBaseTypeList
-                                ? ConfigurationPath.Combine(sectionSettingName!, rowIndex.ToString())
-                                : ConfigurationPath.Combine(sectionSettingName!, rowIndex.ToString(), kvp.Key);
-                                
-                            sectionPath = ConfigurationPath.Combine(section.SectionName, sectionPath);
-                            
-                            if (kvp.Value is JArray sectionArr)
-                            {
-                                for (var i = 0; i < sectionArr.Count; i++)
-                                {
-                                    dictionary[ConfigurationPath.Combine(sectionPath, i.ToString())] = sectionArr[i].ToString();
-                                }
-                            }
-                            else
-                            {
-                                dictionary[sectionPath] = Convert.ToString(kvp.Value, CultureInfo.InvariantCulture)?.ReplaceConstants(ipAddressResolver);
-                            }
+                            dictionary[sectionValue.Key] = sectionValue.Value;
                         }
                     }
                 }
@@ -139,30 +121,20 @@ internal static class SettingDataContractExtensionMethods
             {
                 var parser = new JsonValueParser();
                 var parsedValues = parser.ParseJsonValue(value);
-                
-                // Add the setting with default path
+                var settingName = setting.Name.Replace(Constants.SettingPathSeparator, ":");
+                var sections = configurationSections.TryGetValue(setting.Name, out var configSections) && configSections != null
+                    ? configSections
+                    : [];
+
                 foreach (var kvp in parsedValues)
                 {
-                    var key = ConfigurationPath.Combine(setting.Name, kvp.Key)
-                        .Replace(Constants.SettingPathSeparator, ":");
-                    dictionary[key] = kvp.Value.ReplaceConstants(ipAddressResolver);
-                }
-                
-                // Add the setting for each configuration section
-                if (configurationSections.TryGetValue(setting.Name, out var sections) && sections != null)
-                {
-                    foreach (var section in sections)
+                    var formattedValue = kvp.Value.ReplaceConstants(ipAddressResolver);
+                    var key = ConfigurationPath.Combine(settingName, kvp.Key);
+                    dictionary[key] = formattedValue;
+
+                    foreach (var sectionValue in ConfigurationSectionOverrideKeyBuilder.BuildEntriesForSettingValue(settingName, kvp.Key, sections, formattedValue))
                     {
-                        if (!string.IsNullOrEmpty(section.SectionName))
-                        {
-                            var sectionSettingName = section.SettingNameOverride ?? setting.Name;
-                            foreach (var kvp in parsedValues)
-                            {
-                                var key = ConfigurationPath.Combine(section.SectionName!, sectionSettingName, kvp.Key)
-                                    .Replace(Constants.SettingPathSeparator, ":");
-                                dictionary[key] = kvp.Value.ReplaceConstants(ipAddressResolver);
-                            }
-                        }
+                        dictionary[sectionValue.Key] = sectionValue.Value;
                     }
                 }
             }

--- a/src/client/Fig.Client/Fig.Client.csproj
+++ b/src/client/Fig.Client/Fig.Client.csproj
@@ -32,6 +32,7 @@
 	    <InternalsVisibleTo Include="Fig.Unit.Test" />
 	    <InternalsVisibleTo Include="Fig.Integration.Test" />
 	    <InternalsVisibleTo Include="Fig.Test.Common" />
+	    <InternalsVisibleTo Include="Fig.Client.Testing" />
 	    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
     </ItemGroup>
     <ItemGroup>

--- a/src/tests/Fig.Integration.Test/Client/ComplexConfigurationSectionTests.cs
+++ b/src/tests/Fig.Integration.Test/Client/ComplexConfigurationSectionTests.cs
@@ -1,0 +1,168 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Fig.Client.ExtensionMethods;
+using Fig.Contracts.Settings;
+using Fig.Test.Common;
+using Fig.Test.Common.TestSettings;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+
+namespace Fig.Integration.Test.Client;
+
+public class ComplexConfigurationSectionTests : IntegrationTestBase
+{
+    [Test]
+    public void ShallApplyComplexConfigurationSectionsWhenFigIsOfflineAndNoBackup()
+    {
+        var secret = GetNewSecret();
+        using var offlineHttpClient = new HttpClient
+        {
+            BaseAddress = new Uri("http://localhost:9999"),
+        };
+
+        using var context = InitializeAndGetComplexSettings(secret, offlineHttpClient);
+        AssertConnections(context, "primary-user", "primary-password", "secondary-user", "secondary-password");
+    }
+
+    [Test]
+    public void ShallApplyComplexConfigurationSectionsWhenFigIsOnline()
+    {
+        var secret = GetNewSecret();
+        using var context = InitializeAndGetComplexSettings(secret);
+        AssertConnections(context, "primary-user", "primary-password", "secondary-user", "secondary-password");
+    }
+
+    [Test]
+    public async Task ShallApplyComplexConfigurationSectionsWhenValuesHaveBeenUpdated()
+    {
+        var secret = GetNewSecret();
+        using var context = InitializeAndGetComplexSettings(secret);
+        var clientName = new ClientWithComplexConfigurationSections().ClientName;
+
+        var settings = new List<SettingDataContract>
+        {
+            new("Database->Connections", new DataGridSettingDataContract(
+            [
+                new Dictionary<string, object?>
+                {
+                    ["UserName"] = "updated-user",
+                    ["Password"] = "updated-password",
+                },
+            ])),
+        };
+
+        await SetSettings(clientName, settings);
+        context.Configuration.Reload();
+
+        AssertConnections(context, "updated-user", "updated-password");
+    }
+
+    private ComplexSettingsContext InitializeAndGetComplexSettings(string clientSecret, HttpClient? httpClientOverride = null)
+    {
+        var builder = WebApplication.CreateBuilder();
+        var settings = new ClientWithComplexConfigurationSections();
+
+        var configuration = new ConfigurationBuilder()
+            .AddFig<ClientWithComplexConfigurationSections>(o =>
+            {
+                o.ClientName = settings.ClientName;
+                o.HttpClient = httpClientOverride ?? GetHttpClient();
+                o.ClientSecretOverride = clientSecret;
+            })
+            .Build();
+
+        builder.Services.Configure<ConnectionOverrideSettings>(configuration.GetSection("ConnectionOverrides"));
+        builder.Services.Configure<DatabaseSectionSettings>(configuration.GetSection("Database"));
+
+        var app = builder.Build();
+
+        return new ComplexSettingsContext(
+            app,
+            configuration,
+            app.Services.GetRequiredService<IOptionsMonitor<ConnectionOverrideSettings>>(),
+            app.Services.GetRequiredService<IOptionsMonitor<DatabaseSectionSettings>>());
+    }
+
+    private static void AssertConnections(
+        ComplexSettingsContext context,
+        string firstUserName,
+        string firstPassword,
+        string? secondUserName = null,
+        string? secondPassword = null)
+    {
+        Assert.That(context.Configuration["Database:Connections:0:UserName"], Is.EqualTo(firstUserName));
+        Assert.That(context.Configuration["ConnectionOverrides:ReplicaConnections:0:Password"], Is.EqualTo(firstPassword));
+        Assert.That(context.Configuration["ConnectionOverrides:ReplicaConnections"], Is.Null);
+
+        Assert.That(context.DatabaseSettings.CurrentValue.Connections, Is.Not.Null);
+        Assert.That(context.OverrideSettings.CurrentValue.ReplicaConnections, Is.Not.Null);
+        Assert.That(context.DatabaseSettings.CurrentValue.Connections!.Count, Is.EqualTo(context.OverrideSettings.CurrentValue.ReplicaConnections!.Count));
+        Assert.That(context.DatabaseSettings.CurrentValue.Connections[0].UserName, Is.EqualTo(firstUserName));
+        Assert.That(context.DatabaseSettings.CurrentValue.Connections[0].Password, Is.EqualTo(firstPassword));
+        Assert.That(context.OverrideSettings.CurrentValue.ReplicaConnections[0].UserName, Is.EqualTo(firstUserName));
+        Assert.That(context.OverrideSettings.CurrentValue.ReplicaConnections[0].Password, Is.EqualTo(firstPassword));
+
+        if (secondUserName is null || secondPassword is null)
+        {
+            Assert.That(context.Configuration["Database:Connections:1:UserName"], Is.Null);
+            Assert.That(context.Configuration["ConnectionOverrides:ReplicaConnections:1:UserName"], Is.Null);
+            Assert.That(context.DatabaseSettings.CurrentValue.Connections.Count, Is.EqualTo(1));
+            Assert.That(context.OverrideSettings.CurrentValue.ReplicaConnections.Count, Is.EqualTo(1));
+            return;
+        }
+
+        Assert.That(context.Configuration["Database:Connections:1:UserName"], Is.EqualTo(secondUserName));
+        Assert.That(context.Configuration["ConnectionOverrides:ReplicaConnections:1:Password"], Is.EqualTo(secondPassword));
+        Assert.That(context.DatabaseSettings.CurrentValue.Connections.Count, Is.EqualTo(2));
+        Assert.That(context.OverrideSettings.CurrentValue.ReplicaConnections.Count, Is.EqualTo(2));
+        Assert.That(context.DatabaseSettings.CurrentValue.Connections[1].UserName, Is.EqualTo(secondUserName));
+        Assert.That(context.DatabaseSettings.CurrentValue.Connections[1].Password, Is.EqualTo(secondPassword));
+        Assert.That(context.OverrideSettings.CurrentValue.ReplicaConnections[1].UserName, Is.EqualTo(secondUserName));
+        Assert.That(context.OverrideSettings.CurrentValue.ReplicaConnections[1].Password, Is.EqualTo(secondPassword));
+    }
+
+    private sealed class ComplexSettingsContext : IDisposable
+    {
+        public ComplexSettingsContext(
+            WebApplication application,
+            IConfigurationRoot configuration,
+            IOptionsMonitor<ConnectionOverrideSettings> overrideSettings,
+            IOptionsMonitor<DatabaseSectionSettings> databaseSettings)
+        {
+            Application = application;
+            Configuration = configuration;
+            OverrideSettings = overrideSettings;
+            DatabaseSettings = databaseSettings;
+        }
+
+        public WebApplication Application { get; }
+
+        public IConfigurationRoot Configuration { get; }
+
+        public IOptionsMonitor<ConnectionOverrideSettings> OverrideSettings { get; }
+
+        public IOptionsMonitor<DatabaseSectionSettings> DatabaseSettings { get; }
+
+        public void Dispose()
+        {
+            Application.StopAsync().GetAwaiter().GetResult();
+            Application.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            (Configuration as IDisposable)?.Dispose();
+        }
+    }
+
+    public class ConnectionOverrideSettings
+    {
+        public List<ComplexConnection>? ReplicaConnections { get; set; }
+    }
+
+    public class DatabaseSectionSettings
+    {
+        public List<ComplexConnection>? Connections { get; set; }
+    }
+}

--- a/src/tests/Fig.Test.Common/TestSettings/ClientWithComplexConfigurationSections.cs
+++ b/src/tests/Fig.Test.Common/TestSettings/ClientWithComplexConfigurationSections.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using Fig.Client.Abstractions.Attributes;
+
+namespace Fig.Test.Common.TestSettings;
+
+public class ClientWithComplexConfigurationSections : TestSettingsBase
+{
+    public override string ClientName => "ClientWithComplexConfigurationSections";
+
+    public override string ClientDescription => "ClientWithComplexConfigurationSections";
+
+    [NestedSetting]
+    public ComplexDatabaseSettings Database { get; set; } = new();
+
+    public override IEnumerable<string> GetValidationErrors() => [];
+}
+
+public class ComplexDatabaseSettings
+{
+    [Setting("Complex database connection overrides", true, nameof(GetDefaultConnections))]
+    [ConfigurationSectionOverride("ConnectionOverrides", "ReplicaConnections")]
+    public List<ComplexConnection> Connections { get; set; } = GetDefaultConnections();
+
+    public static List<ComplexConnection> GetDefaultConnections() =>
+    [
+        new()
+        {
+            UserName = "primary-user",
+            Password = "primary-password",
+        },
+        new()
+        {
+            UserName = "secondary-user",
+            Password = "secondary-password",
+        },
+    ];
+}
+
+public class ComplexConnection
+{
+    public string UserName { get; set; } = string.Empty;
+
+    public string Password { get; set; } = string.Empty;
+}

--- a/src/tests/Fig.Unit.Test/Client/ReloadableConfigurationProviderTests.cs
+++ b/src/tests/Fig.Unit.Test/Client/ReloadableConfigurationProviderTests.cs
@@ -175,6 +175,42 @@ public class ReloadableConfigurationProviderTests
         public string ConnStr { get; set; } = "Server=test";
     }
 
+    public class NestedComplexOverrideSettings : SettingsBase
+    {
+        public override string ClientDescription => "Nested settings with complex override";
+
+        [NestedSetting]
+        public ComplexOverrideDb Database { get; set; } = new();
+
+        public override IEnumerable<string> GetValidationErrors() => [];
+    }
+
+    public class ComplexOverrideDb
+    {
+        [Setting("Database connections")]
+        [ConfigurationSectionOverride("ConnectionOverrides", "ReplicaConnections")]
+        public List<ConnectionInfo> Connections { get; set; } =
+        [
+            new()
+            {
+                UserName = "primary-user",
+                Password = "primary-password",
+            },
+            new()
+            {
+                UserName = "secondary-user",
+                Password = "secondary-password",
+            },
+        ];
+    }
+
+    public class ConnectionInfo
+    {
+        public string UserName { get; set; } = string.Empty;
+
+        public string Password { get; set; } = string.Empty;
+    }
+
     #endregion
 
     #region Helper Methods
@@ -362,6 +398,47 @@ public class ReloadableConfigurationProviderTests
         var config = BuildConfiguration(settings);
 
         Assert.That(config["TopLevel"], Is.EqualTo("TopValue"));
+    }
+
+    // 15. Nested complex setting with ConfigurationSectionOverride mirrors child keys into the override section
+    [Test]
+    public void ShallPopulateOverrideSectionForNestedComplexSetting()
+    {
+        var settings = new NestedComplexOverrideSettings();
+        var config = BuildConfiguration(settings);
+
+        Assert.That(config["Database:Connections:0:UserName"], Is.EqualTo("primary-user"));
+        Assert.That(config["Database:Connections:1:Password"], Is.EqualTo("secondary-password"));
+        Assert.That(config["ConnectionOverrides:ReplicaConnections:0:UserName"], Is.EqualTo("primary-user"));
+        Assert.That(config["ConnectionOverrides:ReplicaConnections:1:Password"], Is.EqualTo("secondary-password"));
+        Assert.That(config["ConnectionOverrides:ReplicaConnections"], Is.Null);
+    }
+
+    // 16. Reload mirrors nested complex override keys and clears stale child entries
+    [Test]
+    public void ShallUpdateOverrideSectionsOnReloadForNestedComplexSettings()
+    {
+        var settings = new NestedComplexOverrideSettings();
+        var reloader = new ConfigReloader<SettingsBase>();
+        var config = BuildConfiguration(settings, reloader);
+
+        Assert.That(config["ConnectionOverrides:ReplicaConnections:0:UserName"], Is.EqualTo("primary-user"));
+
+        settings.Database.Connections =
+        [
+            new()
+            {
+                UserName = "updated-user",
+                Password = "updated-password",
+            },
+        ];
+
+        reloader.Reload(settings);
+
+        Assert.That(config["Database:Connections:0:UserName"], Is.EqualTo("updated-user"));
+        Assert.That(config["ConnectionOverrides:ReplicaConnections:0:Password"], Is.EqualTo("updated-password"));
+        Assert.That(config["Database:Connections:1:UserName"], Is.Null);
+        Assert.That(config["ConnectionOverrides:ReplicaConnections:1:UserName"], Is.Null);
     }
 
     // 14. All keys present after reload (no stale keys from previous load)


### PR DESCRIPTION
## Summary
- add shared override key generation for flattened complex values
- reuse it in the reloadable provider, default fallback, and shared data-provider formatting paths
- add unit and integration regression coverage for nested `List<T>` configuration-section overrides

## Validation
- `cd src && dotnet build Fig.sln --configuration Release --no-restore`
- `dotnet test tests/Fig.Unit.Test/Fig.Unit.Test.csproj --configuration Release --no-build --verbosity minimal`
- `dotnet test tests/Fig.Integration.Test/Fig.Integration.Test.csproj --configuration Release --no-build --filter "FullyQualifiedName=Fig.Integration.Test.Client.ComplexConfigurationSectionTests.ShallApplyComplexConfigurationSectionsWhenFigIsOfflineAndNoBackup" --verbosity minimal`
- `dotnet test tests/Fig.Integration.Test/Fig.Integration.Test.csproj --configuration Release --no-build --filter "FullyQualifiedName=Fig.Integration.Test.Client.ComplexConfigurationSectionTests.ShallApplyComplexConfigurationSectionsWhenFigIsOnline" --verbosity minimal`
- `dotnet test tests/Fig.Integration.Test/Fig.Integration.Test.csproj --configuration Release --no-build --filter "FullyQualifiedName=Fig.Integration.Test.Client.ComplexConfigurationSectionTests.ShallApplyComplexConfigurationSectionsWhenValuesHaveBeenUpdated" --verbosity minimal`

## Notes
- The repository does not currently have a remote `master` branch, so this PR targets `main`.
- The full integration suite still aborts in the existing test harness even when `ComplexConfigurationSectionTests` is excluded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated configuration section override key-building into a dedicated builder, simplifying and standardizing how flattened and section-scoped configuration keys are generated and applied.

* **Tests**
  * Added integration and unit tests covering complex nested configuration sections, end-to-end mapping, and reload/update scenarios to verify correct override key population and value updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->