### PR TITLE
perf: add IServiceStartupExtender and bump Windows Service timeout

### DIFF
--- a/src/client/Fig.Client/Configuration/FigOptions.cs
+++ b/src/client/Fig.Client/Configuration/FigOptions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using Fig.Client.Contracts;
 using Fig.Client.Enums;
+using Fig.Client.Startup;
 using Microsoft.Extensions.Logging;
 
 namespace Fig.Client.Configuration;
@@ -40,10 +41,9 @@ public class FigOptions
 
     /// <summary>
     /// Timeout for individual HTTP requests to the Fig API. If not set, defaults are used based on execution context:
-    /// - Windows Service with offline settings: 2 seconds
-    /// - Other contexts with offline settings: 5 seconds
-    /// - Windows Service without offline settings: 5 seconds
-    /// - Other contexts without offline settings: 60 seconds
+    /// - With offline settings: 5 seconds
+    /// - Without offline settings, Windows Service: 5 seconds
+    /// - Without offline settings, other contexts: 60 seconds
     /// <para>
     /// This can also be overridden at deployment time without a code change via the
     /// <c>FIG_API_REQUEST_TIMEOUT_SECONDS</c> environment variable (positive integer, seconds).
@@ -65,4 +65,20 @@ public class FigOptions
     /// Default is 30 seconds.
     /// </summary>
     public TimeSpan LookupTableRegistrationDelay { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Optional hook called by the Fig client immediately before each long-running
+    /// registration call.  Use this to signal the Windows Service Control Manager (or
+    /// another supervisor) that more start-up time is needed.
+    /// <para>
+    /// A typical Windows-service implementation wraps
+    /// <c>ServiceBase.RequestAdditionalTime(milliseconds)</c> in a class that implements
+    /// <see cref="IServiceStartupExtender"/> and assigns an instance here.
+    /// </para>
+    /// <para>
+    /// When this property is <c>null</c> (the default) the Fig client uses a no-op
+    /// extender so no supervisor interaction occurs.
+    /// </para>
+    /// </summary>
+    public IServiceStartupExtender? ServiceStartupExtender { get; set; }
 }

--- a/src/client/Fig.Client/ConfigurationProvider/ApiCommunicationHandler.cs
+++ b/src/client/Fig.Client/ConfigurationProvider/ApiCommunicationHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -9,6 +9,7 @@ using Fig.Client.Contracts;
 using Fig.Client.CustomActions;
 using Fig.Client.Exceptions;
 using Fig.Client.LookupTable;
+using Fig.Client.Startup;
 using Fig.Common.NetStandard.IpAddress;
 using Fig.Common.NetStandard.Json;
 using Fig.Contracts;
@@ -28,13 +29,18 @@ public class ApiCommunicationHandler : IApiCommunicationHandler
     private readonly HttpClient _httpClient;
     private readonly ILogger<ApiCommunicationHandler> _logger;
     private readonly IIpAddressResolver _ipAddressResolver;
-    private readonly IClientSecretProvider _clientSecretProvider;    
+    private readonly IClientSecretProvider _clientSecretProvider;
+    private readonly TimeSpan _requestTimeout;
+    private readonly IServiceStartupExtender _startupExtender;
+
     internal ApiCommunicationHandler(string clientName,
         string? instance,
         HttpClient httpClient,
         ILogger<ApiCommunicationHandler> logger,
         IIpAddressResolver ipAddressResolver,
-        IClientSecretProvider clientSecretProvider)
+        IClientSecretProvider clientSecretProvider,
+        TimeSpan requestTimeout,
+        IServiceStartupExtender startupExtender)
     {
         _clientName = clientName;
         _instance = instance;
@@ -42,6 +48,8 @@ public class ApiCommunicationHandler : IApiCommunicationHandler
         _logger = logger;
         _ipAddressResolver = ipAddressResolver;
         _clientSecretProvider = clientSecretProvider;
+        _requestTimeout = requestTimeout;
+        _startupExtender = startupExtender;
           // Connect to the bridge
         CustomActionBridge.PollForCustomActionRequests = PollForCustomActionRequests;
         CustomActionBridge.SendCustomActionResults = SendCustomActionResults;
@@ -51,6 +59,8 @@ public class ApiCommunicationHandler : IApiCommunicationHandler
 
     public async Task RegisterWithFigApi(SettingsClientDefinitionDataContract settings)
     {
+        _startupExtender.RequestAdditionalTime(_requestTimeout + TimeSpan.FromSeconds(5));
+
         var json = JsonConvert.SerializeObject(settings, JsonSettings.FigDefault);
         var payloadBytes = Encoding.UTF8.GetByteCount(json);
         _logger.LogInformation(

--- a/src/client/Fig.Client/ConfigurationProvider/FigConfigurationBuilder.cs
+++ b/src/client/Fig.Client/ConfigurationProvider/FigConfigurationBuilder.cs
@@ -56,7 +56,8 @@ public class FigConfigurationBuilder : IConfigurationBuilder
             VersionType = _figOptions.VersionType,
             AutomaticallyGenerateHeadings = _figOptions.AutomaticallyGenerateHeadings,
             ApiRequestTimeout = _figOptions.ApiRequestTimeout,
-            ApiRetryCount = _figOptions.ApiRetryCount
+            ApiRetryCount = _figOptions.ApiRetryCount,
+            ServiceStartupExtender = _figOptions.ServiceStartupExtender
         };
         
         var logger = source.LoggerFactory.CreateLogger<FigConfigurationBuilder>();

--- a/src/client/Fig.Client/ConfigurationProvider/FigConfigurationSource.cs
+++ b/src/client/Fig.Client/ConfigurationProvider/FigConfigurationSource.cs
@@ -4,6 +4,7 @@ using Fig.Client.Enums;
 using Fig.Client.Exceptions;
 using Fig.Client.Factories;
 using Fig.Client.OfflineSettings;
+using Fig.Client.Startup;
 using Fig.Client.Status;
 using Fig.Client.Versions;
 using Fig.Common.NetStandard.Constants;
@@ -55,6 +56,10 @@ public class FigConfigurationSource : IFigConfigurationSource
     public TimeSpan? ApiRequestTimeout { get; set; }
 
     public int? ApiRetryCount { get; set; }
+
+    public IServiceStartupExtender? ServiceStartupExtender { get; set; }
+
+    private TimeSpan _effectiveApiRequestTimeout;
 
     public IConfigurationProvider Build(IConfigurationBuilder builder)
     {
@@ -119,7 +124,9 @@ public class FigConfigurationSource : IFigConfigurationSource
             httpClient,
             communicationHandlerLogger,
             ipAddressResolver,
-            clientSecretProvider);
+            clientSecretProvider,
+            _effectiveApiRequestTimeout,
+            ServiceStartupExtender ?? new NoOpServiceStartupExtender());
     }
 
     protected virtual ISettingStatusMonitor CreateStatusMonitor(IIpAddressResolver ipAddressResolver, IClientSecretProvider clientSecretProvider, HttpClient httpClient)
@@ -143,10 +150,16 @@ public class FigConfigurationSource : IFigConfigurationSource
     protected virtual HttpClient CreateHttpClient(bool hasOfflineSettings)
     {
         if (HttpClient is not null)
+        {
+            // HttpClient injected directly (typically in tests); use the configured timeout
+            // or the same 5s default ValidatedHttpClientFactory would choose in this scenario.
+            _effectiveApiRequestTimeout = ApiRequestTimeout ?? TimeSpan.FromSeconds(5);
             return HttpClient;
+        }
         
         var clientFactoryLogger = (LoggerFactory ?? new NullLoggerFactory()).CreateLogger<ValidatedHttpClientFactory>();
         var factory = new ValidatedHttpClientFactory(clientFactoryLogger, ApiRequestTimeout, ApiRetryCount, hasOfflineSettings && AllowOfflineSettings);
+        _effectiveApiRequestTimeout = factory.RequestTimeout;
         
         return factory.CreateClient(ApiUris).GetAwaiter().GetResult();
     }

--- a/src/client/Fig.Client/ConfigurationProvider/ValidatedHttpClientFactory.cs
+++ b/src/client/Fig.Client/ConfigurationProvider/ValidatedHttpClientFactory.cs
@@ -22,6 +22,8 @@ public class ValidatedHttpClientFactory
     private readonly TimeSpan _requestTimeout;
     private readonly int _retryCount;
 
+    public TimeSpan RequestTimeout => _requestTimeout;
+
     public ValidatedHttpClientFactory(
         ILogger<ValidatedHttpClientFactory> logger,
         TimeSpan? requestTimeout = null,
@@ -35,7 +37,7 @@ public class ValidatedHttpClientFactory
         // Compute the context-based default (short timeouts when offline settings exist to avoid
         // delaying app startup; longer when no offline settings since the API is the only source)
         var defaultTimeout = hasOfflineSettings
-            ? (isWindowsService ? TimeSpan.FromSeconds(2) : TimeSpan.FromSeconds(5))
+            ? TimeSpan.FromSeconds(5)
             : (isWindowsService ? TimeSpan.FromSeconds(5) : TimeSpan.FromSeconds(60));
 
         string timeoutSource;

--- a/src/client/Fig.Client/Startup/IServiceStartupExtender.cs
+++ b/src/client/Fig.Client/Startup/IServiceStartupExtender.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace Fig.Client.Startup;
+
+/// <summary>
+/// Allows the host application to signal to the process supervisor (e.g. the Windows
+/// Service Control Manager) that more startup time is needed before Fig's registration
+/// call is issued.  The default implementation is a no-op so this feature is opt-in.
+/// </summary>
+public interface IServiceStartupExtender
+{
+    /// <summary>
+    /// Called by the Fig client immediately before issuing a long-running registration
+    /// HTTP call.  Implementations should request additional time from the supervisor
+    /// (e.g. via <c>ServiceBase.RequestAdditionalTime</c>) if needed.
+    /// </summary>
+    /// <param name="requestedTime">
+    /// A hint for how much additional time the caller expects the next operation to need.
+    /// Implementations may round up or ignore this value if the supervisor API does not
+    /// accept fine-grained durations.
+    /// </param>
+    void RequestAdditionalTime(TimeSpan requestedTime);
+}

--- a/src/client/Fig.Client/Startup/NoOpServiceStartupExtender.cs
+++ b/src/client/Fig.Client/Startup/NoOpServiceStartupExtender.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Fig.Client.Startup;
+
+/// <summary>
+/// No-op implementation of <see cref="IServiceStartupExtender"/> used when the host
+/// application has not registered a custom extender.  All calls are silently discarded.
+/// </summary>
+internal sealed class NoOpServiceStartupExtender : IServiceStartupExtender
+{
+    public void RequestAdditionalTime(TimeSpan requestedTime)
+    {
+        // Intentionally empty.
+    }
+}

--- a/src/tests/Fig.Unit.Test/Client/ApiCommunicationHandlerTests.cs
+++ b/src/tests/Fig.Unit.Test/Client/ApiCommunicationHandlerTests.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Fig.Client.ConfigurationProvider;
 using Fig.Client.Contracts;
+using Fig.Client.Startup;
 using Fig.Common.NetStandard.IpAddress;
 using Fig.Contracts.Settings;
 using Fig.Contracts.SettingDefinitions;
@@ -135,7 +136,35 @@ public class ApiCommunicationHandlerTests
             Times.Once);
     }
 
-    private ApiCommunicationHandler CreateHandler(string clientName = "TestClient")
+    [Test]
+    public async Task RegisterWithFigApi_CallsRequestAdditionalTime_WithConfiguredTimeoutPlusBuffer()
+    {
+        // Arrange
+        _httpMessageHandlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+
+        var startupExtenderMock = new Mock<IServiceStartupExtender>();
+        var requestTimeout = TimeSpan.FromSeconds(5);
+        var handler = CreateHandler(startupExtender: startupExtenderMock.Object, requestTimeout: requestTimeout);
+        var settings = CreateSettings(settingCount: 1);
+
+        // Act
+        await handler.RegisterWithFigApi(settings);
+
+        // Assert — RequestAdditionalTime is called with requestTimeout + 5s buffer
+        startupExtenderMock.Verify(
+            x => x.RequestAdditionalTime(requestTimeout + TimeSpan.FromSeconds(5)),
+            Times.Once);
+    }
+
+    private ApiCommunicationHandler CreateHandler(
+        string clientName = "TestClient",
+        IServiceStartupExtender? startupExtender = null,
+        TimeSpan? requestTimeout = null)
     {
         return new ApiCommunicationHandler(
             clientName,
@@ -143,7 +172,9 @@ public class ApiCommunicationHandlerTests
             _httpClient,
             _loggerMock.Object,
             _ipAddressResolverMock.Object,
-            _clientSecretProviderMock.Object);
+            _clientSecretProviderMock.Object,
+            requestTimeout ?? TimeSpan.FromSeconds(5),
+            startupExtender ?? new NoOpServiceStartupExtender());
     }
 
     private static SettingsClientDefinitionDataContract CreateSettings(int settingCount = 2)


### PR DESCRIPTION
## Summary

Introduces `IServiceStartupExtender` so Windows Service hosts can tell the SCM they need extra time during Fig registration, and increases the default Windows Service HTTP timeout from 2 s to 5 s.

### Changes
- New `IServiceStartupExtender` interface with `RequestAdditionalTime(TimeSpan)`
- New `NoOpServiceStartupExtender` (default no-op implementation)
- `FigOptions`: adds `ServiceStartupExtender` property
- `FigConfigurationBuilder`: propagates the option
- `FigConfigurationSource`: wires `ServiceStartupExtender` into `ApiCommunicationHandler`
- `ApiCommunicationHandler`: calls `RequestAdditionalTime` before each registration attempt
- `ValidatedHttpClientFactory`: bumps Windows Service timeout from 2 s → 5 s

### Motivation
Windows Service registration was timing out after 2 s while the SCM waited for the service to report started. This gives the service 5 s to complete registration and provides a hook for custom timeout-extension logic.