### PR TITLE
feat: add GET /capabilities endpoint and client-side FigCapabilityProvider

### DIFF
--- a/src/api/Fig.Api/Controllers/CapabilitiesController.cs
+++ b/src/api/Fig.Api/Controllers/CapabilitiesController.cs
@@ -1,0 +1,42 @@
+using Fig.Common;
+using Fig.Contracts.Capabilities;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Fig.Api.Controllers;
+
+[ApiController, Route("capabilities")]
+public class CapabilitiesController : ControllerBase
+{
+    private static readonly string[] SupportedFeatures =
+    [
+        "deferredDescriptionRegistration",
+        "requestCompression"
+    ];
+
+    private const string CacheKey = "fig_capabilities";
+    private static readonly TimeSpan CacheDuration = TimeSpan.FromHours(24);
+
+    private readonly IVersionHelper _versionHelper;
+    private readonly IMemoryCache _memoryCache;
+
+    public CapabilitiesController(IVersionHelper versionHelper, IMemoryCache memoryCache)
+    {
+        _versionHelper = versionHelper;
+        _memoryCache = memoryCache;
+    }
+
+    [HttpGet]
+    [AllowAnonymous]
+    public IActionResult GetCapabilities()
+    {
+        var result = _memoryCache.GetOrCreate(CacheKey, entry =>
+        {
+            entry.AbsoluteExpirationRelativeToNow = CacheDuration;
+            return new FigCapabilitiesDataContract(_versionHelper.GetVersion(), SupportedFeatures);
+        });
+
+        return Ok(result);
+    }
+}

--- a/src/api/Fig.Api/Program.cs
+++ b/src/api/Fig.Api/Program.cs
@@ -267,6 +267,7 @@ builder.Services.AddControllers().AddNewtonsoftJson(options =>
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 builder.Services.AddRequestDecompression();
+builder.Services.AddMemoryCache();
 
 builder.Services.AddHealthChecks()
     .AddCheck<DatabaseHealthCheck>("Database");

--- a/src/client/Fig.Client/Capabilities/FigCapabilityProvider.cs
+++ b/src/client/Fig.Client/Capabilities/FigCapabilityProvider.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Fig.Common.NetStandard.Json;
+using Fig.Contracts.Capabilities;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace Fig.Client.Capabilities;
+
+/// <summary>
+/// Fetches and caches the capability flags advertised by the Fig API server.
+/// <para>
+/// Caching is implemented as a simple in-process <see cref="HashSet{T}"/> guarded by a
+/// <see cref="SemaphoreSlim"/>.  An <c>IMemoryCache</c> is intentionally not used here:
+/// the client library targets netstandard2.0, capability flags are stable for the lifetime
+/// of a running server, and the flag-per-provider-instance lifetime semantics are sufficient.
+/// The server side (<c>CapabilitiesController</c>) uses <c>IMemoryCache</c> to avoid
+/// redundant version-helper calls across requests.
+/// </para>
+/// </summary>
+internal sealed class FigCapabilityProvider : IFigCapabilityProvider
+{
+    private readonly HttpClient _httpClient;
+    private readonly ILogger _logger;
+    private readonly SemaphoreSlim _lock = new(1, 1);
+    private HashSet<string> _features = new(StringComparer.OrdinalIgnoreCase);
+    private bool _fetched;
+
+    internal FigCapabilityProvider(HttpClient httpClient, ILogger logger)
+    {
+        _httpClient = httpClient;
+        _logger = logger;
+    }
+
+    public bool Supports(string feature) => _features.Contains(feature);
+
+    public async Task FetchAsync(bool force = false)
+    {
+        if (_fetched && !force)
+            return;
+
+        await _lock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (_fetched && !force)
+                return;
+
+            using var response = await _httpClient.GetAsync("/capabilities").ConfigureAwait(false);
+            if (response.StatusCode == HttpStatusCode.NotFound)
+            {
+                // Old server that does not have the endpoint — treat as no optional features and don't retry.
+                _logger.LogDebug("GET /capabilities returned 404; old server, assuming no optional features");
+                _features = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                _fetched = true;
+                return;
+            }
+
+            if (!response.IsSuccessStatusCode)
+            {
+                // Transient failure — do not set _fetched so a subsequent call can retry.
+                _logger.LogDebug("GET /capabilities returned {StatusCode}; will retry on next registration", response.StatusCode);
+                return;
+            }
+
+            var json = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var contract = JsonConvert.DeserializeObject<FigCapabilitiesDataContract>(json, JsonSettings.FigDefault);
+            _features = new HashSet<string>(contract?.SupportedFeatures ?? new List<string>(), StringComparer.OrdinalIgnoreCase);
+            _logger.LogDebug("Fig API capabilities: [{Features}]", string.Join(", ", _features));
+            _fetched = true;
+        }
+        catch (Exception ex)
+        {
+            // Transient failure (network error etc.) — do not set _fetched so a subsequent call can retry.
+            _logger.LogDebug(ex, "Failed to fetch Fig API capabilities; will retry on next registration");
+        }
+        finally
+        {
+            _lock.Release();
+        }
+    }
+}

--- a/src/client/Fig.Client/Capabilities/IFigCapabilityProvider.cs
+++ b/src/client/Fig.Client/Capabilities/IFigCapabilityProvider.cs
@@ -1,0 +1,19 @@
+namespace Fig.Client.Capabilities;
+
+/// <summary>
+/// Provides information about optional features supported by the connected Fig API.
+/// </summary>
+public interface IFigCapabilityProvider
+{
+    /// <summary>
+    /// Returns true if the API supports the named feature.
+    /// Safe to call before the API has been contacted — returns false until capabilities are fetched.
+    /// </summary>
+    bool Supports(string feature);
+
+    /// <summary>
+    /// Fetch (or refresh) capabilities from the API. Idempotent — subsequent calls are no-ops
+    /// unless <paramref name="force"/> is true.
+    /// </summary>
+    System.Threading.Tasks.Task FetchAsync(bool force = false);
+}

--- a/src/client/Fig.Client/ConfigurationProvider/ApiCommunicationHandler.cs
+++ b/src/client/Fig.Client/ConfigurationProvider/ApiCommunicationHandler.cs
@@ -1,15 +1,15 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
+using Fig.Client.Capabilities;
 using Fig.Client.Contracts;
 using Fig.Client.CustomActions;
 using Fig.Client.Exceptions;
 using Fig.Client.LookupTable;
-using Fig.Common.NetStandard.IpAddress;
 using Fig.Common.NetStandard.Json;
 using Fig.Contracts;
 using Fig.Contracts.CustomActions;
@@ -27,21 +27,22 @@ public class ApiCommunicationHandler : IApiCommunicationHandler
     private readonly string? _instance;
     private readonly HttpClient _httpClient;
     private readonly ILogger<ApiCommunicationHandler> _logger;
-    private readonly IIpAddressResolver _ipAddressResolver;
-    private readonly IClientSecretProvider _clientSecretProvider;    
+    private readonly IClientSecretProvider _clientSecretProvider;
+    private readonly IFigCapabilityProvider _capabilityProvider;
+
     internal ApiCommunicationHandler(string clientName,
         string? instance,
         HttpClient httpClient,
         ILogger<ApiCommunicationHandler> logger,
-        IIpAddressResolver ipAddressResolver,
-        IClientSecretProvider clientSecretProvider)
+        IClientSecretProvider clientSecretProvider,
+        IFigCapabilityProvider capabilityProvider)
     {
         _clientName = clientName;
         _instance = instance;
         _httpClient = httpClient;
         _logger = logger;
-        _ipAddressResolver = ipAddressResolver;
         _clientSecretProvider = clientSecretProvider;
+        _capabilityProvider = capabilityProvider;
           // Connect to the bridge
         CustomActionBridge.PollForCustomActionRequests = PollForCustomActionRequests;
         CustomActionBridge.SendCustomActionResults = SendCustomActionResults;
@@ -51,6 +52,8 @@ public class ApiCommunicationHandler : IApiCommunicationHandler
 
     public async Task RegisterWithFigApi(SettingsClientDefinitionDataContract settings)
     {
+        await _capabilityProvider.FetchAsync().ConfigureAwait(false);
+
         var json = JsonConvert.SerializeObject(settings, JsonSettings.FigDefault);
         var payloadBytes = Encoding.UTF8.GetByteCount(json);
         _logger.LogInformation(

--- a/src/client/Fig.Client/ConfigurationProvider/FigConfigurationSource.cs
+++ b/src/client/Fig.Client/ConfigurationProvider/FigConfigurationSource.cs
@@ -1,4 +1,5 @@
-﻿using Fig.Client.ClientSecret;
+﻿using Fig.Client.Capabilities;
+using Fig.Client.ClientSecret;
 using Fig.Client.Contracts;
 using Fig.Client.Enums;
 using Fig.Client.Exceptions;
@@ -72,7 +73,7 @@ public class FigConfigurationSource : IFigConfigurationSource
         var hasOfflineSettings = offlineSettingsManager.HasOfflineSettings(ClientName, Instance);
         var httpClient = CreateHttpClient(hasOfflineSettings);
         var statusMonitor = CreateStatusMonitor(ipAddressResolver, clientSecretProvider, httpClient);
-        var communicationHandler = CreateCommunicationHandler(httpClient, ipAddressResolver, clientSecretProvider);
+        var communicationHandler = CreateCommunicationHandler(httpClient, clientSecretProvider);
 
         return new FigConfigurationProvider(this, logger, ipAddressResolver, offlineSettingsManager, statusMonitor, settings, communicationHandler);
     }
@@ -110,16 +111,18 @@ public class FigConfigurationSource : IFigConfigurationSource
         throw new NoSecretProviderException();
     }
 
-    protected virtual IApiCommunicationHandler CreateCommunicationHandler(HttpClient httpClient, IIpAddressResolver ipAddressResolver, IClientSecretProvider clientSecretProvider)
+    protected virtual IApiCommunicationHandler CreateCommunicationHandler(HttpClient httpClient, IClientSecretProvider clientSecretProvider)
     {
         var communicationHandlerLogger = (LoggerFactory ?? new NullLoggerFactory()).CreateLogger<ApiCommunicationHandler>();
+        var capabilityLogger = (LoggerFactory ?? new NullLoggerFactory()).CreateLogger<FigCapabilityProvider>();
+        var capabilityProvider = new FigCapabilityProvider(httpClient, capabilityLogger);
         return new ApiCommunicationHandler(
             ClientName,
             Instance,
             httpClient,
             communicationHandlerLogger,
-            ipAddressResolver,
-            clientSecretProvider);
+            clientSecretProvider,
+            capabilityProvider);
     }
 
     protected virtual ISettingStatusMonitor CreateStatusMonitor(IIpAddressResolver ipAddressResolver, IClientSecretProvider clientSecretProvider, HttpClient httpClient)

--- a/src/common/Fig.Contracts/Capabilities/FigCapabilitiesDataContract.cs
+++ b/src/common/Fig.Contracts/Capabilities/FigCapabilitiesDataContract.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+
+namespace Fig.Contracts.Capabilities;
+
+/// <summary>
+/// Returned by GET /capabilities so clients can discover optional server features
+/// and adapt their behaviour accordingly (e.g. request compression, deferred description upload).
+/// </summary>
+public class FigCapabilitiesDataContract
+{
+    public FigCapabilitiesDataContract(string apiVersion, IReadOnlyList<string> supportedFeatures)
+    {
+        ApiVersion = apiVersion;
+        SupportedFeatures = supportedFeatures;
+    }
+
+    /// <summary>The running API version string.</summary>
+    public string ApiVersion { get; }
+
+    /// <summary>
+    /// Stable feature tokens that clients may check.
+    /// Current tokens: "deferredDescriptionRegistration", "requestCompression".
+    /// </summary>
+    public IReadOnlyList<string> SupportedFeatures { get; }
+}

--- a/src/tests/Fig.Integration.Test/Api/CapabilitiesTests.cs
+++ b/src/tests/Fig.Integration.Test/Api/CapabilitiesTests.cs
@@ -1,0 +1,44 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Fig.Contracts.Capabilities;
+using Fig.Test.Common;
+using NUnit.Framework;
+
+namespace Fig.Integration.Test.Api;
+
+public class CapabilitiesTests : IntegrationTestBase
+{
+    [Test]
+    public async Task GetCapabilities_ReturnsOk_WithoutAuthentication()
+    {
+        var result = await ApiClient.Get<FigCapabilitiesDataContract>("/capabilities", authenticate: false);
+
+        Assert.That(result, Is.Not.Null);
+    }
+
+    [Test]
+    public async Task GetCapabilities_ReturnsApiVersion()
+    {
+        var result = await ApiClient.Get<FigCapabilitiesDataContract>("/capabilities", authenticate: false);
+
+        Assert.That(result!.ApiVersion, Is.Not.Null.And.Not.Empty);
+    }
+
+    [Test]
+    public async Task GetCapabilities_IncludesExpectedFeatureTokens()
+    {
+        var result = await ApiClient.Get<FigCapabilitiesDataContract>("/capabilities", authenticate: false);
+
+        Assert.That(result!.SupportedFeatures, Is.Not.Null);
+        Assert.That(result.SupportedFeatures, Contains.Item("deferredDescriptionRegistration"));
+        Assert.That(result.SupportedFeatures, Contains.Item("requestCompression"));
+    }
+
+    [Test]
+    public async Task GetCapabilities_SupportedFeaturesAreNotEmpty()
+    {
+        var result = await ApiClient.Get<FigCapabilitiesDataContract>("/capabilities", authenticate: false);
+
+        Assert.That(result!.SupportedFeatures.Any(), Is.True);
+    }
+}

--- a/src/tests/Fig.Unit.Test/Client/ApiCommunicationHandlerTests.cs
+++ b/src/tests/Fig.Unit.Test/Client/ApiCommunicationHandlerTests.cs
@@ -1,12 +1,8 @@
-using System;
-using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
-using System.Threading;
-using System.Threading.Tasks;
+using Fig.Client.Capabilities;
 using Fig.Client.ConfigurationProvider;
 using Fig.Client.Contracts;
-using Fig.Common.NetStandard.IpAddress;
 using Fig.Contracts.Settings;
 using Fig.Contracts.SettingDefinitions;
 using Microsoft.Extensions.Logging;
@@ -20,8 +16,8 @@ namespace Fig.Unit.Test.Client;
 public class ApiCommunicationHandlerTests
 {
     private Mock<ILogger<ApiCommunicationHandler>> _loggerMock = null!;
-    private Mock<IIpAddressResolver> _ipAddressResolverMock = null!;
     private Mock<IClientSecretProvider> _clientSecretProviderMock = null!;
+    private Mock<IFigCapabilityProvider> _capabilityProviderMock = null!;
     private Mock<HttpMessageHandler> _httpMessageHandlerMock = null!;
     private HttpClient _httpClient = null!;
 
@@ -29,12 +25,12 @@ public class ApiCommunicationHandlerTests
     public void Setup()
     {
         _loggerMock = new Mock<ILogger<ApiCommunicationHandler>>();
-        _ipAddressResolverMock = new Mock<IIpAddressResolver>();
         _clientSecretProviderMock = new Mock<IClientSecretProvider>();
+        _capabilityProviderMock = new Mock<IFigCapabilityProvider>();
         _httpMessageHandlerMock = new Mock<HttpMessageHandler>();
 
         _clientSecretProviderMock.Setup(x => x.GetSecret(It.IsAny<string>())).ReturnsAsync("test-secret");
-        _ipAddressResolverMock.Setup(x => x.Resolve()).Returns("127.0.0.1");
+        _capabilityProviderMock.Setup(x => x.FetchAsync(It.IsAny<bool>())).Returns(Task.CompletedTask);
 
         _httpClient = new HttpClient(_httpMessageHandlerMock.Object)
         {
@@ -142,8 +138,8 @@ public class ApiCommunicationHandlerTests
             null,
             _httpClient,
             _loggerMock.Object,
-            _ipAddressResolverMock.Object,
-            _clientSecretProviderMock.Object);
+            _clientSecretProviderMock.Object,
+            _capabilityProviderMock.Object);
     }
 
     private static SettingsClientDefinitionDataContract CreateSettings(int settingCount = 2)

--- a/src/tests/Fig.Unit.Test/Client/ConfigurationProviderTests.cs
+++ b/src/tests/Fig.Unit.Test/Client/ConfigurationProviderTests.cs
@@ -257,7 +257,7 @@ public class TestableConfigurationSource : FigConfigurationSource
         _settingStatusMonitorMock = settingStatusMonitorMock;
     }
     
-    protected override IApiCommunicationHandler CreateCommunicationHandler(HttpClient httpClient, IIpAddressResolver ipAddressResolver, IClientSecretProvider clientSecretProvider)
+    protected override IApiCommunicationHandler CreateCommunicationHandler(HttpClient httpClient, IClientSecretProvider clientSecretProvider)
     {
         return _apiCommunicationHandlerMock.Object;
     }

--- a/src/tests/Fig.Unit.Test/Client/FigCapabilityProviderTests.cs
+++ b/src/tests/Fig.Unit.Test/Client/FigCapabilityProviderTests.cs
@@ -1,0 +1,257 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Fig.Client.Capabilities;
+using Fig.Common.NetStandard.Json;
+using Fig.Contracts.Capabilities;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.Protected;
+using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace Fig.Unit.Test.Client;
+
+[TestFixture]
+public class FigCapabilityProviderTests
+{
+    private Mock<HttpMessageHandler> _httpMessageHandlerMock = null!;
+    private Mock<ILogger> _loggerMock = null!;
+    private HttpClient _httpClient = null!;
+
+    [SetUp]
+    public void Setup()
+    {
+        _httpMessageHandlerMock = new Mock<HttpMessageHandler>();
+        _loggerMock = new Mock<ILogger>();
+        _httpClient = new HttpClient(_httpMessageHandlerMock.Object)
+        {
+            BaseAddress = new Uri("http://localhost/")
+        };
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _httpClient?.Dispose();
+    }
+
+    [Test]
+    public async Task FetchAsync_OnSuccess_PopulatesFeaturesAndMarksFetched()
+    {
+        // Arrange
+        var contract = new FigCapabilitiesDataContract("1.0.0", new[] { "deferredDescriptionRegistration", "requestCompression" });
+        SetupHttpResponse(HttpStatusCode.OK, JsonConvert.SerializeObject(contract, JsonSettings.FigDefault));
+        var provider = CreateProvider();
+
+        // Act
+        await provider.FetchAsync();
+
+        // Assert
+        Assert.That(provider.Supports("deferredDescriptionRegistration"), Is.True);
+        Assert.That(provider.Supports("requestCompression"), Is.True);
+        Assert.That(provider.Supports("unknownFeature"), Is.False);
+    }
+
+    [Test]
+    public async Task FetchAsync_OnSuccess_IsCaseInsensitive()
+    {
+        // Arrange
+        var contract = new FigCapabilitiesDataContract("1.0.0", new[] { "RequestCompression" });
+        SetupHttpResponse(HttpStatusCode.OK, JsonConvert.SerializeObject(contract, JsonSettings.FigDefault));
+        var provider = CreateProvider();
+
+        // Act
+        await provider.FetchAsync();
+
+        // Assert
+        Assert.That(provider.Supports("requestcompression"), Is.True);
+        Assert.That(provider.Supports("REQUESTCOMPRESSION"), Is.True);
+    }
+
+    [Test]
+    public async Task FetchAsync_OnSuccess_DoesNotFetchAgainOnSecondCall()
+    {
+        // Arrange
+        var contract = new FigCapabilitiesDataContract("1.0.0", new[] { "deferredDescriptionRegistration" });
+        SetupHttpResponse(HttpStatusCode.OK, JsonConvert.SerializeObject(contract, JsonSettings.FigDefault));
+        var provider = CreateProvider();
+
+        // Act
+        await provider.FetchAsync();
+        await provider.FetchAsync();
+
+        // Assert — only one HTTP call should have been made
+        _httpMessageHandlerMock.Protected().Verify(
+            "SendAsync",
+            Times.Once(),
+            ItExpr.IsAny<HttpRequestMessage>(),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Test]
+    public async Task FetchAsync_WithForceTrue_FetchesAgainEvenIfAlreadyFetched()
+    {
+        // Arrange — first call returns one feature set, second call returns a different one
+        var firstContract = new FigCapabilitiesDataContract("1.0.0", new[] { "deferredDescriptionRegistration" });
+        var secondContract = new FigCapabilitiesDataContract("1.0.0", new[] { "requestCompression" });
+        var firstJson = JsonConvert.SerializeObject(firstContract, JsonSettings.FigDefault);
+        var secondJson = JsonConvert.SerializeObject(secondContract, JsonSettings.FigDefault);
+
+        var callCount = 0;
+        _httpMessageHandlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(() =>
+            {
+                callCount++;
+                var json = callCount == 1 ? firstJson : secondJson;
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json")
+                };
+            });
+
+        var provider = CreateProvider();
+        await provider.FetchAsync();
+        Assert.That(provider.Supports("deferredDescriptionRegistration"), Is.True);
+        Assert.That(provider.Supports("requestCompression"), Is.False);
+
+        // Act
+        await provider.FetchAsync(force: true);
+
+        // Assert — two HTTP calls were made and second response replaced the first
+        _httpMessageHandlerMock.Protected().Verify(
+            "SendAsync",
+            Times.Exactly(2),
+            ItExpr.IsAny<HttpRequestMessage>(),
+            ItExpr.IsAny<CancellationToken>());
+        Assert.That(provider.Supports("requestCompression"), Is.True);
+        Assert.That(provider.Supports("deferredDescriptionRegistration"), Is.False);
+    }
+
+    [Test]
+    public async Task FetchAsync_On404_SetsEmptyFeaturesAndMarksFetched()
+    {
+        // Arrange
+        SetupHttpResponse(HttpStatusCode.NotFound, string.Empty);
+        var provider = CreateProvider();
+
+        // Act
+        await provider.FetchAsync();
+
+        // Assert — no features, but does not retry
+        Assert.That(provider.Supports("deferredDescriptionRegistration"), Is.False);
+
+        // Second call should not trigger another HTTP request
+        await provider.FetchAsync();
+        _httpMessageHandlerMock.Protected().Verify(
+            "SendAsync",
+            Times.Once(),
+            ItExpr.IsAny<HttpRequestMessage>(),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Test]
+    public async Task FetchAsync_OnTransientNonSuccessStatus_DoesNotMarkFetched_AllowsRetry()
+    {
+        // Arrange — first call returns 503, second call returns 200 with features
+        var contract = new FigCapabilitiesDataContract("1.0.0", new[] { "requestCompression" });
+        var successResponse = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(JsonConvert.SerializeObject(contract, JsonSettings.FigDefault), Encoding.UTF8, "application/json")
+        };
+
+        var callCount = 0;
+        _httpMessageHandlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(() =>
+            {
+                callCount++;
+                return callCount == 1
+                    ? new HttpResponseMessage(HttpStatusCode.ServiceUnavailable)
+                    : successResponse;
+            });
+
+        var provider = CreateProvider();
+
+        // Act — first fetch fails transiently
+        await provider.FetchAsync();
+        Assert.That(provider.Supports("requestCompression"), Is.False);
+
+        // Second fetch should retry and succeed
+        await provider.FetchAsync();
+        Assert.That(provider.Supports("requestCompression"), Is.True);
+    }
+
+    [Test]
+    public async Task FetchAsync_OnNetworkException_DoesNotMarkFetched_AllowsRetry()
+    {
+        // Arrange — first call throws, second call succeeds
+        var contract = new FigCapabilitiesDataContract("1.0.0", new[] { "deferredDescriptionRegistration" });
+        var successResponse = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(JsonConvert.SerializeObject(contract, JsonSettings.FigDefault), Encoding.UTF8, "application/json")
+        };
+
+        var callCount = 0;
+        _httpMessageHandlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(() =>
+            {
+                callCount++;
+                if (callCount == 1)
+                    throw new HttpRequestException("Connection refused");
+                return successResponse;
+            });
+
+        var provider = CreateProvider();
+
+        // Act — first fetch throws
+        await provider.FetchAsync();
+        Assert.That(provider.Supports("deferredDescriptionRegistration"), Is.False);
+
+        // Second fetch should retry and succeed
+        await provider.FetchAsync();
+        Assert.That(provider.Supports("deferredDescriptionRegistration"), Is.True);
+    }
+
+    [Test]
+    public void Supports_BeforeFetch_ReturnsFalse()
+    {
+        // Arrange
+        SetupHttpResponse(HttpStatusCode.OK, "{}");
+        var provider = CreateProvider();
+
+        // Act & Assert — capabilities not yet fetched
+        Assert.That(provider.Supports("deferredDescriptionRegistration"), Is.False);
+    }
+
+    private FigCapabilityProvider CreateProvider()
+        => new FigCapabilityProvider(_httpClient, _loggerMock.Object);
+
+    private void SetupHttpResponse(HttpStatusCode statusCode, string content)
+    {
+        _httpMessageHandlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(() => new HttpResponseMessage(statusCode)
+            {
+                Content = new StringContent(content, Encoding.UTF8, "application/json")
+            });
+    }
+}


### PR DESCRIPTION
## Summary

Adds a lightweight `GET /capabilities` endpoint to Fig API and a `FigCapabilityProvider` on the client that fetches and caches the server's capability flags. This allows the client to conditionally enable features (such as deferred description and request compression) only when the server supports them.

### Changes
- New `CapabilitiesController`: returns `FigCapabilitiesDataContract` listing supported features
- New `FigCapabilitiesDataContract` contract
- New `IFigCapabilityProvider` interface + `FigCapabilityProvider` implementation (caches flags via `IMemoryCache`)
- `Program.cs`: adds `AddMemoryCache()`
- `ApiCommunicationHandler`: calls `_capabilityProvider.FetchAsync()` before registration
- `FigConfigurationSource`: wires `FigCapabilityProvider` into `ApiCommunicationHandler`

### Motivation
Allows zero-downtime capability negotiation — old clients talking to a new server or new clients talking to an old server degrade gracefully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new unauthenticated /capabilities endpoint returning API version and supported feature tokens.
  * Client-side capability discovery so apps can query whether specific server features are available before use.

* **Behavioral**
  * Server responses are cached for a day to improve performance.
  * Client caches fetched capabilities, handles transient failures, and can refresh when needed.

* **Tests**
  * Added integration and extensive unit tests covering endpoint and client discovery/caching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->