### PR TITLE
Fix nested category heading propagation

### DIFF
--- a/src/client/Fig.Client/CategoryMetadataResolver.cs
+++ b/src/client/Fig.Client/CategoryMetadataResolver.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Linq;
+using Fig.Client.Abstractions.Attributes;
+
+namespace Fig.Client;
+
+internal static class CategoryMetadataResolver
+{
+    public static bool IsCategoryAttribute(Attribute attribute)
+    {
+        return attribute is CategoryAttribute || IsGenericCategoryAttributeType(attribute.GetType());
+    }
+
+    public static bool TryGetCategoryMetadata(Attribute attribute, out CategoryMetadata metadata)
+    {
+        if (attribute is CategoryAttribute categoryAttribute)
+        {
+            metadata = new CategoryMetadata(categoryAttribute.Name, categoryAttribute.ColorHex);
+            return true;
+        }
+
+        if (IsGenericCategoryAttributeType(attribute.GetType()))
+        {
+            var nameProperty = attribute.GetType().GetProperty("Name");
+            var colorProperty = attribute.GetType().GetProperty("ColorHex");
+
+            metadata = new CategoryMetadata(
+                nameProperty?.GetValue(attribute) as string,
+                colorProperty?.GetValue(attribute) as string);
+            return true;
+        }
+
+        metadata = default;
+        return false;
+    }
+
+    public static CategoryMetadata? GetEffectiveCategory(SettingDetails settingDetails)
+    {
+        CategoryMetadata? effectiveCategory = null;
+
+        foreach (var attribute in settingDetails.InheritedAttributes
+                     .Concat(settingDetails.Property.GetCustomAttributes(true).Cast<Attribute>()))
+        {
+            if (TryGetCategoryMetadata(attribute, out var categoryMetadata))
+            {
+                effectiveCategory = categoryMetadata;
+            }
+        }
+
+        return effectiveCategory;
+    }
+
+    private static bool IsGenericCategoryAttributeType(Type attributeType)
+    {
+        return attributeType.IsGenericType &&
+               attributeType.GetGenericTypeDefinition() == typeof(CategoryAttribute<>);
+    }
+}
+
+internal readonly struct CategoryMetadata
+{
+    public CategoryMetadata(string? name, string? colorHex)
+    {
+        Name = name;
+        ColorHex = colorHex;
+    }
+
+    public string? Name { get; }
+
+    public string? ColorHex { get; }
+}

--- a/src/client/Fig.Client/SettingDefinitionFactory.cs
+++ b/src/client/Fig.Client/SettingDefinitionFactory.cs
@@ -196,23 +196,8 @@ internal class SettingDefinitionFactory : ISettingDefinitionFactory
             case InitOnlyExportAttribute:
                 setting.InitOnlyExport = true;
                 break;
-            case CategoryAttribute categoryAttribute:
-                ValidateCategoryAttribute(categoryAttribute, settingDetails.Name);
-                setting.CategoryName = categoryAttribute.Name;
-                setting.CategoryColor = categoryAttribute.ColorHex;
-                break;
-            case { } genericCategoryAttribute when genericCategoryAttribute.GetType().IsGenericType && 
-                                                   genericCategoryAttribute.GetType().GetGenericTypeDefinition() == typeof(CategoryAttribute<>):
-                // Handle CategoryAttribute<TEnum>
-                var nameProperty = genericCategoryAttribute.GetType().GetProperty("Name");
-                var colorProperty = genericCategoryAttribute.GetType().GetProperty("ColorHex");
-                var categoryName = nameProperty?.GetValue(genericCategoryAttribute) as string;
-                var categoryColor = colorProperty?.GetValue(genericCategoryAttribute) as string;
-
-                ValidateGenericCategoryAttribute(categoryColor, settingDetails.Name);
-
-                setting.CategoryName = categoryName;
-                setting.CategoryColor = categoryColor;
+            case { } categoryAttribute when CategoryMetadataResolver.IsCategoryAttribute(categoryAttribute):
+                SetCategory(categoryAttribute, settingDetails.Name, setting);
                 break;
             case DisplayScriptAttribute scriptAttribute:
                 setting.DisplayScript = scriptAttribute.DisplayScript;
@@ -375,6 +360,26 @@ internal class SettingDefinitionFactory : ISettingDefinitionFactory
         }
     }
 
+    private static void SetCategory(Attribute categoryAttribute, string propertyName, SettingDefinitionDataContract setting)
+    {
+        if (!CategoryMetadataResolver.TryGetCategoryMetadata(categoryAttribute, out var categoryMetadata))
+        {
+            return;
+        }
+
+        if (categoryAttribute is CategoryAttribute directCategoryAttribute)
+        {
+            ValidateCategoryAttribute(directCategoryAttribute, propertyName);
+        }
+        else
+        {
+            ValidateGenericCategoryAttribute(categoryMetadata.ColorHex, propertyName);
+        }
+
+        setting.CategoryName = categoryMetadata.Name;
+        setting.CategoryColor = categoryMetadata.ColorHex;
+    }
+
     private static string ValidateDependsOnAttribute(DependsOnAttribute attribute, string propertyName, List<SettingDetails>? allSettings)
     {
         // Validate DependsOnProperty is specified
@@ -473,28 +478,10 @@ internal class SettingDefinitionFactory : ISettingDefinitionFactory
     {
         for (var i = 0; i < currentSettingIndex; i++)
         {
-            var previousSetting = allSettings[i];
-            
-            // Check all attributes for both CategoryAttribute and CategoryAttribute<TEnum>
-            foreach (var attr in previousSetting.Property.GetCustomAttributes())
+            var previousCategoryName = CategoryMetadataResolver.GetEffectiveCategory(allSettings[i])?.Name;
+            if (previousCategoryName == categoryName)
             {
-                string? previousCategoryName = null;
-                
-                if (attr is CategoryAttribute categoryAttribute)
-                {
-                    previousCategoryName = categoryAttribute.Name;
-                }
-                else if (attr.GetType().IsGenericType && 
-                         attr.GetType().GetGenericTypeDefinition() == typeof(CategoryAttribute<>))
-                {
-                    var nameProperty = attr.GetType().GetProperty("Name");
-                    previousCategoryName = nameProperty?.GetValue(attr) as string;
-                }
-
-                if (previousCategoryName == categoryName)
-                {
-                    return false;
-                }
+                return false;
             }
         }
         

--- a/src/client/Fig.Client/SettingsBase.cs
+++ b/src/client/Fig.Client/SettingsBase.cs
@@ -207,6 +207,7 @@ public abstract class SettingsBase
 
         return allAttributes.Where(attr => 
             attr is not NestedSettingAttribute &&
-            inheritableAttributeTypes.Any(t => t.IsAssignableFrom(attr.GetType())));
+            (CategoryMetadataResolver.IsCategoryAttribute(attr) ||
+             inheritableAttributeTypes.Any(t => t.IsAssignableFrom(attr.GetType()))));
     }
 }

--- a/src/tests/Fig.Unit.Test/Client/ApplyAutomaticHeadingGenerationTests.cs
+++ b/src/tests/Fig.Unit.Test/Client/ApplyAutomaticHeadingGenerationTests.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using Fig.Client;
 using Fig.Client.Abstractions.Attributes;
 using Fig.Client.Description;
@@ -185,6 +186,77 @@ namespace Fig.Unit.Test.Client
             var log2Result = _factory.Create(log2Details, "TestClient", 3, allSettings, automaticallyGenerateHeadings: true);
             Assert.That(log2Result.Heading, Is.Null); // Should not add heading as Logging category already seen
         }
+
+        [Test]
+        public void ApplyAutomaticHeadingGeneration_ForNestedInheritedCategory_ShouldOnlyAddHeadingToFirstNestedSetting()
+        {
+            // Arrange
+            var settings = new TestSettingsWithInheritedNestedCategory();
+
+            // Act
+            var dataContract = settings.CreateDataContract("TestClient");
+            var connectionString = dataContract.Settings.Single(s => s.Name == "Database->ConnectionString");
+            var anotherSetting = dataContract.Settings.Single(s => s.Name == "Database->AnotherSetting");
+
+            // Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(connectionString.CategoryName, Is.EqualTo("File Handling"));
+                Assert.That(connectionString.CategoryColor, Is.EqualTo("#357535"));
+                Assert.That(connectionString.Heading?.Text, Is.EqualTo("File Handling"));
+
+                Assert.That(anotherSetting.CategoryName, Is.EqualTo("File Handling"));
+                Assert.That(anotherSetting.CategoryColor, Is.EqualTo("#357535"));
+                Assert.That(anotherSetting.Heading, Is.Null);
+            });
+        }
+
+        [Test]
+        public void ApplyAutomaticHeadingGeneration_ForNestedGenericInheritedCategory_ShouldOnlyAddHeadingToFirstNestedSetting()
+        {
+            // Arrange
+            var settings = new TestSettingsWithGenericInheritedNestedCategory();
+
+            // Act
+            var dataContract = settings.CreateDataContract("TestClient");
+            var apiKey = dataContract.Settings.Single(s => s.Name == "Payments->ApiKey");
+            var endpoint = dataContract.Settings.Single(s => s.Name == "Payments->Endpoint");
+
+            // Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(apiKey.CategoryName, Is.EqualTo("My Custom Category"));
+                Assert.That(apiKey.CategoryColor, Is.EqualTo("#FF5733"));
+                Assert.That(apiKey.Heading?.Text, Is.EqualTo("My Custom Category"));
+
+                Assert.That(endpoint.CategoryName, Is.EqualTo("My Custom Category"));
+                Assert.That(endpoint.CategoryColor, Is.EqualTo("#FF5733"));
+                Assert.That(endpoint.Heading, Is.Null);
+            });
+        }
+
+        [Test]
+        public void ApplyAutomaticHeadingGeneration_WhenSiblingBeforeNestedSettingHasSameCategory_ShouldNotAddNestedHeading()
+        {
+            // Arrange
+            var settings = new TestSettingsWithSiblingAndInheritedNestedCategory();
+
+            // Act
+            var dataContract = settings.CreateDataContract("TestClient");
+            var environmentName = dataContract.Settings.Single(s => s.Name == "EnvironmentName");
+            var connectionString = dataContract.Settings.Single(s => s.Name == "Database->ConnectionString");
+            var anotherSetting = dataContract.Settings.Single(s => s.Name == "Database->AnotherSetting");
+
+            // Assert
+            Assert.Multiple(() =>
+            {
+                Assert.That(environmentName.Heading?.Text, Is.EqualTo("File Handling"));
+                Assert.That(connectionString.CategoryName, Is.EqualTo("File Handling"));
+                Assert.That(connectionString.Heading, Is.Null);
+                Assert.That(anotherSetting.CategoryName, Is.EqualTo("File Handling"));
+                Assert.That(anotherSetting.Heading, Is.Null);
+            });
+        }
     }
 
     // Test classes
@@ -250,5 +322,60 @@ namespace Fig.Unit.Test.Client
         [Setting("Second logging setting")]
         [Fig.Client.Abstractions.Attributes.Category("Logging", "#FF6600")]
         public string Logging2 { get; set; } = "default";
+    }
+
+    public class TestSettingsWithInheritedNestedCategory : SettingsBase
+    {
+        public override string ClientDescription => "Test settings with inherited nested category";
+
+        [NestedSetting]
+        [Fig.Client.Abstractions.Attributes.Category("File Handling", "#357535")]
+        public FileHandlingNestedSettings Database { get; set; } = new();
+
+        public override IEnumerable<string> GetValidationErrors() => [];
+    }
+
+    public class TestSettingsWithGenericInheritedNestedCategory : SettingsBase
+    {
+        public override string ClientDescription => "Test settings with generic inherited nested category";
+
+        [NestedSetting]
+        [Category<TestCustomCategory>(TestCustomCategory.CustomCategory1)]
+        public PaymentNestedSettings Payments { get; set; } = new();
+
+        public override IEnumerable<string> GetValidationErrors() => [];
+    }
+
+    public class TestSettingsWithSiblingAndInheritedNestedCategory : SettingsBase
+    {
+        public override string ClientDescription => "Test settings with sibling and inherited nested category";
+
+        [Setting("Environment name")]
+        [Fig.Client.Abstractions.Attributes.Category("File Handling", "#357535")]
+        public string EnvironmentName { get; set; } = "Development";
+
+        [NestedSetting]
+        [Fig.Client.Abstractions.Attributes.Category("File Handling", "#357535")]
+        public FileHandlingNestedSettings Database { get; set; } = new();
+
+        public override IEnumerable<string> GetValidationErrors() => [];
+    }
+
+    public class FileHandlingNestedSettings
+    {
+        [Setting("Database connection string")]
+        public string ConnectionString { get; set; } = "default";
+
+        [Setting("Another database setting")]
+        public string AnotherSetting { get; set; } = "default";
+    }
+
+    public class PaymentNestedSettings
+    {
+        [Setting("Payment API key")]
+        public string ApiKey { get; set; } = "default";
+
+        [Setting("Payment endpoint")]
+        public string Endpoint { get; set; } = "default";
     }
 }

--- a/src/tests/Fig.Unit.Test/Client/NestedSettingsAttributeInheritanceTests.cs
+++ b/src/tests/Fig.Unit.Test/Client/NestedSettingsAttributeInheritanceTests.cs
@@ -40,6 +40,21 @@ public class NestedSettingsAttributeInheritanceTests
     }
 
     [Test]
+    public void GenericCategoryAttribute_OnNestedSetting_IsInheritedByChildren()
+    {
+        // Arrange
+        var settings = new NestedSettingsWithGenericCategory();
+
+        // Act
+        var dataContract = settings.CreateDataContract("TestClient");
+
+        // Assert
+        var childSetting = dataContract.Settings.First(s => s.Name == "NestedClass->ChildProperty");
+        Assert.That(childSetting.CategoryName, Is.EqualTo("My Custom Category"));
+        Assert.That(childSetting.CategoryColor, Is.EqualTo("#FF5733"));
+    }
+
+    [Test]
     public void GroupAttribute_OnNestedSetting_IsInheritedByChildren()
     {
         // Arrange
@@ -347,6 +362,17 @@ public class NestedSettingsWithCategory : SettingsBase
 
     [NestedSetting]
     [Fig.Client.Abstractions.Attributes.Category("Inherited Category", "#FF0000")]
+    public SimpleNestedClass NestedClass { get; set; } = new();
+
+    public override IEnumerable<string> GetValidationErrors() => [];
+}
+
+public class NestedSettingsWithGenericCategory : SettingsBase
+{
+    public override string ClientDescription => "Test settings with generic Category nested";
+
+    [NestedSetting]
+    [Category<TestCustomCategory>(TestCustomCategory.CustomCategory1)]
     public SimpleNestedClass NestedClass { get; set; } = new();
 
     public override IEnumerable<string> GetValidationErrors() => [];


### PR DESCRIPTION
## Summary
- resolve nested categories through a shared effective-category path so `[Category(...)]` and `[Category<TEnum>(...)]` inherit consistently
- deduplicate automatic category headings using flattened effective category order, including sibling-before-nested cases
- add regression coverage for nested generic and non-generic categories plus preserved override behavior