### PR TITLE
perf: enable request decompression middleware on Fig API

### DIFF
--- a/src/api/Fig.Api/Program.cs
+++ b/src/api/Fig.Api/Program.cs
@@ -266,6 +266,7 @@ builder.Services.AddControllers().AddNewtonsoftJson(options =>
 });
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
+builder.Services.AddRequestDecompression();
 
 builder.Services.AddHealthChecks()
     .AddCheck<DatabaseHealthCheck>("Database");
@@ -287,6 +288,7 @@ if (forwardedHeaderSettingsForMiddleware?.TrustForwardedHeaders == true)
 }
 
 app.UseMiddleware<ErrorHandlerMiddleware>();
+app.UseRequestDecompression();
 app.UseMiddleware<TransactionMiddleware>();
 app.UseMiddleware<RequestCountMiddleware>();
 


### PR DESCRIPTION
## Summary

Enables the ASP.NET Core built-in request decompression middleware so clients can send compressed request bodies.

### Changes
- `Program.cs`: `builder.Services.AddRequestDecompression()` + `app.UseRequestDecompression()`

### Motivation
Prerequisite for the client-side gzip compression PR (#perf/7). The server must be able to decompress before clients can start sending compressed payloads.