### PR TITLE
perf: deferred description registration

### DIFF
--- a/src/api/Fig.Api/Controllers/ClientsController.cs
+++ b/src/api/Fig.Api/Controllers/ClientsController.cs
@@ -8,7 +8,6 @@ using Fig.Contracts.SettingClients;
 using Fig.Contracts.SettingDefinitions;
 using Fig.Contracts.Settings;
 using Microsoft.AspNetCore.Mvc;
-
 namespace Fig.Api.Controllers;
 
 [ApiController]
@@ -140,5 +139,24 @@ public class ClientsController : ControllerBase
         
         var result = await _settingsService.ChangeClientSecret(clientName, changeRequest);
         return Ok(result);
+    }
+
+    /// <summary>
+    ///     Called by the client after registration to update the description without
+    ///     repeating the full payload (deferred description registration).
+    /// </summary>
+    [LogFigClientCall]
+    [AllowAnonymous]
+    [HttpPut("{clientName}/description")]
+    public async Task<IActionResult> UpdateClientDescription(string clientName,
+        [FromHeader] string clientSecret,
+        [FromQuery] string? instance,
+        [FromBody] ClientDescriptionUpdateDataContract update)
+    {
+        if (!_clientSecretValidator.IsValid(clientSecret))
+            throw new InvalidClientSecretException(clientSecret);
+
+        await _settingsService.UpdateClientDescription(clientName, instance, clientSecret, update.Description);
+        return Ok();
     }
 }

--- a/src/api/Fig.Api/Converters/SettingDefinitionConverter.cs
+++ b/src/api/Fig.Api/Converters/SettingDefinitionConverter.cs
@@ -32,7 +32,7 @@ public class SettingDefinitionConverter : ISettingDefinitionConverter
         return new SettingClientBusinessEntity
         {
             Name = dataContract.Name,
-            Description = dataContract.Description,
+            Description = dataContract.Description ?? string.Empty,
             Settings = dataContract.Settings.Select(Convert).ToList()
         };
     }

--- a/src/api/Fig.Api/EventLogFactory.cs
+++ b/src/api/Fig.Api/EventLogFactory.cs
@@ -376,6 +376,15 @@ public class EventLogFactory : IEventLogFactory
             authenticatedUsername: authenticatedUsername);
     }
 
+    public EventLogBusinessEntity ClientDescriptionUpdated(Guid clientId, string clientName, string? instance, string newDescription)
+    {
+        return Create(EventMessage.ClientDescriptionUpdated,
+            clientId: clientId,
+            clientName: clientName,
+            instance: instance,
+            newValue: newDescription);
+    }
+
     private EventLogBusinessEntity Create(string eventType,
         Guid? clientId = null,
         string? clientName = null,

--- a/src/api/Fig.Api/IEventLogFactory.cs
+++ b/src/api/Fig.Api/IEventLogFactory.cs
@@ -133,4 +133,6 @@ public interface IEventLogFactory
     EventLogBusinessEntity GroupSettingAdded(string groupName, string settingName, string clientName, string? authenticatedUsername);
     
     EventLogBusinessEntity GroupSettingRemoved(string groupName, string settingName, string clientName, string? authenticatedUsername);
+    
+    EventLogBusinessEntity ClientDescriptionUpdated(Guid clientId, string clientName, string? instance, string newDescription);
 }

--- a/src/api/Fig.Api/Services/ISettingsService.cs
+++ b/src/api/Fig.Api/Services/ISettingsService.cs
@@ -26,5 +26,7 @@ public interface ISettingsService : IAuthenticatedService
     
     Task<ClientsDescriptionDataContract> GetClientDescriptions();
     
+    Task UpdateClientDescription(string clientName, string? instance, string clientSecret, string description);
+
     void SetRequesterDetails(string? ipAddress, string? hostname);
 }

--- a/src/api/Fig.Api/Services/SettingsService.cs
+++ b/src/api/Fig.Api/Services/SettingsService.cs
@@ -145,6 +145,11 @@ public class SettingsService : AuthenticatedService, ISettingsService
 
         clientBusinessEntity.LastRegistration = DateTime.UtcNow;
 
+        // When description is empty (deferred registration), copy the existing description so the
+        // equivalence check doesn't incorrectly treat every startup as a "definition changed" event.
+        if (string.IsNullOrEmpty(clientBusinessEntity.Description) && existingRegistrations.Any())
+            clientBusinessEntity.Description = existingRegistrations.First().Description;
+
         if (!existingRegistrations.Any())
         {
             if (debugEnabled) _logger.LogDebug("Starting initial registration for client {ClientName}", sanitizedClientName);
@@ -478,6 +483,30 @@ public class SettingsService : AuthenticatedService, ISettingsService
         return new ClientsDescriptionDataContract(clientDescriptionContracts);
     }
 
+    public async Task UpdateClientDescription(string clientName, string? instance, string clientSecret, string description)
+    {
+        var client = await _settingClientRepository.GetClient(clientName, instance);
+        if (client == null)
+            return;
+
+        var registrationStatus = _registrationStatusValidator.GetStatus(client, clientSecret);
+        if (registrationStatus == CurrentRegistrationStatus.DoesNotMatchSecret)
+        {
+            await _eventLogRepository.Add(_eventLogFactory.InvalidClientSecretAttempt(clientName, "update description", _requestIpAddress, _requesterHostname));
+            throw new UnauthorizedAccessException($"Invalid client secret for client '{clientName}'");
+        }
+
+        client.Description = description;
+        await _settingClientRepository.UpdateClient(client);
+
+        const int maxDescriptionLogLength = 200;
+        var descriptionSummary = description.Length > maxDescriptionLogLength
+            ? $"{description[..maxDescriptionLogLength]}... [{description.Length} chars]"
+            : description;
+        await _eventLogRepository.Add(
+            _eventLogFactory.ClientDescriptionUpdated(client.Id, client.Name, client.Instance, descriptionSummary));
+    }
+
     public void SetRequesterDetails(string? ipAddress, string? hostname)
     {
         _requestIpAddress = ipAddress;
@@ -586,7 +615,8 @@ public class SettingsService : AuthenticatedService, ISettingsService
 
         foreach (var registration in existingRegistrations)
         {
-            registration.Description = updatedSettingDefinitions.Description;
+            if (!string.IsNullOrEmpty(updatedSettingDefinitions.Description))
+                registration.Description = updatedSettingDefinitions.Description;
             registration.Settings.Clear();
             var values = settingValues[registration.Instance ?? "Default"];
             foreach (var setting in updatedSettingDefinitions.Settings)

--- a/src/client/Fig.Client/ConfigurationProvider/ApiCommunicationHandler.cs
+++ b/src/client/Fig.Client/ConfigurationProvider/ApiCommunicationHandler.cs
@@ -14,6 +14,7 @@ using Fig.Common.NetStandard.Json;
 using Fig.Contracts;
 using Fig.Contracts.CustomActions;
 using Fig.Contracts.LookupTable;
+using Fig.Contracts.SettingClients;
 using Fig.Contracts.SettingDefinitions;
 using Fig.Contracts.Settings;
 using Microsoft.Extensions.Logging;
@@ -54,17 +55,39 @@ public class ApiCommunicationHandler : IApiCommunicationHandler
     {
         await _capabilityProvider.FetchAsync().ConfigureAwait(false);
 
-        var json = JsonConvert.SerializeObject(settings, JsonSettings.FigDefault);
+        var useDeferredDescription = _capabilityProvider.Supports("deferredDescriptionRegistration") 
+                                     && settings.Description != null;
+
+        SettingsClientDefinitionDataContract payload;
+        if (useDeferredDescription)
+        {
+            payload = new SettingsClientDefinitionDataContract(
+                settings.Name,
+                null,
+                settings.Instance,
+                settings.HasDisplayScripts,
+                settings.Settings,
+                settings.ClientSettingOverrides,
+                settings.CustomActions,
+                settings.ClientVersion);
+        }
+        else
+        {
+            payload = settings;
+        }
+
+        var json = JsonConvert.SerializeObject(payload, JsonSettings.FigDefault);
         var payloadBytes = Encoding.UTF8.GetByteCount(json);
         _logger.LogInformation(
             "Registering configuration with the Fig API at address {FigUri}. " +
             "Payload size: {PayloadBytes} bytes ({PayloadKB:F1} KB), " +
-            "setting count: {SettingCount}, custom action count: {CustomActionCount}",
+            "setting count: {SettingCount}, custom action count: {CustomActionCount}{DeferredDesc}",
             _httpClient.BaseAddress,
             payloadBytes,
             payloadBytes / 1024.0,
             settings.Settings.Count,
-            settings.CustomActions.Count);
+            settings.CustomActions.Count,
+            useDeferredDescription ? " (description deferred)" : string.Empty);
 
         var data = new StringContent(json, Encoding.UTF8, "application/json");
         var secret = await _clientSecretProvider.GetSecret(_clientName);
@@ -87,6 +110,21 @@ public class ApiCommunicationHandler : IApiCommunicationHandler
         if (result.IsSuccessStatusCode)
         {
             _logger.LogInformation("Successfully registered settings with Fig API in {ElapsedMs} ms", sw.ElapsedMilliseconds);
+
+            if (useDeferredDescription)
+            {
+                _ = PostDescriptionAsync(settings.Name, settings.Instance, settings.Description!, secret)
+                    .ContinueWith(
+                        task =>
+                        {
+                            _logger.LogError(
+                                task.Exception,
+                                "Failed to update deferred description for client {Name} instance {Instance}",
+                                settings.Name,
+                                settings.Instance);
+                        },
+                        TaskContinuationOptions.OnlyOnFaulted);
+            }
         }
         else
         {
@@ -103,6 +141,24 @@ public class ApiCommunicationHandler : IApiCommunicationHandler
                 throw new FigRegistrationException(error);
             }
         }
+    }
+
+    private async Task PostDescriptionAsync(string clientName, string? instance, string description, string secret)
+    {
+        var descJson = JsonConvert.SerializeObject(
+            new ClientDescriptionUpdateDataContract(description), JsonSettings.FigDefault);
+        var descData = new StringContent(descJson, Encoding.UTF8, "application/json");
+        var uri = instance != null
+            ? $"/clients/{Uri.EscapeDataString(clientName)}/description?instance={Uri.EscapeDataString(instance)}"
+            : $"/clients/{Uri.EscapeDataString(clientName)}/description";
+
+        using var msg = new HttpRequestMessage(HttpMethod.Put, uri) { Content = descData };
+        msg.Headers.TryAddWithoutValidation("ClientSecret", secret);
+        using var response = await _httpClient.SendAsync(msg).ConfigureAwait(false);
+        if (response.IsSuccessStatusCode)
+            _logger.LogDebug("Deferred description for {ClientName} uploaded successfully", clientName);
+        else
+            _logger.LogWarning("Deferred description for {ClientName} returned {StatusCode}", clientName, response.StatusCode);
     }
 
     public async Task<List<SettingDataContract>> RequestConfiguration()

--- a/src/client/Fig.Client/ConfigurationProvider/FigConfigurationProvider.cs
+++ b/src/client/Fig.Client/ConfigurationProvider/FigConfigurationProvider.cs
@@ -117,9 +117,9 @@ public class FigConfigurationProvider : Microsoft.Extensions.Configuration.Confi
                 string.Join(", ",
                     settingsDataContract.ClientSettingOverrides.Select(a => a.Name)));
 
-        if (settingsDataContract.Description.Length > 2500000)
+        if ((settingsDataContract.Description?.Length ?? 0) > 2500000)
         {
-            var sizeInMb = Math.Round(settingsDataContract.Description.Length * 2 / 1024.0 / 1024.0, 2);
+            var sizeInMb = Math.Round(settingsDataContract.Description!.Length * 2 / 1024.0 / 1024.0, 2);
             _logger.LogWarning(
                 "Client description exceeds 5MB (approx size is {Size}MB), which may cause issues with the Fig API. " +
                 "Consider reducing the size of the description by removing or resizing images", sizeInMb);

--- a/src/common/Fig.Common/Constants/EventMessage.cs
+++ b/src/common/Fig.Common/Constants/EventMessage.cs
@@ -49,6 +49,7 @@ public static class EventMessage
     public const string GroupDeleted = "Setting Group Deleted";
     public const string GroupSettingAdded = "Setting Added to Group";
     public const string GroupSettingRemoved = "Setting Removed from Group";
+    public const string ClientDescriptionUpdated = "Client Description Updated";
 
     public static readonly List<string> UnrestrictedEvents =
     [

--- a/src/common/Fig.Contracts/SettingClients/ClientDescriptionUpdateDataContract.cs
+++ b/src/common/Fig.Contracts/SettingClients/ClientDescriptionUpdateDataContract.cs
@@ -1,0 +1,14 @@
+namespace Fig.Contracts.SettingClients;
+
+/// <summary>
+/// Body for the deferred client description PUT endpoint.
+/// </summary>
+public class ClientDescriptionUpdateDataContract
+{
+    public ClientDescriptionUpdateDataContract(string description)
+    {
+        Description = description;
+    }
+
+    public string Description { get; }
+}

--- a/src/common/Fig.Contracts/SettingDefinitions/SettingsClientDefinitionDataContract.cs
+++ b/src/common/Fig.Contracts/SettingDefinitions/SettingsClientDefinitionDataContract.cs
@@ -9,7 +9,7 @@ namespace Fig.Contracts.SettingDefinitions
     public class SettingsClientDefinitionDataContract
     {
         public SettingsClientDefinitionDataContract(string name,
-            string description,
+            string? description,
             string? instance,
             bool hasDisplayScripts,
             List<SettingDefinitionDataContract> settings,
@@ -29,7 +29,7 @@ namespace Fig.Contracts.SettingDefinitions
 
         public string Name { get; }
         
-        public string Description { get; }
+        public string? Description { get; }
 
         public string? Instance { get; }
         

--- a/src/tests/Fig.Integration.Test/Api/ClientDescriptionsTests.cs
+++ b/src/tests/Fig.Integration.Test/Api/ClientDescriptionsTests.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using Fig.Contracts.SettingClients;
 using Fig.Test.Common;
 using Fig.Test.Common.TestSettings;
@@ -38,5 +39,38 @@ public class ClientDescriptionsTests : IntegrationTestBase
         var descriptions = await ApiClient.Get<ClientsDescriptionDataContract>("/clients/descriptions");
         Assert.That(descriptions!.Clients.Single().Name, Is.EqualTo(settings.ClientName));
         Assert.That(descriptions!.Clients.Single().Description, Is.EqualTo(settings.ClientDescription));
+    }
+
+    [Test]
+    public async Task PutClientDescription_WithValidSecret_UpdatesDescription()
+    {
+        // Arrange
+        var secret = GetNewSecret();
+        var settings = await RegisterSettings<AllSettingsAndTypes>(secret);
+        const string updatedDescription = "An updated description for testing";
+        var updateBody = new ClientDescriptionUpdateDataContract(updatedDescription);
+
+        // Act
+        var uri = $"/clients/{settings.ClientName}/description";
+        await ApiClient.PutWithClientSecretAndVerify(uri, updateBody, secret, HttpStatusCode.OK);
+
+        // Assert — description endpoint should now reflect the update
+        var descriptions = await ApiClient.Get<ClientsDescriptionDataContract>("/clients/descriptions");
+        var updated = descriptions!.Clients.Single(c => c.Name == settings.ClientName);
+        Assert.That(updated.Description, Is.EqualTo(updatedDescription));
+    }
+
+    [Test]
+    public async Task PutClientDescription_WithInvalidSecret_ReturnsUnauthorized()
+    {
+        // Arrange
+        var secret = GetNewSecret();
+        var settings = await RegisterSettings<AllSettingsAndTypes>(secret);
+        var wrongSecret = GetNewSecret(); // different secret
+        var updateBody = new ClientDescriptionUpdateDataContract("Should not be applied");
+
+        // Act & Assert
+        var uri = $"/clients/{settings.ClientName}/description";
+        await ApiClient.PutWithClientSecretAndVerify(uri, updateBody, wrongSecret, HttpStatusCode.Unauthorized);
     }
 }

--- a/src/tests/Fig.Test.Common/ApiClient.cs
+++ b/src/tests/Fig.Test.Common/ApiClient.cs
@@ -86,6 +86,23 @@ public class ApiClient
         Assert.That(result.StatusCode, Is.EqualTo(expected));
     }
 
+    public async Task PutWithClientSecretAndVerify(string uri, object? data, string clientSecret, HttpStatusCode expected)
+    {
+        using var httpClient = GetHttpClient();
+        httpClient.DefaultRequestHeaders.Add("ClientSecret", clientSecret);
+
+        StringContent? content = null;
+        if (data is not null)
+        {
+            var json = JsonConvert.SerializeObject(data, JsonSettings.FigDefault);
+            content = new StringContent(json, Encoding.UTF8, "application/json");
+        }
+
+        var result = await httpClient.PutAsync(uri, content);
+
+        Assert.That(result.StatusCode, Is.EqualTo(expected));
+    }
+
     public async Task PutAndVerify(string uri, object? data, HttpStatusCode expected, bool authenticate = true)
     {
         using var httpClient = GetHttpClient();

--- a/src/tests/Fig.Unit.Test/Client/ApiCommunicationHandlerTests.cs
+++ b/src/tests/Fig.Unit.Test/Client/ApiCommunicationHandlerTests.cs
@@ -131,6 +131,77 @@ public class ApiCommunicationHandlerTests
             Times.Once);
     }
 
+    [Test]
+    public async Task RegisterWithFigApi_WhenDeferredDescriptionSupported_PostPayloadOmitsDescription()
+    {
+        // Arrange
+        _capabilityProviderMock.Setup(x => x.Supports("deferredDescriptionRegistration")).Returns(true);
+
+        string? capturedPostBody = null;
+        var putSignal = new SemaphoreSlim(0, 1);
+        _httpMessageHandlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync((HttpRequestMessage req, CancellationToken _) =>
+            {
+                if (req.Method == HttpMethod.Post)
+                    capturedPostBody = req.Content!.ReadAsStringAsync().GetAwaiter().GetResult();
+                if (req.Method == HttpMethod.Put)
+                    putSignal.Release();
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            });
+
+        var handler = CreateHandler();
+        var settings = CreateSettings(settingCount: 2);
+
+        // Act
+        await handler.RegisterWithFigApi(settings);
+        var putIssued = await putSignal.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Assert — POST payload must not contain the description field value
+        Assert.That(putIssued, Is.True, "Deferred description PUT should be issued within 5 seconds");
+        Assert.That(capturedPostBody, Is.Not.Null);
+        Assert.That(capturedPostBody, Does.Not.Contain("A test client"));
+    }
+
+    [Test]
+    public async Task RegisterWithFigApi_WhenDeferredDescriptionSupported_SendsPutDescriptionRequest()
+    {
+        // Arrange
+        _capabilityProviderMock.Setup(x => x.Supports("deferredDescriptionRegistration")).Returns(true);
+
+        var putRequests = new List<string>();
+        var putSignal = new SemaphoreSlim(0, 1);
+        _httpMessageHandlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync((HttpRequestMessage req, CancellationToken _) =>
+            {
+                if (req.Method == HttpMethod.Put)
+                {
+                    putRequests.Add(req.RequestUri!.ToString());
+                    putSignal.Release();
+                }
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            });
+
+        var handler = CreateHandler();
+        var settings = CreateSettings(settingCount: 2);
+
+        // Act
+        await handler.RegisterWithFigApi(settings);
+        var putIssued = await putSignal.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Assert — a PUT to the description endpoint should have been issued
+        Assert.That(putIssued, Is.True, "Deferred description PUT should be issued within 5 seconds");
+        Assert.That(putRequests, Has.Count.EqualTo(1));
+        Assert.That(putRequests[0], Does.Contain("/clients/TestClient/description"));
+    }
+
     private ApiCommunicationHandler CreateHandler(string clientName = "TestClient")
     {
         return new ApiCommunicationHandler(


### PR DESCRIPTION
## Summary

When the server advertises `deferredDescriptionRegistration` capability, the Fig client now strips the `Description` field from the initial registration payload and sends it in a separate fire-and-forget PUT request afterward. This reduces the size of the hot-path registration POST.

### Changes
- New `ClientDescriptionUpdateDataContract`
- New `PUT /clients/{name}/description` endpoint on `ClientsController`
- `ISettingsService` / `SettingsService`: `UpdateClientDescriptionAsync`
- `EventLogFactory` / `IEventLogFactory`: `DescriptionUpdated` event
- `EventMessage`: new `DescriptionUpdated` enum value
- `SettingsClientDefinitionDataContract`: `Description` made nullable
- `SettingDefinitionConverter`: null-coalesce guard on description
- `FigConfigurationProvider`: null-guard on description
- `ApiCommunicationHandler`: capability-gated deferred description + `PostDescriptionAsync`

### Motivation
Descriptions are human-readable strings that don't affect runtime behaviour; deferring them keeps the registration latency path lean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clients can update their descriptions after registration via a new authenticated endpoint.
  * Deferred description registration: clients may register without a description and supply it later.
  * Description updates are recorded in the audit/event log.

* **Bug Fixes**
  * Null/empty descriptions are handled to avoid spurious registration validation issues.

* **Tests**
  * Added integration and unit tests covering deferred registration and description updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->