### PR TITLE
Use compression for registrations of settings

### DIFF
--- a/src/client/Fig.Client/ConfigurationProvider/ApiCommunicationHandler.cs
+++ b/src/client/Fig.Client/ConfigurationProvider/ApiCommunicationHandler.cs
@@ -1,8 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
 using Fig.Client.Capabilities;
@@ -89,7 +92,7 @@ public class ApiCommunicationHandler : IApiCommunicationHandler
             settings.CustomActions.Count,
             useDeferredDescription ? " (description deferred)" : string.Empty);
 
-        var data = new StringContent(json, Encoding.UTF8, "application/json");
+        var data = BuildContent(json);
         var secret = await _clientSecretProvider.GetSecret(_clientName);
         AddHeaderToHttpClient("ClientSecret", () => secret);
 
@@ -147,12 +150,13 @@ public class ApiCommunicationHandler : IApiCommunicationHandler
     {
         var descJson = JsonConvert.SerializeObject(
             new ClientDescriptionUpdateDataContract(description), JsonSettings.FigDefault);
-        var descData = new StringContent(descJson, Encoding.UTF8, "application/json");
+        var descData = BuildContent(descJson);
         var uri = instance != null
             ? $"/clients/{Uri.EscapeDataString(clientName)}/description?instance={Uri.EscapeDataString(instance)}"
             : $"/clients/{Uri.EscapeDataString(clientName)}/description";
 
-        using var msg = new HttpRequestMessage(HttpMethod.Put, uri) { Content = descData };
+        using var msg = new HttpRequestMessage(HttpMethod.Put, uri);
+        msg.Content = descData;
         msg.Headers.TryAddWithoutValidation("ClientSecret", secret);
         using var response = await _httpClient.SendAsync(msg).ConfigureAwait(false);
         if (response.IsSuccessStatusCode)
@@ -196,7 +200,7 @@ public class ApiCommunicationHandler : IApiCommunicationHandler
             payloadBytes,
             payloadBytes / 1024.0);
 
-        var data = new StringContent(json, Encoding.UTF8, "application/json");
+        var data = BuildContent(json);
 
         var sw = Stopwatch.StartNew();
         HttpResponseMessage response;
@@ -239,7 +243,7 @@ public class ApiCommunicationHandler : IApiCommunicationHandler
             payloadBytes,
             payloadBytes / 1024.0);
 
-        var data = new StringContent(json, Encoding.UTF8, "application/json");
+        var data = BuildContent(json);
 
         var sw = Stopwatch.StartNew();
         HttpResponseMessage response;
@@ -293,7 +297,7 @@ public class ApiCommunicationHandler : IApiCommunicationHandler
         _logger.LogInformation("Sending custom action results for ExecutionId: {ExecutionId}", results.ExecutionId);
         results.RunSessionId = RunSession.GetId(_clientName);
         var json = JsonConvert.SerializeObject(results, JsonSettings.FigDefault);
-        var data = new StringContent(json, Encoding.UTF8, "application/json");
+        var data = BuildContent(json);
         var secret = await _clientSecretProvider.GetSecret(_clientName);
         AddHeaderToHttpClient("clientSecret", () => secret);
         
@@ -318,6 +322,28 @@ public class ApiCommunicationHandler : IApiCommunicationHandler
             _logger.LogError(ex, "Error sending custom action results for ExecutionId: {ExecutionId}", results.ExecutionId);
         }
     }
+    
+    private HttpContent BuildContent(string json)
+    {
+        const int CompressionThresholdBytes = 4096;
+        if (!_capabilityProvider.Supports("requestCompression"))
+            return new StringContent(json, Encoding.UTF8, "application/json");
+
+        var bytes = Encoding.UTF8.GetBytes(json);
+        if (bytes.Length < CompressionThresholdBytes)
+            return new StringContent(json, Encoding.UTF8, "application/json");
+
+        var ms = new MemoryStream();
+        using (var gz = new GZipStream(ms, CompressionLevel.Fastest, leaveOpen: true))
+            gz.Write(bytes, 0, bytes.Length);
+
+        ms.Seek(0, SeekOrigin.Begin);
+        var content = new StreamContent(ms);
+        content.Headers.ContentType = new MediaTypeHeaderValue("application/json") { CharSet = "utf-8" };
+        content.Headers.ContentEncoding.Add("gzip");
+        return content;
+    }
+
 
     private void AddHeaderToHttpClient(string key, Func<string> getValue)
     {

--- a/src/tests/Fig.Unit.Test/Client/ApiCommunicationHandlerTests.cs
+++ b/src/tests/Fig.Unit.Test/Client/ApiCommunicationHandlerTests.cs
@@ -1,5 +1,8 @@
+using System.IO;
+using System.IO.Compression;
 using System.Net;
 using System.Net.Http;
+using System.Text;
 using Fig.Client.Capabilities;
 using Fig.Client.ConfigurationProvider;
 using Fig.Client.Contracts;
@@ -202,6 +205,78 @@ public class ApiCommunicationHandlerTests
         Assert.That(putRequests[0], Does.Contain("/clients/TestClient/description"));
     }
 
+    [Test]
+    public async Task RegisterWithFigApi_WhenCompressionSupportedAndPayloadExceedsThreshold_SendsGzipCompressedContent()
+    {
+        // Arrange — enable compression capability and create a large payload (> 4096 bytes)
+        _capabilityProviderMock.Setup(x => x.Supports("requestCompression")).Returns(true);
+
+        HttpRequestMessage? capturedRequest = null;
+        _httpMessageHandlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync((HttpRequestMessage req, CancellationToken _) =>
+            {
+                capturedRequest = req;
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            });
+
+        var handler = CreateHandler();
+        // 30 settings each with a 200-char description ensures the serialized payload exceeds the 4096-byte threshold
+        var settings = CreateSettings(settingCount: 30, description: new string('x', 200));
+
+        // Act
+        await handler.RegisterWithFigApi(settings);
+
+        // Assert — Content-Encoding: gzip must be present
+        Assert.That(capturedRequest, Is.Not.Null);
+        Assert.That(capturedRequest!.Content!.Headers.ContentEncoding, Does.Contain("gzip"));
+
+        // Assert — decompressing the body yields valid JSON containing the original content
+        var compressedBytes = await capturedRequest.Content.ReadAsByteArrayAsync();
+        await using var ms = new MemoryStream(compressedBytes);
+        await using var gz = new GZipStream(ms, CompressionMode.Decompress);
+        using var reader = new StreamReader(gz, Encoding.UTF8);
+        var decompressedJson = await reader.ReadToEndAsync();
+        Assert.That(decompressedJson, Does.Contain("TestClient"));
+        Assert.That(decompressedJson, Does.Contain("Setting0"));
+    }
+
+    [Test]
+    public async Task RegisterWithFigApi_WhenCompressionSupportedButPayloadBelowThreshold_SendsUncompressedContent()
+    {
+        // Arrange — enable compression capability but keep the payload small (< 4096 bytes)
+        _capabilityProviderMock.Setup(x => x.Supports("requestCompression")).Returns(true);
+
+        HttpRequestMessage? capturedRequest = null;
+        _httpMessageHandlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync((HttpRequestMessage req, CancellationToken _) =>
+            {
+                capturedRequest = req;
+                return new HttpResponseMessage(HttpStatusCode.OK);
+            });
+
+        var handler = CreateHandler();
+        var settings = CreateSettings(settingCount: 2); // Small payload, well under 4096 bytes
+
+        // Act
+        await handler.RegisterWithFigApi(settings);
+
+        // Assert — no Content-Encoding header (plain JSON, no compression)
+        Assert.That(capturedRequest, Is.Not.Null);
+        Assert.That(capturedRequest!.Content!.Headers.ContentEncoding, Is.Empty);
+
+        // Assert — body is readable as plain JSON
+        var json = await capturedRequest.Content.ReadAsStringAsync();
+        Assert.That(json, Does.Contain("TestClient"));
+    }
+
     private ApiCommunicationHandler CreateHandler(string clientName = "TestClient")
     {
         return new ApiCommunicationHandler(
@@ -213,12 +288,12 @@ public class ApiCommunicationHandlerTests
             _capabilityProviderMock.Object);
     }
 
-    private static SettingsClientDefinitionDataContract CreateSettings(int settingCount = 2)
+    private static SettingsClientDefinitionDataContract CreateSettings(int settingCount = 2, string description = "A test setting")
     {
         var settings = new List<SettingDefinitionDataContract>();
         for (var i = 0; i < settingCount; i++)
         {
-            settings.Add(new SettingDefinitionDataContract($"Setting{i}", "A test setting"));
+            settings.Add(new SettingDefinitionDataContract($"Setting{i}", description));
         }
 
         return new SettingsClientDefinitionDataContract(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Request payloads are now automatically gzip-compressed when supported and large enough, reducing bandwidth and improving transmission efficiency.
* **Tests**
  * Added integration-style tests to validate compressed and uncompressed request behavior and ensure payload integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->