### PR TITLE
perf: disable Expect:100-Continue on all Fig HTTP clients

### DIFF
--- a/src/client/Fig.Client/ConfigurationProvider/ValidatedHttpClientFactory.cs
+++ b/src/client/Fig.Client/ConfigurationProvider/ValidatedHttpClientFactory.cs
@@ -159,6 +159,7 @@ public class ValidatedHttpClientFactory
         return new HttpClient(handler)
         {
             BaseAddress = new Uri(apiUri),
+            DefaultRequestHeaders = { ExpectContinue = false }
         };
     }
 

--- a/src/client/Fig.Client/Factories/SimpleHttpClientFactory.cs
+++ b/src/client/Fig.Client/Factories/SimpleHttpClientFactory.cs
@@ -13,14 +13,15 @@ public class SimpleHttpClientFactory : IHttpClientFactory
     public SimpleHttpClientFactory(Uri baseAddress)
     {
         _clients = new ReadOnlyDictionary<string, HttpClient>(new Dictionary<string, HttpClient>()
-        {
             {
-                HttpClientNames.FigApi, new HttpClient()
                 {
-                    BaseAddress = baseAddress
+                    HttpClientNames.FigApi, new HttpClient()
+                    {
+                        BaseAddress = baseAddress,
+                        DefaultRequestHeaders = { ExpectContinue = false }
+                    }
                 }
-            }
-        });
+            });
     }
     
     public SimpleHttpClientFactory(Dictionary<string, HttpClient> clients)


### PR DESCRIPTION
## Summary

Disables the `Expect: 100-Continue` header on all Fig HTTP clients. By default, .NET's `HttpClient` sends this header on POST requests, which requires a round-trip to the server before the request body is sent — adding unnecessary latency on every registration call.

### Changes
- `ValidatedHttpClientFactory`: set `DefaultRequestHeaders.ExpectContinue = false`
- `SimpleHttpClientFactory`: set `DefaultRequestHeaders.ExpectContinue = false`

### Motivation
Eliminates an extra network round-trip on every client registration and settings-update POST, measurably reducing startup latency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP request handling by optimizing header configuration for better performance and network compatibility across client operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->