### PR TITLE
Add display script library and ability to use more display scripts an…

### DIFF
--- a/doc/fig-documentation/docs/features/settings-management/8-display-scripts.md
+++ b/doc/fig-documentation/docs/features/settings-management/8-display-scripts.md
@@ -141,6 +141,128 @@ If a leaf property name conflicts with a top-level setting name, the top-level s
 If two nested settings share the same leaf name (e.g., `Database1->Timeout` and `Database2->Timeout`), use dot notation to disambiguate (e.g., `Database1.Timeout` and `Database2.Timeout`).
 :::
 
+## Multiple Display Scripts
+
+Multiple `[DisplayScript]` attributes can be applied to a single setting. When a setting has multiple display scripts, they are concatenated in declaration order and all execute when the setting value changes.
+
+This enables composing smaller, focused, reusable scripts rather than writing one large monolithic script.
+
+```csharp
+[Setting("Server port")]
+[DisplayScript(DisplayScriptLibrary.ValidatePort)]
+[DisplayScript(@"
+if ({{this}}.Value === 443) {
+    {{this}}.InformationText = 'Default HTTPS port';
+} else if ({{this}}.Value === 80) {
+    {{this}}.InformationText = 'Default HTTP port';
+} else {
+    {{this}}.InformationText = null;
+}
+")]
+public int Port { get; set; } = 8080;
+```
+
+In this example, the first attribute validates the port range (1-65535) and the second adds contextual information for well-known ports. Both scripts run in sequence.
+
+:::note
+When multiple scripts modify the same property (e.g., `IsValid`), the last script to set the value wins. Order your scripts accordingly.
+:::
+
+## `{{this}}` Placeholder
+
+Display scripts support a `{{this}}` placeholder that is automatically replaced with the setting's name at registration time. This allows scripts to be reused across multiple settings without hardcoding setting names.
+
+**Before (hardcoded):**
+
+```javascript
+var port = Port.Value;
+if (port < 1 || port > 65535) {
+    Port.IsValid = false;
+    Port.ValidationExplanation = 'Port must be between 1 and 65535';
+} else {
+    Port.IsValid = true;
+}
+```
+
+**After (reusable with `{{this}}`):**
+
+```javascript
+var port = {{this}}.Value;
+if (port < 1 || port > 65535) {
+    {{this}}.IsValid = false;
+    {{this}}.ValidationExplanation = 'Port must be between 1 and 65535';
+} else {
+    {{this}}.IsValid = true;
+}
+```
+
+The `{{this}}` placeholder works correctly with nested settings. For a setting at path `Connection->Auth->Username`, `{{this}}` resolves to `Connection.Auth.Username` (using dot notation).
+
+:::tip
+Scripts that reference only the current setting should use `{{this}}` to maximize reusability. Scripts that need to reference multiple settings by name should continue to use explicit setting names.
+:::
+
+## Display Script Library
+
+Fig includes a built-in library of common display scripts in the `DisplayScriptLibrary` class (namespace `Fig.Client.Abstractions.DisplayScripts`). All library scripts use the `{{this}}` placeholder for automatic setting name resolution.
+
+### Usage
+
+```csharp
+using Fig.Client.Abstractions.DisplayScripts;
+
+[Setting("Server port")]
+[DisplayScript(DisplayScriptLibrary.ValidatePort)]
+public int Port { get; set; } = 8080;
+
+[Setting("Connection timeout in milliseconds")]
+[DisplayScript(DisplayScriptLibrary.MillisecondsToHumanReadableTime)]
+public long TimeoutMs { get; set; } = 30000;
+```
+
+### Available Scripts
+
+#### Formatters
+
+These scripts convert numeric values to human-readable text displayed as `InformationText` below the setting.
+
+| Script | Description | Applies To |
+|--------|-------------|------------|
+| `MillisecondsToHumanReadableTime` | Converts milliseconds to readable duration (e.g., "2 hours 30 minutes") | `int`, `long`, `double` |
+| `SecondsToHumanReadableTime` | Converts seconds to readable duration (e.g., "1 hour 15 minutes 30 seconds") | `int`, `long`, `double` |
+| `BytesToHumanReadableSize` | Converts bytes to readable size (e.g., "1.5 GB", "256 KB") | `int`, `long`, `double` |
+
+#### Validators
+
+These scripts validate the setting value and set `IsValid` to `false` with a `ValidationExplanation` on failure.
+
+| Script | Description | Applies To |
+|--------|-------------|------------|
+| `ValidateIpAddress` | Validates IPv4 address format (4 octets, 0-255 each) | `string` |
+| `ValidatePort` | Validates port number (1-65535) | `int`, `long` |
+| `ValidateWindowsFilename` | Validates Windows filename rules (no illegal chars, no reserved names) | `string` |
+| `ValidateLinuxFilename` | Validates Linux filename rules (no `/`, max 255 chars) | `string` |
+| `ValidateUrl` | Validates URL format (must start with `http://` or `https://`) | `string` |
+| `ValidateEmail` | Validates email address format | `string` |
+| `ValidateJson` | Validates that the string is valid JSON | `string` |
+| `ValidateHostname` | Validates RFC-1123 hostname format | `string` |
+| `ValidateCidr` | Validates CIDR notation (e.g., `192.168.1.0/24`) | `string` |
+
+### Combining Library and Custom Scripts
+
+Library scripts can be combined with custom scripts using multiple `[DisplayScript]` attributes:
+
+```csharp
+[Setting("API endpoint URL")]
+[DisplayScript(DisplayScriptLibrary.ValidateUrl)]
+[DisplayScript(@"
+if ({{this}}.Value && {{this}}.Value.indexOf('localhost') >= 0) {
+    {{this}}.InformationText = 'Warning: Using localhost - not suitable for production';
+}
+")]
+public string ApiUrl { get; set; } = "https://api.example.com";
+```
+
 ## Security
 
 There are a number of security features related to this feature:

--- a/doc/fig-documentation/versioned_docs/version-3.x/features/settings-management/8-display-scripts.md
+++ b/doc/fig-documentation/versioned_docs/version-3.x/features/settings-management/8-display-scripts.md
@@ -141,6 +141,128 @@ If a leaf property name conflicts with a top-level setting name, the top-level s
 If two nested settings share the same leaf name (e.g., `Database1->Timeout` and `Database2->Timeout`), use dot notation to disambiguate (e.g., `Database1.Timeout` and `Database2.Timeout`).
 :::
 
+## Multiple Display Scripts
+
+Multiple `[DisplayScript]` attributes can be applied to a single setting. When a setting has multiple display scripts, they are concatenated in declaration order and all execute when the setting value changes.
+
+This enables composing smaller, focused, reusable scripts rather than writing one large monolithic script.
+
+```csharp
+[Setting("Server port")]
+[DisplayScript(DisplayScriptLibrary.ValidatePort)]
+[DisplayScript(@"
+if ({{this}}.Value === 443) {
+    {{this}}.InformationText = 'Default HTTPS port';
+} else if ({{this}}.Value === 80) {
+    {{this}}.InformationText = 'Default HTTP port';
+} else {
+    {{this}}.InformationText = null;
+}
+")]
+public int Port { get; set; } = 8080;
+```
+
+In this example, the first attribute validates the port range (1-65535) and the second adds contextual information for well-known ports. Both scripts run in sequence.
+
+:::note
+When multiple scripts modify the same property (e.g., `IsValid`), the last script to set the value wins. Order your scripts accordingly.
+:::
+
+## `{{this}}` Placeholder
+
+Display scripts support a `{{this}}` placeholder that is automatically replaced with the setting's name at registration time. This allows scripts to be reused across multiple settings without hardcoding setting names.
+
+**Before (hardcoded):**
+
+```javascript
+var port = Port.Value;
+if (port < 1 || port > 65535) {
+    Port.IsValid = false;
+    Port.ValidationExplanation = 'Port must be between 1 and 65535';
+} else {
+    Port.IsValid = true;
+}
+```
+
+**After (reusable with `{{this}}`):**
+
+```javascript
+var port = {{this}}.Value;
+if (port < 1 || port > 65535) {
+    {{this}}.IsValid = false;
+    {{this}}.ValidationExplanation = 'Port must be between 1 and 65535';
+} else {
+    {{this}}.IsValid = true;
+}
+```
+
+The `{{this}}` placeholder works correctly with nested settings. For a setting at path `Connection->Auth->Username`, `{{this}}` resolves to `Connection.Auth.Username` (using dot notation).
+
+:::tip
+Scripts that reference only the current setting should use `{{this}}` to maximize reusability. Scripts that need to reference multiple settings by name should continue to use explicit setting names.
+:::
+
+## Display Script Library
+
+Fig includes a built-in library of common display scripts in the `DisplayScriptLibrary` class (namespace `Fig.Client.Abstractions.DisplayScripts`). All library scripts use the `{{this}}` placeholder for automatic setting name resolution.
+
+### Usage
+
+```csharp
+using Fig.Client.Abstractions.DisplayScripts;
+
+[Setting("Server port")]
+[DisplayScript(DisplayScriptLibrary.ValidatePort)]
+public int Port { get; set; } = 8080;
+
+[Setting("Connection timeout in milliseconds")]
+[DisplayScript(DisplayScriptLibrary.MillisecondsToHumanReadableTime)]
+public long TimeoutMs { get; set; } = 30000;
+```
+
+### Available Scripts
+
+#### Formatters
+
+These scripts convert numeric values to human-readable text displayed as `InformationText` below the setting.
+
+| Script | Description | Applies To |
+|--------|-------------|------------|
+| `MillisecondsToHumanReadableTime` | Converts milliseconds to readable duration (e.g., "2 hours 30 minutes") | `int`, `long`, `double` |
+| `SecondsToHumanReadableTime` | Converts seconds to readable duration (e.g., "1 hour 15 minutes 30 seconds") | `int`, `long`, `double` |
+| `BytesToHumanReadableSize` | Converts bytes to readable size (e.g., "1.5 GB", "256 KB") | `int`, `long`, `double` |
+
+#### Validators
+
+These scripts validate the setting value and set `IsValid` to `false` with a `ValidationExplanation` on failure.
+
+| Script | Description | Applies To |
+|--------|-------------|------------|
+| `ValidateIpAddress` | Validates IPv4 address format (4 octets, 0-255 each) | `string` |
+| `ValidatePort` | Validates port number (1-65535) | `int`, `long` |
+| `ValidateWindowsFilename` | Validates Windows filename rules (no illegal chars, no reserved names) | `string` |
+| `ValidateLinuxFilename` | Validates Linux filename rules (no `/`, max 255 chars) | `string` |
+| `ValidateUrl` | Validates URL format (must start with `http://` or `https://`) | `string` |
+| `ValidateEmail` | Validates email address format | `string` |
+| `ValidateJson` | Validates that the string is valid JSON | `string` |
+| `ValidateHostname` | Validates RFC-1123 hostname format | `string` |
+| `ValidateCidr` | Validates CIDR notation (e.g., `192.168.1.0/24`) | `string` |
+
+### Combining Library and Custom Scripts
+
+Library scripts can be combined with custom scripts using multiple `[DisplayScript]` attributes:
+
+```csharp
+[Setting("API endpoint URL")]
+[DisplayScript(DisplayScriptLibrary.ValidateUrl)]
+[DisplayScript(@"
+if ({{this}}.Value && {{this}}.Value.indexOf('localhost') >= 0) {
+    {{this}}.InformationText = 'Warning: Using localhost - not suitable for production';
+}
+")]
+public string ApiUrl { get; set; } = "https://api.example.com";
+```
+
 ## Security
 
 There are a number of security features related to this feature:

--- a/examples/Fig.Examples.DisplayScript/Scripts.cs
+++ b/examples/Fig.Examples.DisplayScript/Scripts.cs
@@ -72,6 +72,31 @@ if (seconds >= 3600) {
 }
 ";
 
+    public const string DisplayDurationWithPlaceholder = @"
+var seconds = {{this}}.Value;
+if (seconds >= 3600) {
+    var hours = Math.floor(seconds / 3600);
+    var mins = Math.floor((seconds % 3600) / 60);
+    {{this}}.InformationText = hours + ' hour(s)' + (mins > 0 ? ' ' + mins + ' minute(s)' : '');
+} else if (seconds >= 60) {
+    var mins = Math.floor(seconds / 60);
+    var secs = seconds % 60;
+    {{this}}.InformationText = mins + ' minute(s)' + (secs > 0 ? ' ' + secs + ' second(s)' : '');
+} else {
+    {{this}}.InformationText = null;
+}
+";
+
+    public const string ValidateNotEmpty = @"
+if (!{{this}}.Value || (typeof {{this}}.Value === 'string' && {{this}}.Value.trim() === '')) {
+    {{this}}.IsValid = false;
+    {{this}}.ValidationExplanation = {{this}}.Name + ' must not be empty';
+} else {
+    {{this}}.IsValid = true;
+    {{this}}.ValidationExplanation = '';
+}
+";
+
     public const string ControlOtherSettings = @"
 Option.ValidValues = ['Select Option...', 'All Read Only', 'All Writable', 'Line Count 4', 'Category Stuff', 'Category Reset'];
 if (ControlledString.Advanced) {

--- a/examples/Fig.Examples.DisplayScript/Settings.cs
+++ b/examples/Fig.Examples.DisplayScript/Settings.cs
@@ -1,5 +1,6 @@
 using Fig.Client;
 using Fig.Client.Abstractions.Attributes;
+using Fig.Client.Abstractions.DisplayScripts;
 using Fig.Client.Abstractions.Enums;
 
 namespace Fig.Examples.DisplayScript;
@@ -96,6 +97,51 @@ public class Settings : SettingsBase
     [Category("Setting Manipulation", CategoryColor.Purple)]
     public TimeSpan? ControlledTimeSpan { get; set; }
     
+    [Setting("The IP address of the server. Validated using the library's IP address validator.")]
+    [Category("Display Script Library Examples", CategoryColor.Gray)]
+    [DisplayScript(DisplayScriptLibrary.ValidateIpAddress)]
+    public string ServerIpAddress { get; set; } = "192.168.1.1";
+
+    [Setting("The port number for the server. Validated using the library's port validator.")]
+    [Category("Display Script Library Examples", CategoryColor.Gray)]
+    [DisplayScript(DisplayScriptLibrary.ValidatePort)]
+    public int ServerPort { get; set; } = 8080;
+
+    [Setting("A timeout value in milliseconds. Displays a human-readable time using the library script.")]
+    [Category("Display Script Library Examples", CategoryColor.Gray)]
+    [DisplayScript(DisplayScriptLibrary.MillisecondsToHumanReadableTime)]
+    public long ConnectionTimeoutMs { get; set; } = 90000;
+
+    [Setting("Maximum file size in bytes. Displays a human-readable size using the library script.")]
+    [Category("Display Script Library Examples", CategoryColor.Gray)]
+    [DisplayScript(DisplayScriptLibrary.BytesToHumanReadableSize)]
+    public long MaxFileSizeBytes { get; set; } = 10485760;
+
+    [Setting("The hostname of the target server. Demonstrates multiple display script attributes: " +
+             "validates hostname format AND shows contextual information for localhost.")]
+    [Category("Display Script Library Examples", CategoryColor.Gray)]
+    [DisplayScript(DisplayScriptLibrary.ValidateHostname)]
+    [DisplayScript(@"
+if ({{this}}.Value && {{this}}.Value.toLowerCase() === 'localhost') {
+    {{this}}.InformationText = 'Using localhost - not recommended for production';
+} else if ({{this}}.Value && {{this}}.Value.toLowerCase().endsWith('.local')) {
+    {{this}}.InformationText = 'Using a local network hostname';
+} else {
+    {{this}}.InformationText = null;
+}
+")]
+    public string TargetHostname { get; set; } = "localhost";
+
+    [Setting("A timeout value in seconds. Uses the {{this}} placeholder version of the duration script.")]
+    [Category("Display Script Library Examples", CategoryColor.Gray)]
+    [DisplayScript(Scripts.DisplayDurationWithPlaceholder)]
+    public int RetryTimeoutSeconds { get; set; } = 7200;
+
+    [Setting("A timeout value in seconds. Uses the library's SecondsToHumanReadableTime script.")]
+    [Category("Display Script Library Examples", CategoryColor.Gray)]
+    [DisplayScript(DisplayScriptLibrary.SecondsToHumanReadableTime)]
+    public int SessionTimeoutSeconds { get; set; } = 1800;
+
     [NestedSetting]
     [Category("Nested Settings Example", CategoryColor.Green)]
     public DatabaseConnection Connection { get; set; } = new();

--- a/src/client/Fig.Client.Abstractions/Attributes/DisplayScriptAttribute.cs
+++ b/src/client/Fig.Client.Abstractions/Attributes/DisplayScriptAttribute.cs
@@ -6,7 +6,7 @@ namespace Fig.Client.Abstractions.Attributes;
 /// Display scripts are JavaScript snippets that can be used to modify the display of settings in the UI.
 /// Using JavaScript, you can add validation, change visibility or update the value of settings among other things.
 /// </summary>
-[AttributeUsage(AttributeTargets.Property)]
+[AttributeUsage(AttributeTargets.Property, AllowMultiple = true)]
 public class DisplayScriptAttribute : Attribute
 {
     public DisplayScriptAttribute(string displayScript)

--- a/src/client/Fig.Client.Abstractions/DisplayScripts/DisplayScriptLibrary.cs
+++ b/src/client/Fig.Client.Abstractions/DisplayScripts/DisplayScriptLibrary.cs
@@ -1,0 +1,373 @@
+namespace Fig.Client.Abstractions.DisplayScripts;
+
+/// <summary>
+/// A library of predefined display scripts that can be used with the <see cref="Fig.Client.Abstractions.Attributes.DisplayScriptAttribute"/>.
+/// All scripts use the <c>{{this}}</c> placeholder which is automatically replaced with the setting name
+/// at registration time, making them reusable across any setting.
+/// </summary>
+/// <example>
+/// <code>
+/// [Setting("Server port")]
+/// [DisplayScript(DisplayScriptLibrary.ValidatePort)]
+/// public int Port { get; set; } = 8080;
+/// </code>
+/// </example>
+public static class DisplayScriptLibrary
+{
+    /// <summary>
+    /// Converts a millisecond value to a human-readable time string displayed as InformationText.
+    /// Supports days, hours, minutes, seconds, and milliseconds.
+    /// Applies to: numeric settings (int, long, double).
+    /// </summary>
+    public const string MillisecondsToHumanReadableTime = @"
+var ms = {{this}}.Value;
+if (ms == null || ms < 0) {
+    {{this}}.InformationText = null;
+} else if (ms === 0) {
+    {{this}}.InformationText = '0 milliseconds';
+} else {
+    var parts = [];
+    var days = Math.floor(ms / 86400000);
+    if (days > 0) parts.push(days + (days === 1 ? ' day' : ' days'));
+    var hours = Math.floor((ms % 86400000) / 3600000);
+    if (hours > 0) parts.push(hours + (hours === 1 ? ' hour' : ' hours'));
+    var mins = Math.floor((ms % 3600000) / 60000);
+    if (mins > 0) parts.push(mins + (mins === 1 ? ' minute' : ' minutes'));
+    var secs = Math.floor((ms % 60000) / 1000);
+    if (secs > 0) parts.push(secs + (secs === 1 ? ' second' : ' seconds'));
+    var remainingMs = ms % 1000;
+    if (remainingMs > 0) parts.push(remainingMs + ' ms');
+    {{this}}.InformationText = parts.length > 0 ? '= ' + parts.join(' ') : null;
+}
+";
+
+    /// <summary>
+    /// Converts a seconds value to a human-readable time string displayed as InformationText.
+    /// Supports days, hours, minutes, and seconds.
+    /// Applies to: numeric settings (int, long, double).
+    /// </summary>
+    public const string SecondsToHumanReadableTime = @"
+var totalSeconds = {{this}}.Value;
+if (totalSeconds == null || totalSeconds < 0) {
+    {{this}}.InformationText = null;
+} else if (totalSeconds === 0) {
+    {{this}}.InformationText = '0 seconds';
+} else {
+    var parts = [];
+    var days = Math.floor(totalSeconds / 86400);
+    if (days > 0) parts.push(days + (days === 1 ? ' day' : ' days'));
+    var hours = Math.floor((totalSeconds % 86400) / 3600);
+    if (hours > 0) parts.push(hours + (hours === 1 ? ' hour' : ' hours'));
+    var mins = Math.floor((totalSeconds % 3600) / 60);
+    if (mins > 0) parts.push(mins + (mins === 1 ? ' minute' : ' minutes'));
+    var secs = totalSeconds % 60;
+    if (secs > 0) parts.push(secs + (secs === 1 ? ' second' : ' seconds'));
+    {{this}}.InformationText = parts.length > 0 ? '= ' + parts.join(' ') : null;
+}
+";
+
+    /// <summary>
+    /// Validates that the value is a valid IPv4 address (four octets, each 0-255).
+    /// Sets IsValid to false with a ValidationExplanation on failure.
+    /// Applies to: string settings.
+    /// </summary>
+    public const string ValidateIpAddress = @"
+var ip = {{this}}.Value;
+if (!ip || typeof ip !== 'string' || ip.trim() === '') {
+    {{this}}.IsValid = false;
+    {{this}}.ValidationExplanation = 'IP address is required';
+} else {
+    var parts = ip.trim().split('.');
+    if (parts.length !== 4) {
+        {{this}}.IsValid = false;
+        {{this}}.ValidationExplanation = 'IP address must have exactly 4 octets (e.g. 192.168.1.1)';
+    } else {
+        var valid = true;
+        for (var i = 0; i < 4; i++) {
+            var octet = parts[i];
+            if (!/^\d{1,3}$/.test(octet)) { valid = false; break; }
+            var num = parseInt(octet, 10);
+            if (num < 0 || num > 255) { valid = false; break; }
+            if (octet.length > 1 && octet[0] === '0') { valid = false; break; }
+        }
+        if (valid) {
+            {{this}}.IsValid = true;
+            {{this}}.ValidationExplanation = '';
+        } else {
+            {{this}}.IsValid = false;
+            {{this}}.ValidationExplanation = 'Each octet must be a number between 0 and 255 with no leading zeros';
+        }
+    }
+}
+";
+
+    /// <summary>
+    /// Validates that the value is a valid port number (integer between 1 and 65535).
+    /// Sets IsValid to false with a ValidationExplanation on failure.
+    /// Applies to: numeric settings (int, long).
+    /// </summary>
+    public const string ValidatePort = @"
+var port = {{this}}.Value;
+if (port == null) {
+    {{this}}.IsValid = false;
+    {{this}}.ValidationExplanation = 'Port number is required';
+} else if (typeof port !== 'number' || !Number.isInteger(port)) {
+    {{this}}.IsValid = false;
+    {{this}}.ValidationExplanation = 'Port must be a whole number';
+} else if (port < 1 || port > 65535) {
+    {{this}}.IsValid = false;
+    {{this}}.ValidationExplanation = 'Port must be between 1 and 65535';
+} else {
+    {{this}}.IsValid = true;
+    {{this}}.ValidationExplanation = '';
+}
+";
+
+    /// <summary>
+    /// Validates that the value is a valid Windows filename.
+    /// Checks for illegal characters (&lt;&gt;:"/\|?*), reserved names (CON, PRN, NUL, etc.),
+    /// trailing dots/spaces, and empty values.
+    /// Sets IsValid to false with a ValidationExplanation on failure.
+    /// Applies to: string settings.
+    /// </summary>
+    public const string ValidateWindowsFilename = @"
+var filename = {{this}}.Value;
+if (!filename || typeof filename !== 'string' || filename.trim() === '') {
+    {{this}}.IsValid = false;
+    {{this}}.ValidationExplanation = 'Filename is required';
+} else if (/[<>:""/\\|?*]/.test(filename)) {
+    {{this}}.IsValid = false;
+    {{this}}.ValidationExplanation = 'Filename contains illegal characters: < > : "" / \\ | ? *';
+} else if (/[\. ]$/.test(filename)) {
+    {{this}}.IsValid = false;
+    {{this}}.ValidationExplanation = 'Filename must not end with a dot or space';
+} else {
+    var reserved = ['CON','PRN','AUX','NUL','COM1','COM2','COM3','COM4','COM5','COM6','COM7','COM8','COM9','LPT1','LPT2','LPT3','LPT4','LPT5','LPT6','LPT7','LPT8','LPT9'];
+    var nameWithoutExt = filename.split('.')[0].toUpperCase();
+    if (reserved.indexOf(nameWithoutExt) >= 0) {
+        {{this}}.IsValid = false;
+        {{this}}.ValidationExplanation = 'Filename uses a reserved Windows name: ' + nameWithoutExt;
+    } else if (filename.length > 255) {
+        {{this}}.IsValid = false;
+        {{this}}.ValidationExplanation = 'Filename must not exceed 255 characters';
+    } else {
+        {{this}}.IsValid = true;
+        {{this}}.ValidationExplanation = '';
+    }
+}
+";
+
+    /// <summary>
+    /// Validates that the value is a valid Linux filename.
+    /// Checks for forward slash, null bytes, and maximum length of 255 characters.
+    /// Sets IsValid to false with a ValidationExplanation on failure.
+    /// Applies to: string settings.
+    /// </summary>
+    public const string ValidateLinuxFilename = @"
+var filename = {{this}}.Value;
+if (!filename || typeof filename !== 'string' || filename.trim() === '') {
+    {{this}}.IsValid = false;
+    {{this}}.ValidationExplanation = 'Filename is required';
+} else if (filename.indexOf('/') >= 0) {
+    {{this}}.IsValid = false;
+    {{this}}.ValidationExplanation = 'Filename must not contain forward slash (/)';
+} else if (filename.indexOf('\0') >= 0) {
+    {{this}}.IsValid = false;
+    {{this}}.ValidationExplanation = 'Filename must not contain null bytes';
+} else if (filename.length > 255) {
+    {{this}}.IsValid = false;
+    {{this}}.ValidationExplanation = 'Filename must not exceed 255 characters';
+} else {
+    {{this}}.IsValid = true;
+    {{this}}.ValidationExplanation = '';
+}
+";
+
+    /// <summary>
+    /// Validates that the value is a valid URL starting with http:// or https://.
+    /// Sets IsValid to false with a ValidationExplanation on failure.
+    /// Applies to: string settings.
+    /// </summary>
+    public const string ValidateUrl = @"
+var url = {{this}}.Value;
+if (!url || typeof url !== 'string' || url.trim() === '') {
+    {{this}}.IsValid = false;
+    {{this}}.ValidationExplanation = 'URL is required';
+} else {
+    var pattern = /^https?:\/\/[^\s/$.?#].[^\s]*$/i;
+    if (pattern.test(url.trim())) {
+        {{this}}.IsValid = true;
+        {{this}}.ValidationExplanation = '';
+    } else {
+        {{this}}.IsValid = false;
+        {{this}}.ValidationExplanation = 'URL must start with http:// or https:// and be well-formed';
+    }
+}
+";
+
+    /// <summary>
+    /// Validates that the value is a valid email address format.
+    /// Uses a practical regex that covers common email patterns.
+    /// Sets IsValid to false with a ValidationExplanation on failure.
+    /// Applies to: string settings.
+    /// </summary>
+    public const string ValidateEmail = @"
+var email = {{this}}.Value;
+if (!email || typeof email !== 'string' || email.trim() === '') {
+    {{this}}.IsValid = false;
+    {{this}}.ValidationExplanation = 'Email address is required';
+} else {
+    var pattern = /^[a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+    if (pattern.test(email.trim())) {
+        {{this}}.IsValid = true;
+        {{this}}.ValidationExplanation = '';
+    } else {
+        {{this}}.IsValid = false;
+        {{this}}.ValidationExplanation = 'Invalid email address format';
+    }
+}
+";
+
+    /// <summary>
+    /// Validates that the value is valid JSON by attempting to parse it.
+    /// Sets IsValid to false with a ValidationExplanation on failure.
+    /// Applies to: string settings (typically with MultiLine).
+    /// </summary>
+    public const string ValidateJson = @"
+var jsonStr = {{this}}.Value;
+if (!jsonStr || typeof jsonStr !== 'string' || jsonStr.trim() === '') {
+    {{this}}.IsValid = false;
+    {{this}}.ValidationExplanation = 'JSON string is required';
+} else {
+    try {
+        JSON.parse(jsonStr);
+        {{this}}.IsValid = true;
+        {{this}}.ValidationExplanation = '';
+    } catch (e) {
+        {{this}}.IsValid = false;
+        {{this}}.ValidationExplanation = 'Invalid JSON: ' + e.message;
+    }
+}
+";
+
+    /// <summary>
+    /// Converts a byte count to a human-readable size string displayed as InformationText.
+    /// Supports bytes, KB, MB, GB, TB, and PB with up to 2 decimal places.
+    /// Applies to: numeric settings (int, long, double).
+    /// </summary>
+    public const string BytesToHumanReadableSize = @"
+var bytes = {{this}}.Value;
+if (bytes == null || bytes < 0) {
+    {{this}}.InformationText = null;
+} else if (bytes === 0) {
+    {{this}}.InformationText = '0 bytes';
+} else {
+    var units = ['bytes', 'KB', 'MB', 'GB', 'TB', 'PB'];
+    var unitIndex = 0;
+    var size = bytes;
+    while (size >= 1024 && unitIndex < units.length - 1) {
+        size = size / 1024;
+        unitIndex++;
+    }
+    var display = unitIndex === 0 ? size.toString() : size.toFixed(2).replace(/\.?0+$/, '');
+    var unit = units[unitIndex];
+    if (unitIndex === 0 && display === '1') unit = 'byte';
+    {{this}}.InformationText = '= ' + display + ' ' + unit;
+}
+";
+
+    /// <summary>
+    /// Validates that the value is a valid RFC-1123 hostname.
+    /// Labels must be 1-63 characters (alphanumeric and hyphens, not starting/ending with hyphen).
+    /// Total length must not exceed 253 characters.
+    /// Sets IsValid to false with a ValidationExplanation on failure.
+    /// Applies to: string settings.
+    /// </summary>
+    public const string ValidateHostname = @"
+var hostname = {{this}}.Value;
+if (!hostname || typeof hostname !== 'string' || hostname.trim() === '') {
+    {{this}}.IsValid = false;
+    {{this}}.ValidationExplanation = 'Hostname is required';
+} else {
+    hostname = hostname.trim();
+    if (hostname.length > 253) {
+        {{this}}.IsValid = false;
+        {{this}}.ValidationExplanation = 'Hostname must not exceed 253 characters';
+    } else {
+        var labels = hostname.split('.');
+        var valid = true;
+        var reason = '';
+        for (var i = 0; i < labels.length; i++) {
+            var label = labels[i];
+            if (label.length === 0 || label.length > 63) {
+                valid = false;
+                reason = 'Each label must be 1-63 characters long';
+                break;
+            }
+            if (!/^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?$/.test(label)) {
+                valid = false;
+                reason = 'Labels must contain only alphanumeric characters and hyphens, and must not start or end with a hyphen';
+                break;
+            }
+        }
+        if (valid) {
+            {{this}}.IsValid = true;
+            {{this}}.ValidationExplanation = '';
+        } else {
+            {{this}}.IsValid = false;
+            {{this}}.ValidationExplanation = reason;
+        }
+    }
+}
+";
+
+    /// <summary>
+    /// Validates that the value is valid CIDR notation (e.g., 192.168.1.0/24).
+    /// Validates the IPv4 address and that the prefix length is between 0 and 32.
+    /// Sets IsValid to false with a ValidationExplanation on failure.
+    /// Applies to: string settings.
+    /// </summary>
+    public const string ValidateCidr = @"
+var cidr = {{this}}.Value;
+if (!cidr || typeof cidr !== 'string' || cidr.trim() === '') {
+    {{this}}.IsValid = false;
+    {{this}}.ValidationExplanation = 'CIDR notation is required';
+} else {
+    cidr = cidr.trim();
+    var slashIndex = cidr.indexOf('/');
+    if (slashIndex < 0) {
+        {{this}}.IsValid = false;
+        {{this}}.ValidationExplanation = 'CIDR must contain a / separator (e.g. 192.168.1.0/24)';
+    } else {
+        var ipPart = cidr.substring(0, slashIndex);
+        var prefixPart = cidr.substring(slashIndex + 1);
+        var ipParts = ipPart.split('.');
+        var ipValid = ipParts.length === 4;
+        if (ipValid) {
+            for (var i = 0; i < 4; i++) {
+                var octet = ipParts[i];
+                if (!/^\d{1,3}$/.test(octet)) { ipValid = false; break; }
+                var num = parseInt(octet, 10);
+                if (num < 0 || num > 255) { ipValid = false; break; }
+            }
+        }
+        if (!ipValid) {
+            {{this}}.IsValid = false;
+            {{this}}.ValidationExplanation = 'IP address portion is not a valid IPv4 address';
+        } else if (!/^\d{1,2}$/.test(prefixPart)) {
+            {{this}}.IsValid = false;
+            {{this}}.ValidationExplanation = 'Prefix length must be a number between 0 and 32';
+        } else {
+            var prefix = parseInt(prefixPart, 10);
+            if (prefix < 0 || prefix > 32) {
+                {{this}}.IsValid = false;
+                {{this}}.ValidationExplanation = 'Prefix length must be between 0 and 32';
+            } else {
+                {{this}}.IsValid = true;
+                {{this}}.ValidationExplanation = '';
+            }
+        }
+    }
+}
+";
+}

--- a/src/client/Fig.Client.Abstractions/Fig.Client.Abstractions.csproj
+++ b/src/client/Fig.Client.Abstractions/Fig.Client.Abstractions.csproj
@@ -29,6 +29,7 @@
     </ItemGroup>
     
     <ItemGroup>
+	    <InternalsVisibleTo Include="Fig.Client" />
 	    <InternalsVisibleTo Include="Fig.Unit.Test" />
 	    <InternalsVisibleTo Include="Fig.Integration.Test" />
 	    <InternalsVisibleTo Include="Fig.Test.Common" />

--- a/src/client/Fig.Client.Abstractions/Validation/DisplayScriptPath.cs
+++ b/src/client/Fig.Client.Abstractions/Validation/DisplayScriptPath.cs
@@ -4,9 +4,22 @@ internal static class DisplayScriptPath
 {
     public const string NestedSettingSeparator = "->";
     public const string ScriptPropertySeparator = ".";
+    public const string SettingPlaceholder = "{{this}}";
 
     public static string NormalizePropertyName(string propertyName)
     {
         return propertyName.Replace(NestedSettingSeparator, ScriptPropertySeparator);
+    }
+
+    public static string? SubstitutePlaceholder(string? script, string settingName)
+    {
+        if (script is null)
+            return null;
+
+        if (script.Length == 0 || !script.Contains(SettingPlaceholder))
+            return script;
+
+        var normalizedName = NormalizePropertyName(settingName);
+        return script.Replace(SettingPlaceholder, normalizedName);
     }
 }

--- a/src/client/Fig.Client/SettingDefinitionFactory.cs
+++ b/src/client/Fig.Client/SettingDefinitionFactory.cs
@@ -90,10 +90,12 @@ internal class SettingDefinitionFactory : ISettingDefinitionFactory
                                                   t == Nullable.GetUnderlyingType(settingDetails.Property.PropertyType))) ?? false)
             .ToList() ?? [];
 
-        // Process inherited attributes first (so they can be overridden by direct attributes)
+        // Process inherited attributes first so direct and inherited display scripts compose in declaration order.
+        var collectedScripts = new List<string>();
+        
         foreach (var inheritedAttribute in settingDetails.InheritedAttributes)
         {
-            ProcessAttributeForSetting(inheritedAttribute, settingDetails, clientName, setting, allSettings);
+            ProcessAttributeForSetting(inheritedAttribute, settingDetails, clientName, setting, allSettings, collectedScripts);
         }
 
         // Process all attributes except HeadingAttribute first
@@ -102,7 +104,14 @@ internal class SettingDefinitionFactory : ISettingDefinitionFactory
                      .Where(a => !(a is HeadingAttribute))
                      .OrderBy(a => a is SettingAttribute))
         {
-            ProcessAttributeForSetting(attribute, settingDetails, clientName, setting, allSettings);
+            ProcessAttributeForSetting(attribute, settingDetails, clientName, setting, allSettings, collectedScripts);
+        }
+
+        // Combine all collected display scripts
+        if (collectedScripts.Count > 0)
+        {
+            var combinedScript = string.Join("\n", collectedScripts);
+            setting.DisplayScript = DisplayScriptPath.SubstitutePlaceholder(combinedScript, setting.Name);
         }
 
         // Process HeadingAttribute last so it can inherit final values from other attributes
@@ -130,7 +139,7 @@ internal class SettingDefinitionFactory : ISettingDefinitionFactory
         }
     }
 
-    private void ProcessAttributeForSetting(Attribute attribute, SettingDetails settingDetails, string clientName, SettingDefinitionDataContract setting, List<SettingDetails>? allSettings)
+    private void ProcessAttributeForSetting(Attribute attribute, SettingDetails settingDetails, string clientName, SettingDefinitionDataContract setting, List<SettingDetails>? allSettings, List<string> collectedScripts)
     {
         switch (attribute)
         {
@@ -140,17 +149,17 @@ internal class SettingDefinitionFactory : ISettingDefinitionFactory
                 break;
             case ValidateIsBetweenAttribute validateIsBetweenAttribute:
                 ValidateIsBetweenAttributeValues(validateIsBetweenAttribute, settingDetails.Name);
-                setting.DisplayScript = validateIsBetweenAttribute.GetScript(
+                collectedScripts.Add(validateIsBetweenAttribute.GetScript(
                     setting.Name.Contains(Constants.SettingPathSeparator)
                         ? setting.Name.Replace(Constants.SettingPathSeparator, ".")
-                        : setting.Name);
+                        : setting.Name));
                 break;
             case ValidateCountAttribute validateCountAttribute:
                 ValidateCountAttributeValues(validateCountAttribute, settingDetails.Name);
-                setting.DisplayScript = validateCountAttribute.GetScript(
+                collectedScripts.Add(validateCountAttribute.GetScript(
                     setting.Name.Contains(Constants.SettingPathSeparator)
                         ? setting.Name.Replace(Constants.SettingPathSeparator, ".")
-                        : setting.Name);
+                        : setting.Name));
                 break;
             case SecretAttribute:
                 ThrowIfNotString(settingDetails.Property);
@@ -200,13 +209,13 @@ internal class SettingDefinitionFactory : ISettingDefinitionFactory
                 SetCategory(categoryAttribute, settingDetails.Name, setting);
                 break;
             case DisplayScriptAttribute scriptAttribute:
-                setting.DisplayScript = scriptAttribute.DisplayScript;
+                collectedScripts.Add(scriptAttribute.DisplayScript);
                 break;
             case IDisplayScriptProvider displayScriptProvider:
                 var scriptPropertyName = setting.Name.Contains(Constants.SettingPathSeparator)
                     ? setting.Name.Replace(Constants.SettingPathSeparator, ".")
                     : setting.Name;
-                setting.DisplayScript = displayScriptProvider.GetScript(scriptPropertyName);
+                collectedScripts.Add(displayScriptProvider.GetScript(scriptPropertyName));
                 break;
             case IndentAttribute indentAttribute:
                 ValidateIndentAttribute(indentAttribute, settingDetails.Name);

--- a/src/tests/Fig.Integration.Test/Api/DisplayScriptTests.cs
+++ b/src/tests/Fig.Integration.Test/Api/DisplayScriptTests.cs
@@ -52,4 +52,52 @@ public class DisplayScriptTests : IntegrationTestBase
             Is.EqualTo(ThreeSettingsUpdatedScript.DisplayScript));
         
     }
+
+    [Test]
+    public async Task ShallRegisterMultipleDisplayScripts()
+    {
+        await SetConfiguration(CreateConfiguration(allowDisplayScripts: true));
+        await RegisterSettings<MultipleDisplayScriptsSettings>();
+
+        var clients = (await GetAllClients()).ToList();
+
+        Assert.That(clients.Count, Is.EqualTo(1));
+        var displayScript = clients.First().Settings
+            .FirstOrDefault(a => a.Name == nameof(MultipleDisplayScriptsSettings.ABoolSetting))?.DisplayScript;
+        Assert.That(displayScript, Is.Not.Null);
+        Assert.That(displayScript, Does.Contain(MultipleDisplayScriptsSettings.Script1));
+        Assert.That(displayScript, Does.Contain(MultipleDisplayScriptsSettings.Script2));
+    }
+
+    [Test]
+    public async Task ShallSubstitutePlaceholderInDisplayScript()
+    {
+        await SetConfiguration(CreateConfiguration(allowDisplayScripts: true));
+        await RegisterSettings<MultipleDisplayScriptsSettings>();
+
+        var clients = (await GetAllClients()).ToList();
+
+        Assert.That(clients.Count, Is.EqualTo(1));
+        var displayScript = clients.First().Settings
+            .FirstOrDefault(a => a.Name == nameof(MultipleDisplayScriptsSettings.AStringSetting))?.DisplayScript;
+        Assert.That(displayScript, Is.Not.Null);
+        Assert.That(displayScript, Does.Not.Contain("{{this}}"));
+        Assert.That(displayScript, Does.Contain(nameof(MultipleDisplayScriptsSettings.AStringSetting)));
+    }
+
+    [Test]
+    public async Task ShallRegisterLibraryDisplayScript()
+    {
+        await SetConfiguration(CreateConfiguration(allowDisplayScripts: true));
+        await RegisterSettings<MultipleDisplayScriptsSettings>();
+
+        var clients = (await GetAllClients()).ToList();
+
+        Assert.That(clients.Count, Is.EqualTo(1));
+        var displayScript = clients.First().Settings
+            .FirstOrDefault(a => a.Name == nameof(MultipleDisplayScriptsSettings.AnIntSetting))?.DisplayScript;
+        Assert.That(displayScript, Is.Not.Null);
+        Assert.That(displayScript, Does.Not.Contain("{{this}}"));
+        Assert.That(displayScript, Does.Contain($"{nameof(MultipleDisplayScriptsSettings.AnIntSetting)}.Value"));
+    }
 }

--- a/src/tests/Fig.Test.Common/TestSettings/MultipleDisplayScriptsSettings.cs
+++ b/src/tests/Fig.Test.Common/TestSettings/MultipleDisplayScriptsSettings.cs
@@ -1,0 +1,32 @@
+using Fig.Client.Abstractions.Attributes;
+using Fig.Client.Abstractions.DisplayScripts;
+
+namespace Fig.Test.Common.TestSettings;
+
+public class MultipleDisplayScriptsSettings : TestSettingsBase
+{
+    public const string Script1 = "AStringSetting.IsReadOnly = true;";
+    public const string Script2 = "AnIntSetting.IsVisible = false;";
+    public const string PlaceholderScript = "{{this}}.InformationText = 'Current value: ' + {{this}}.Value;";
+
+    public override string ClientName => "MultipleDisplayScriptsSettings";
+    public override string ClientDescription => "Client with multiple display scripts";
+
+    [Setting("This is a string")]
+    [DisplayScript(PlaceholderScript)]
+    public string AStringSetting { get; set; } = "Hello";
+
+    [Setting("This is an int", false)]
+    [DisplayScript(DisplayScriptLibrary.ValidatePort)]
+    public int AnIntSetting { get; set; } = 8080;
+
+    [Setting("This is a bool setting")]
+    [DisplayScript(Script1)]
+    [DisplayScript(Script2)]
+    public bool ABoolSetting { get; set; } = true;
+
+    public override IEnumerable<string> GetValidationErrors()
+    {
+        return [];
+    }
+}

--- a/src/tests/Fig.Unit.Test/Client/DisplayScriptLibraryTests.cs
+++ b/src/tests/Fig.Unit.Test/Client/DisplayScriptLibraryTests.cs
@@ -1,0 +1,741 @@
+using Fig.Client.Abstractions.DisplayScripts;
+using Fig.Client.Abstractions.Validation;
+using Fig.Client.Testing.Scripts;
+using NUnit.Framework;
+
+namespace Fig.Unit.Test.Client;
+
+public class DisplayScriptLibraryTests
+{
+    private DisplayScriptTestRunner _runner = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _runner = new DisplayScriptTestRunner();
+    }
+
+    private string Substitute(string libraryScript, string settingName)
+    {
+        return DisplayScriptPath.SubstitutePlaceholder(libraryScript, settingName)!;
+    }
+
+    #region MillisecondsToHumanReadableTime
+
+    [Test]
+    public void MillisecondsToHumanReadableTime_Zero_ShowsZeroMilliseconds()
+    {
+        // Arrange
+        var client = _runner.CreateTestClient("TestClient");
+        client.AddIntegerSetting("Timeout", 0);
+        var script = Substitute(DisplayScriptLibrary.MillisecondsToHumanReadableTime, "Timeout");
+
+        // Act
+        _runner.RunScript(script, client);
+
+        // Assert
+        var setting = client.GetSetting("Timeout");
+        Assert.That(setting!.InformationText, Is.EqualTo("0 milliseconds"));
+    }
+
+    [Test]
+    public void MillisecondsToHumanReadableTime_LargeValue_ShowsAllComponents()
+    {
+        // Arrange - 3661001ms = 1 hour 1 minute 1 second 1 ms
+        var client = _runner.CreateTestClient("TestClient");
+        client.AddIntegerSetting("Timeout", 3661001);
+        var script = Substitute(DisplayScriptLibrary.MillisecondsToHumanReadableTime, "Timeout");
+
+        // Act
+        _runner.RunScript(script, client);
+
+        // Assert
+        var setting = client.GetSetting("Timeout");
+        Assert.That(setting!.InformationText, Is.EqualTo("= 1 hour 1 minute 1 second 1 ms"));
+    }
+
+    [Test]
+    public void MillisecondsToHumanReadableTime_90000_ShowsMinuteAndSeconds()
+    {
+        // Arrange - 90000ms = 1 minute 30 seconds
+        var client = _runner.CreateTestClient("TestClient");
+        client.AddIntegerSetting("Timeout", 90000);
+        var script = Substitute(DisplayScriptLibrary.MillisecondsToHumanReadableTime, "Timeout");
+
+        // Act
+        _runner.RunScript(script, client);
+
+        // Assert
+        var setting = client.GetSetting("Timeout");
+        Assert.That(setting!.InformationText, Does.StartWith("= "));
+        Assert.That(setting.InformationText, Is.EqualTo("= 1 minute 30 seconds"));
+    }
+
+    [Test]
+    public void MillisecondsToHumanReadableTime_Negative_SetsNull()
+    {
+        // Arrange
+        var client = _runner.CreateTestClient("TestClient");
+        client.AddIntegerSetting("Timeout", -1);
+        var script = Substitute(DisplayScriptLibrary.MillisecondsToHumanReadableTime, "Timeout");
+
+        // Act
+        _runner.RunScript(script, client);
+
+        // Assert
+        var setting = client.GetSetting("Timeout");
+        Assert.That(setting!.InformationText, Is.Null);
+    }
+
+    #endregion
+
+    #region SecondsToHumanReadableTime
+
+    [Test]
+    public void SecondsToHumanReadableTime_Zero_ShowsZeroSeconds()
+    {
+        // Arrange
+        var client = _runner.CreateTestClient("TestClient");
+        client.AddIntegerSetting("Interval", 0);
+        var script = Substitute(DisplayScriptLibrary.SecondsToHumanReadableTime, "Interval");
+
+        // Act
+        _runner.RunScript(script, client);
+
+        // Assert
+        var setting = client.GetSetting("Interval");
+        Assert.That(setting!.InformationText, Is.EqualTo("0 seconds"));
+    }
+
+    [Test]
+    public void SecondsToHumanReadableTime_3661_ShowsHourMinuteSecond()
+    {
+        // Arrange - 3661s = 1 hour 1 minute 1 second
+        var client = _runner.CreateTestClient("TestClient");
+        client.AddIntegerSetting("Interval", 3661);
+        var script = Substitute(DisplayScriptLibrary.SecondsToHumanReadableTime, "Interval");
+
+        // Act
+        _runner.RunScript(script, client);
+
+        // Assert
+        var setting = client.GetSetting("Interval");
+        Assert.That(setting!.InformationText, Is.EqualTo("= 1 hour 1 minute 1 second"));
+    }
+
+    [Test]
+    public void SecondsToHumanReadableTime_90_ShowsMinuteAndSeconds()
+    {
+        // Arrange - 90s = 1 minute 30 seconds
+        var client = _runner.CreateTestClient("TestClient");
+        client.AddIntegerSetting("Interval", 90);
+        var script = Substitute(DisplayScriptLibrary.SecondsToHumanReadableTime, "Interval");
+
+        // Act
+        _runner.RunScript(script, client);
+
+        // Assert
+        var setting = client.GetSetting("Interval");
+        Assert.That(setting!.InformationText, Is.EqualTo("= 1 minute 30 seconds"));
+    }
+
+    [Test]
+    public void SecondsToHumanReadableTime_Negative_SetsNull()
+    {
+        // Arrange
+        var client = _runner.CreateTestClient("TestClient");
+        client.AddIntegerSetting("Interval", -5);
+        var script = Substitute(DisplayScriptLibrary.SecondsToHumanReadableTime, "Interval");
+
+        // Act
+        _runner.RunScript(script, client);
+
+        // Assert
+        var setting = client.GetSetting("Interval");
+        Assert.That(setting!.InformationText, Is.Null);
+    }
+
+    #endregion
+
+    #region ValidateIpAddress
+
+    [Test]
+    [TestCase("192.168.1.1")]
+    [TestCase("0.0.0.0")]
+    [TestCase("255.255.255.255")]
+    public void ValidateIpAddress_ValidAddress_IsValid(string ipAddress)
+    {
+        // Arrange
+        var client = _runner.CreateTestClient("TestClient");
+        client.AddStringSetting("IpAddress", ipAddress);
+        var script = Substitute(DisplayScriptLibrary.ValidateIpAddress, "IpAddress");
+
+        // Act
+        _runner.RunScript(script, client);
+
+        // Assert
+        var setting = client.GetSetting("IpAddress");
+        Assert.That(setting!.IsValid, Is.True);
+    }
+
+    [Test]
+    [TestCase("256.1.1.1")]
+    [TestCase("1.2.3")]
+    [TestCase("abc.def.ghi.jkl")]
+    [TestCase("")]
+    public void ValidateIpAddress_InvalidAddress_IsNotValid(string ipAddress)
+    {
+        // Arrange
+        var client = _runner.CreateTestClient("TestClient");
+        client.AddStringSetting("IpAddress", ipAddress);
+        var script = Substitute(DisplayScriptLibrary.ValidateIpAddress, "IpAddress");
+
+        // Act
+        _runner.RunScript(script, client);
+
+        // Assert
+        var setting = client.GetSetting("IpAddress");
+        Assert.That(setting!.IsValid, Is.False);
+        Assert.That(setting.ValidationExplanation, Is.Not.Null.And.Not.Empty);
+    }
+
+    #endregion
+
+    #region ValidatePort
+
+    [Test]
+    [TestCase(80)]
+    [TestCase(1)]
+    [TestCase(65535)]
+    public void ValidatePort_ValidPort_IsValid(int port)
+    {
+        // Arrange
+        var client = _runner.CreateTestClient("TestClient");
+        client.AddIntegerSetting("Port", port);
+        var script = Substitute(DisplayScriptLibrary.ValidatePort, "Port");
+
+        // Act
+        _runner.RunScript(script, client);
+
+        // Assert
+        var setting = client.GetSetting("Port");
+        Assert.That(setting!.IsValid, Is.True);
+    }
+
+    [Test]
+    [TestCase(0)]
+    [TestCase(65536)]
+    [TestCase(-1)]
+    public void ValidatePort_InvalidPort_IsNotValid(int port)
+    {
+        // Arrange
+        var client = _runner.CreateTestClient("TestClient");
+        client.AddIntegerSetting("Port", port);
+        var script = Substitute(DisplayScriptLibrary.ValidatePort, "Port");
+
+        // Act
+        _runner.RunScript(script, client);
+
+        // Assert
+        var setting = client.GetSetting("Port");
+        Assert.That(setting!.IsValid, Is.False);
+        Assert.That(setting.ValidationExplanation, Is.Not.Null.And.Not.Empty);
+    }
+
+    #endregion
+
+    #region ValidateWindowsFilename
+
+    [Test]
+    public void ValidateWindowsFilename_ValidFilename_IsValid()
+    {
+        // Arrange
+        var client = _runner.CreateTestClient("TestClient");
+        client.AddStringSetting("Filename", "myfile.txt");
+        var script = Substitute(DisplayScriptLibrary.ValidateWindowsFilename, "Filename");
+
+        // Act
+        _runner.RunScript(script, client);
+
+        // Assert
+        var setting = client.GetSetting("Filename");
+        Assert.That(setting!.IsValid, Is.True);
+    }
+
+    [Test]
+    public void ValidateWindowsFilename_IllegalChars_IsNotValid()
+    {
+        // Arrange
+        var client = _runner.CreateTestClient("TestClient");
+        client.AddStringSetting("Filename", "file<name");
+        var script = Substitute(DisplayScriptLibrary.ValidateWindowsFilename, "Filename");
+
+        // Act
+        _runner.RunScript(script, client);
+
+        // Assert
+        var setting = client.GetSetting("Filename");
+        Assert.That(setting!.IsValid, Is.False);
+        Assert.That(setting.ValidationExplanation, Does.Contain("illegal characters"));
+    }
+
+    [Test]
+    public void ValidateWindowsFilename_ReservedName_IsNotValid()
+    {
+        // Arrange
+        var client = _runner.CreateTestClient("TestClient");
+        client.AddStringSetting("Filename", "CON");
+        var script = Substitute(DisplayScriptLibrary.ValidateWindowsFilename, "Filename");
+
+        // Act
+        _runner.RunScript(script, client);
+
+        // Assert
+        var setting = client.GetSetting("Filename");
+        Assert.That(setting!.IsValid, Is.False);
+        Assert.That(setting.ValidationExplanation, Does.Contain("reserved"));
+    }
+
+    [Test]
+    public void ValidateWindowsFilename_TrailingDot_IsNotValid()
+    {
+        // Arrange
+        var client = _runner.CreateTestClient("TestClient");
+        client.AddStringSetting("Filename", "file.");
+        var script = Substitute(DisplayScriptLibrary.ValidateWindowsFilename, "Filename");
+
+        // Act
+        _runner.RunScript(script, client);
+
+        // Assert
+        var setting = client.GetSetting("Filename");
+        Assert.That(setting!.IsValid, Is.False);
+        Assert.That(setting.ValidationExplanation, Does.Contain("dot or space"));
+    }
+
+    [Test]
+    public void ValidateWindowsFilename_Empty_IsNotValid()
+    {
+        // Arrange
+        var client = _runner.CreateTestClient("TestClient");
+        client.AddStringSetting("Filename", "");
+        var script = Substitute(DisplayScriptLibrary.ValidateWindowsFilename, "Filename");
+
+        // Act
+        _runner.RunScript(script, client);
+
+        // Assert
+        var setting = client.GetSetting("Filename");
+        Assert.That(setting!.IsValid, Is.False);
+    }
+
+    #endregion
+
+    #region ValidateLinuxFilename
+
+    [Test]
+    public void ValidateLinuxFilename_ValidFilename_IsValid()
+    {
+        // Arrange
+        var client = _runner.CreateTestClient("TestClient");
+        client.AddStringSetting("Filename", "myfile.txt");
+        var script = Substitute(DisplayScriptLibrary.ValidateLinuxFilename, "Filename");
+
+        // Act
+        _runner.RunScript(script, client);
+
+        // Assert
+        var setting = client.GetSetting("Filename");
+        Assert.That(setting!.IsValid, Is.True);
+    }
+
+    [Test]
+    public void ValidateLinuxFilename_ForwardSlash_IsNotValid()
+    {
+        // Arrange
+        var client = _runner.CreateTestClient("TestClient");
+        client.AddStringSetting("Filename", "path/file");
+        var script = Substitute(DisplayScriptLibrary.ValidateLinuxFilename, "Filename");
+
+        // Act
+        _runner.RunScript(script, client);
+
+        // Assert
+        var setting = client.GetSetting("Filename");
+        Assert.That(setting!.IsValid, Is.False);
+        Assert.That(setting.ValidationExplanation, Does.Contain("forward slash"));
+    }
+
+    [Test]
+    public void ValidateLinuxFilename_Empty_IsNotValid()
+    {
+        // Arrange
+        var client = _runner.CreateTestClient("TestClient");
+        client.AddStringSetting("Filename", "");
+        var script = Substitute(DisplayScriptLibrary.ValidateLinuxFilename, "Filename");
+
+        // Act
+        _runner.RunScript(script, client);
+
+        // Assert
+        var setting = client.GetSetting("Filename");
+        Assert.That(setting!.IsValid, Is.False);
+    }
+
+    [Test]
+    public void ValidateLinuxFilename_ExceedsMaxLength_IsNotValid()
+    {
+        // Arrange
+        var client = _runner.CreateTestClient("TestClient");
+        client.AddStringSetting("Filename", new string('a', 256));
+        var script = Substitute(DisplayScriptLibrary.ValidateLinuxFilename, "Filename");
+
+        // Act
+        _runner.RunScript(script, client);
+
+        // Assert
+        var setting = client.GetSetting("Filename");
+        Assert.That(setting!.IsValid, Is.False);
+        Assert.That(setting.ValidationExplanation, Does.Contain("255"));
+    }
+
+    #endregion
+
+    #region ValidateUrl
+
+    [Test]
+    [TestCase("https://example.com")]
+    [TestCase("http://localhost:8080/path")]
+    public void ValidateUrl_ValidUrl_IsValid(string url)
+    {
+        // Arrange
+        var client = _runner.CreateTestClient("TestClient");
+        client.AddStringSetting("Url", url);
+        var script = Substitute(DisplayScriptLibrary.ValidateUrl, "Url");
+
+        // Act
+        _runner.RunScript(script, client);
+
+        // Assert
+        var setting = client.GetSetting("Url");
+        Assert.That(setting!.IsValid, Is.True);
+    }
+
+    [Test]
+    [TestCase("ftp://example.com")]
+    [TestCase("not a url")]
+    [TestCase("")]
+    public void ValidateUrl_InvalidUrl_IsNotValid(string url)
+    {
+        // Arrange
+        var client = _runner.CreateTestClient("TestClient");
+        client.AddStringSetting("Url", url);
+        var script = Substitute(DisplayScriptLibrary.ValidateUrl, "Url");
+
+        // Act
+        _runner.RunScript(script, client);
+
+        // Assert
+        var setting = client.GetSetting("Url");
+        Assert.That(setting!.IsValid, Is.False);
+        Assert.That(setting.ValidationExplanation, Is.Not.Null.And.Not.Empty);
+    }
+
+    #endregion
+
+    #region ValidateEmail
+
+    [Test]
+    [TestCase("user@example.com")]
+    [TestCase("user@sub.example.com")]
+    public void ValidateEmail_ValidEmail_IsValid(string email)
+    {
+        // Arrange
+        var client = _runner.CreateTestClient("TestClient");
+        client.AddStringSetting("Email", email);
+        var script = Substitute(DisplayScriptLibrary.ValidateEmail, "Email");
+
+        // Act
+        _runner.RunScript(script, client);
+
+        // Assert
+        var setting = client.GetSetting("Email");
+        Assert.That(setting!.IsValid, Is.True);
+    }
+
+    [Test]
+    [TestCase("notanemail")]
+    [TestCase("")]
+    public void ValidateEmail_InvalidEmail_IsNotValid(string email)
+    {
+        // Arrange
+        var client = _runner.CreateTestClient("TestClient");
+        client.AddStringSetting("Email", email);
+        var script = Substitute(DisplayScriptLibrary.ValidateEmail, "Email");
+
+        // Act
+        _runner.RunScript(script, client);
+
+        // Assert
+        var setting = client.GetSetting("Email");
+        Assert.That(setting!.IsValid, Is.False);
+        Assert.That(setting.ValidationExplanation, Is.Not.Null.And.Not.Empty);
+    }
+
+    #endregion
+
+    #region ValidateJson
+
+    [Test]
+    [TestCase("{\"key\": \"value\"}")]
+    [TestCase("[1,2,3]")]
+    public void ValidateJson_ValidJson_IsValid(string json)
+    {
+        // Arrange
+        var client = _runner.CreateTestClient("TestClient");
+        client.AddStringSetting("JsonConfig", json);
+        var script = Substitute(DisplayScriptLibrary.ValidateJson, "JsonConfig");
+
+        // Act
+        _runner.RunScript(script, client);
+
+        // Assert
+        var setting = client.GetSetting("JsonConfig");
+        Assert.That(setting!.IsValid, Is.True);
+    }
+
+    [Test]
+    [TestCase("not json")]
+    [TestCase("")]
+    public void ValidateJson_InvalidJson_IsNotValid(string json)
+    {
+        // Arrange
+        var client = _runner.CreateTestClient("TestClient");
+        client.AddStringSetting("JsonConfig", json);
+        var script = Substitute(DisplayScriptLibrary.ValidateJson, "JsonConfig");
+
+        // Act
+        _runner.RunScript(script, client);
+
+        // Assert
+        var setting = client.GetSetting("JsonConfig");
+        Assert.That(setting!.IsValid, Is.False);
+        Assert.That(setting.ValidationExplanation, Is.Not.Null.And.Not.Empty);
+    }
+
+    #endregion
+
+    #region BytesToHumanReadableSize
+
+    [Test]
+    public void BytesToHumanReadableSize_Zero_ShowsZeroBytes()
+    {
+        // Arrange
+        var client = _runner.CreateTestClient("TestClient");
+        client.AddIntegerSetting("FileSize", 0);
+        var script = Substitute(DisplayScriptLibrary.BytesToHumanReadableSize, "FileSize");
+
+        // Act
+        _runner.RunScript(script, client);
+
+        // Assert
+        var setting = client.GetSetting("FileSize");
+        Assert.That(setting!.InformationText, Is.EqualTo("0 bytes"));
+    }
+
+    [Test]
+    public void BytesToHumanReadableSize_One_ShowsSingleByte()
+    {
+        // Arrange
+        var client = _runner.CreateTestClient("TestClient");
+        client.AddIntegerSetting("FileSize", 1);
+        var script = Substitute(DisplayScriptLibrary.BytesToHumanReadableSize, "FileSize");
+
+        // Act
+        _runner.RunScript(script, client);
+
+        // Assert
+        var setting = client.GetSetting("FileSize");
+        Assert.That(setting!.InformationText, Is.EqualTo("= 1 byte"));
+    }
+
+    [Test]
+    public void BytesToHumanReadableSize_1024_Shows1KB()
+    {
+        // Arrange
+        var client = _runner.CreateTestClient("TestClient");
+        client.AddIntegerSetting("FileSize", 1024);
+        var script = Substitute(DisplayScriptLibrary.BytesToHumanReadableSize, "FileSize");
+
+        // Act
+        _runner.RunScript(script, client);
+
+        // Assert
+        var setting = client.GetSetting("FileSize");
+        Assert.That(setting!.InformationText, Is.EqualTo("= 1 KB"));
+    }
+
+    [Test]
+    public void BytesToHumanReadableSize_1536_ShowsApprox1Point5KB()
+    {
+        // Arrange
+        var client = _runner.CreateTestClient("TestClient");
+        client.AddIntegerSetting("FileSize", 1536);
+        var script = Substitute(DisplayScriptLibrary.BytesToHumanReadableSize, "FileSize");
+
+        // Act
+        _runner.RunScript(script, client);
+
+        // Assert
+        var setting = client.GetSetting("FileSize");
+        Assert.That(setting!.InformationText, Is.EqualTo("= 1.5 KB"));
+    }
+
+    [Test]
+    public void BytesToHumanReadableSize_1GB_Shows1GB()
+    {
+        // Arrange
+        var client = _runner.CreateTestClient("TestClient");
+        client.AddIntegerSetting("FileSize", 1073741824);
+        var script = Substitute(DisplayScriptLibrary.BytesToHumanReadableSize, "FileSize");
+
+        // Act
+        _runner.RunScript(script, client);
+
+        // Assert
+        var setting = client.GetSetting("FileSize");
+        Assert.That(setting!.InformationText, Is.EqualTo("= 1 GB"));
+    }
+
+    [Test]
+    public void BytesToHumanReadableSize_Negative_SetsNull()
+    {
+        // Arrange
+        var client = _runner.CreateTestClient("TestClient");
+        client.AddIntegerSetting("FileSize", -100);
+        var script = Substitute(DisplayScriptLibrary.BytesToHumanReadableSize, "FileSize");
+
+        // Act
+        _runner.RunScript(script, client);
+
+        // Assert
+        var setting = client.GetSetting("FileSize");
+        Assert.That(setting!.InformationText, Is.Null);
+    }
+
+    #endregion
+
+    #region ValidateHostname
+
+    [Test]
+    [TestCase("example.com")]
+    [TestCase("localhost")]
+    [TestCase("sub.domain.example.com")]
+    public void ValidateHostname_ValidHostname_IsValid(string hostname)
+    {
+        // Arrange
+        var client = _runner.CreateTestClient("TestClient");
+        client.AddStringSetting("Hostname", hostname);
+        var script = Substitute(DisplayScriptLibrary.ValidateHostname, "Hostname");
+
+        // Act
+        _runner.RunScript(script, client);
+
+        // Assert
+        var setting = client.GetSetting("Hostname");
+        Assert.That(setting!.IsValid, Is.True);
+    }
+
+    [Test]
+    [TestCase("-invalid.com")]
+    [TestCase("")]
+    public void ValidateHostname_InvalidHostname_IsNotValid(string hostname)
+    {
+        // Arrange
+        var client = _runner.CreateTestClient("TestClient");
+        client.AddStringSetting("Hostname", hostname);
+        var script = Substitute(DisplayScriptLibrary.ValidateHostname, "Hostname");
+
+        // Act
+        _runner.RunScript(script, client);
+
+        // Assert
+        var setting = client.GetSetting("Hostname");
+        Assert.That(setting!.IsValid, Is.False);
+        Assert.That(setting.ValidationExplanation, Is.Not.Null.And.Not.Empty);
+    }
+
+    #endregion
+
+    #region ValidateCidr
+
+    [Test]
+    [TestCase("192.168.1.0/24")]
+    [TestCase("10.0.0.0/8")]
+    public void ValidateCidr_ValidCidr_IsValid(string cidr)
+    {
+        // Arrange
+        var client = _runner.CreateTestClient("TestClient");
+        client.AddStringSetting("Cidr", cidr);
+        var script = Substitute(DisplayScriptLibrary.ValidateCidr, "Cidr");
+
+        // Act
+        _runner.RunScript(script, client);
+
+        // Assert
+        var setting = client.GetSetting("Cidr");
+        Assert.That(setting!.IsValid, Is.True);
+    }
+
+    [Test]
+    public void ValidateCidr_NoPrefix_IsNotValid()
+    {
+        // Arrange
+        var client = _runner.CreateTestClient("TestClient");
+        client.AddStringSetting("Cidr", "192.168.1.0");
+        var script = Substitute(DisplayScriptLibrary.ValidateCidr, "Cidr");
+
+        // Act
+        _runner.RunScript(script, client);
+
+        // Assert
+        var setting = client.GetSetting("Cidr");
+        Assert.That(setting!.IsValid, Is.False);
+        Assert.That(setting.ValidationExplanation, Does.Contain("/"));
+    }
+
+    [Test]
+    public void ValidateCidr_PrefixTooLarge_IsNotValid()
+    {
+        // Arrange
+        var client = _runner.CreateTestClient("TestClient");
+        client.AddStringSetting("Cidr", "192.168.1.0/33");
+        var script = Substitute(DisplayScriptLibrary.ValidateCidr, "Cidr");
+
+        // Act
+        _runner.RunScript(script, client);
+
+        // Assert
+        var setting = client.GetSetting("Cidr");
+        Assert.That(setting!.IsValid, Is.False);
+        Assert.That(setting.ValidationExplanation, Does.Contain("32"));
+    }
+
+    [Test]
+    public void ValidateCidr_Empty_IsNotValid()
+    {
+        // Arrange
+        var client = _runner.CreateTestClient("TestClient");
+        client.AddStringSetting("Cidr", "");
+        var script = Substitute(DisplayScriptLibrary.ValidateCidr, "Cidr");
+
+        // Act
+        _runner.RunScript(script, client);
+
+        // Assert
+        var setting = client.GetSetting("Cidr");
+        Assert.That(setting!.IsValid, Is.False);
+    }
+
+    #endregion
+}

--- a/src/tests/Fig.Unit.Test/Client/DisplayScriptPlaceholderTests.cs
+++ b/src/tests/Fig.Unit.Test/Client/DisplayScriptPlaceholderTests.cs
@@ -1,0 +1,92 @@
+using Fig.Client.Abstractions.Validation;
+using NUnit.Framework;
+
+namespace Fig.Unit.Test.Client;
+
+public class DisplayScriptPlaceholderTests
+{
+    [Test]
+    public void SubstitutePlaceholder_ReplacesPlaceholder_ForFlatSetting()
+    {
+        // Arrange
+        var script = "{{this}}.Value = 5;";
+
+        // Act
+        var result = DisplayScriptPath.SubstitutePlaceholder(script, "MySetting");
+
+        // Assert
+        Assert.That(result, Is.EqualTo("MySetting.Value = 5;"));
+    }
+
+    [Test]
+    public void SubstitutePlaceholder_ReplacesPlaceholder_ForNestedSetting()
+    {
+        // Arrange
+        var script = "{{this}}.Value = 'localhost';";
+
+        // Act
+        var result = DisplayScriptPath.SubstitutePlaceholder(script, "Connection->Host");
+
+        // Assert
+        Assert.That(result, Is.EqualTo("Connection.Host.Value = 'localhost';"));
+    }
+
+    [Test]
+    public void SubstitutePlaceholder_ReplacesMultiplePlaceholders()
+    {
+        // Arrange
+        var script = "if ({{this}}.Value > 0) { {{this}}.IsValid = true; } else { {{this}}.IsValid = false; }";
+
+        // Act
+        var result = DisplayScriptPath.SubstitutePlaceholder(script, "Port");
+
+        // Assert
+        Assert.That(result, Is.EqualTo("if (Port.Value > 0) { Port.IsValid = true; } else { Port.IsValid = false; }"));
+    }
+
+    [Test]
+    public void SubstitutePlaceholder_NoPlaceholder_LeavesScriptUnchanged()
+    {
+        // Arrange
+        var script = "MySetting.Value = 42;";
+
+        // Act
+        var result = DisplayScriptPath.SubstitutePlaceholder(script, "MySetting");
+
+        // Assert
+        Assert.That(result, Is.EqualTo("MySetting.Value = 42;"));
+    }
+
+    [Test]
+    public void SubstitutePlaceholder_NullScript_ReturnsNull()
+    {
+        // Act
+        var result = DisplayScriptPath.SubstitutePlaceholder(null, "MySetting");
+
+        // Assert
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public void SubstitutePlaceholder_EmptyScript_ReturnsEmpty()
+    {
+        // Act
+        var result = DisplayScriptPath.SubstitutePlaceholder(string.Empty, "MySetting");
+
+        // Assert
+        Assert.That(result, Is.EqualTo(string.Empty));
+    }
+
+    [Test]
+    public void SubstitutePlaceholder_DeeplyNestedSetting()
+    {
+        // Arrange
+        var script = "{{this}}.IsValid = true;";
+
+        // Act
+        var result = DisplayScriptPath.SubstitutePlaceholder(script, "A->B->C->D");
+
+        // Assert
+        Assert.That(result, Is.EqualTo("A.B.C.D.IsValid = true;"));
+    }
+}


### PR DESCRIPTION
…d ability to use placeholders in display scripts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Built-in display script library with common formatters and validators; support for multiple display scripts per setting (executed in declaration order; last assignment wins for shared targets).
  * `{{this}}` placeholder is auto-resolved at registration to the current setting path, including nested paths.

* **Documentation**
  * Expanded guidance and examples for using the library, placeholder semantics, and combining multiple scripts.

* **Examples**
  * Added sample settings demonstrating library and custom script combinations.

* **Tests**
  * New unit and integration tests covering script composition, placeholder substitution, formatting and validation behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->