### PR TITLE
Slight memory improvement in registered providers class

### DIFF
--- a/src/api/Fig.Api/Services/ImportExportService.cs
+++ b/src/api/Fig.Api/Services/ImportExportService.cs
@@ -1,4 +1,5 @@
 // using Fig.Api.ExtensionMethods;
+using System.Security.Cryptography;
 using System.Text;
 using Fig.Api.Converters;
 using Fig.Api.DataImport;
@@ -160,7 +161,7 @@ public class ImportExportService : AuthenticatedService, IImportExportService
             {
                 ImportType = data.ImportType,
                 ErrorMessage = e.Message,
-                RequiresDecryptionKey = string.IsNullOrWhiteSpace(data.DecryptionKey)
+                RequiresDecryptionKey = true
             };
         }
 
@@ -206,6 +207,18 @@ public class ImportExportService : AuthenticatedService, IImportExportService
                 ImportType = data.ImportType,
                 ErrorMessage = e.Message,
                 RequiresDecryptionKey = string.IsNullOrWhiteSpace(data.DecryptionKey)
+            };
+        }
+        catch (CryptographicException e)
+        {
+            const string message = "Unable to decrypt existing client data. The server encryption key may have changed since this client was registered.";
+            _logger.LogError(e, "Value only import failed during client retrieval due to decryption error");
+            await _eventLogRepository.Add(_eventLogFactory.DataImportFailed(data.ImportType, importMode, AuthenticatedUser, message));
+            return new ImportResultDataContract
+            {
+                ImportType = data.ImportType,
+                ErrorMessage = message,
+                RequiresDecryptionKey = true
             };
         }
         

--- a/src/api/Fig.Api/Workers/CheckpointTriggerWorker.cs
+++ b/src/api/Fig.Api/Workers/CheckpointTriggerWorker.cs
@@ -1,8 +1,10 @@
+using System.Threading.Channels;
 using Fig.Api.Constants;
 using Fig.Api.Datalayer.Repositories;
 using Fig.Api.Utils;
 using Fig.Common.Events;
 using Fig.Datalayer.BusinessEntities;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Fig.Api.Workers;
 
@@ -10,6 +12,11 @@ public class CheckpointTriggerWorker : BackgroundService
 {
     private readonly IServiceScopeFactory _serviceScopeFactory;
     private readonly ILogger<CheckpointTriggerWorker> _logger;
+    private readonly Channel<CheckPointTrigger> _channel = Channel.CreateUnbounded<CheckPointTrigger>(new UnboundedChannelOptions
+    {
+        SingleReader = true,
+        SingleWriter = false
+    });
 
     public CheckpointTriggerWorker(IEventDistributor eventDistributor, IServiceScopeFactory serviceScopeFactory, ILogger<CheckpointTriggerWorker> logger)
     {
@@ -19,28 +26,16 @@ public class CheckpointTriggerWorker : BackgroundService
         eventDistributor.Subscribe<CheckPointTrigger>(EventConstants.CheckPointTrigger, AddCheckPointTrigger);
     }
 
-    protected override Task ExecuteAsync(CancellationToken stoppingToken)
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        return Task.CompletedTask;
-    }
-
-    private Task AddCheckPointTrigger(CheckPointTrigger trigger)
-    {
-        _logger.LogInformation("Queueing a checkpoint creation with message {Message}", trigger.Message);
-        
-        // Run in background to avoid blocking the caller and to ensure we don't interfere
-        // with any existing database transaction (especially important for SQLite in tests)
-        _ = Task.Run(async () =>
+        await foreach (var trigger in _channel.Reader.ReadAllAsync(stoppingToken))
         {
             try
             {
-                // Small delay to ensure any parent transaction has completed
-                await Task.Delay(50);
-                
+                await Task.Delay(50, stoppingToken);
+
                 using var scope = _serviceScopeFactory.CreateScope();
-                var repository = scope.ServiceProvider.GetService<ICheckPointTriggerRepository>();
-                if (repository is null)
-                    throw new InvalidOperationException("Unable to find checkpoint trigger repository");
+                var repository = scope.ServiceProvider.GetRequiredService<ICheckPointTriggerRepository>();
 
                 var triggerBusinessEntity = new CheckPointTriggerBusinessEntity
                 {
@@ -51,12 +46,34 @@ public class CheckpointTriggerWorker : BackgroundService
 
                 await repository.AddTrigger(triggerBusinessEntity);
             }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Error while creating checkpoint trigger");
             }
-        });
-        
+        }
+    }
+
+    private Task AddCheckPointTrigger(CheckPointTrigger trigger)
+    {
+        if (_channel.Writer.TryWrite(trigger))
+        {
+            _logger.LogInformation("Queued a checkpoint creation with message {Message}", trigger.Message);
+        }
+        else
+        {
+            _logger.LogWarning("Dropped checkpoint creation with message {Message} because the worker is stopping", trigger.Message);
+        }
+
         return Task.CompletedTask;
+    }
+
+    public override Task StopAsync(CancellationToken cancellationToken)
+    {
+        _channel.Writer.TryComplete();
+        return base.StopAsync(cancellationToken);
     }
 }

--- a/src/client/Fig.Client/ConfigurationProvider/ApiCommunicationHandler.cs
+++ b/src/client/Fig.Client/ConfigurationProvider/ApiCommunicationHandler.cs
@@ -40,7 +40,7 @@ public class ApiCommunicationHandler : IApiCommunicationHandler, IFigClientBridg
         IFigCapabilityProvider capabilityProvider)
     {
         _clientName = clientName;
-        _instance = instance;
+        _instance = InstanceNormalization.Normalize(instance);
         _httpClient = httpClient;
         _logger = logger;
         _clientSecretProvider = clientSecretProvider;
@@ -173,11 +173,12 @@ public class ApiCommunicationHandler : IApiCommunicationHandler, IFigClientBridg
 
     private async Task PostDescriptionAsync(string clientName, string? instance, string description, string secret)
     {
+        var normalizedInstance = InstanceNormalization.Normalize(instance);
         var descJson = JsonConvert.SerializeObject(
             new ClientDescriptionUpdateDataContract(description), JsonSettings.FigDefault);
         var descData = BuildContent(descJson);
-        var uri = instance != null
-            ? $"/clients/{Uri.EscapeDataString(clientName)}/description?instance={Uri.EscapeDataString(instance)}"
+        var uri = normalizedInstance != null
+            ? $"/clients/{Uri.EscapeDataString(clientName)}/description?instance={Uri.EscapeDataString(normalizedInstance)}"
             : $"/clients/{Uri.EscapeDataString(clientName)}/description";
 
         using var msg = new HttpRequestMessage(HttpMethod.Put, uri);
@@ -196,7 +197,7 @@ public class ApiCommunicationHandler : IApiCommunicationHandler, IFigClientBridg
         var secret = await _clientSecretProvider.GetSecret(_clientName);
 
         var uri = $"/clients/{Uri.EscapeDataString(_clientName)}/settings";
-        uri += $"?runSessionId={RunSession.GetId(_clientName)}";
+        uri += $"?runSessionId={RunSession.GetId(_clientName, _instance)}";
         if (!string.IsNullOrEmpty(_instance))
             uri += $"&instance={Uri.EscapeDataString(_instance!)}";
 
@@ -311,7 +312,7 @@ public class ApiCommunicationHandler : IApiCommunicationHandler, IFigClientBridg
     private async Task<IEnumerable<CustomActionPollResponseDataContract>?> PollForCustomActionRequests()
     {
         var pollUri = $"/customactions/poll/{Uri.EscapeDataString(_clientName)}";
-        pollUri += $"?runSessionId={RunSession.GetId(_clientName)}";
+        pollUri += $"?runSessionId={RunSession.GetId(_clientName, _instance)}";
 
         var secret = await _clientSecretProvider.GetSecret(_clientName);
         using var request = new HttpRequestMessage(HttpMethod.Get, pollUri);
@@ -332,7 +333,7 @@ public class ApiCommunicationHandler : IApiCommunicationHandler, IFigClientBridg
     private async Task SendCustomActionResults(CustomActionExecutionResultsDataContract results)
     {
         _logger.LogInformation("Sending custom action results for ExecutionId: {ExecutionId}", results.ExecutionId);
-        results.RunSessionId = RunSession.GetId(_clientName);
+        results.RunSessionId = RunSession.GetId(_clientName, _instance);
         var json = JsonConvert.SerializeObject(results, JsonSettings.FigDefault);
         var secret = await _clientSecretProvider.GetSecret(_clientName);
         

--- a/src/client/Fig.Client/ConfigurationProvider/FigConfigurationProvider.cs
+++ b/src/client/Fig.Client/ConfigurationProvider/FigConfigurationProvider.cs
@@ -52,7 +52,7 @@ public class FigConfigurationProvider : Microsoft.Extensions.Configuration.Confi
         _apiCommunicationHandler = apiCommunicationHandler;
         _clientBridge = apiCommunicationHandler as IFigClientBridge;
         _statusMonitor = statusMonitor;
-        RunSession.Acquire(_source.ClientName);
+        RunSession.Acquire(_source.ClientName, _source.Instance);
         if (_clientBridge is not null)
             FigClientBridgeRegistry.Register(_source.SettingsType, _clientBridge, bridgeOptions);
 
@@ -78,6 +78,10 @@ public class FigConfigurationProvider : Microsoft.Extensions.Configuration.Confi
 
     public string Name => _source.ClientName;
 
+    internal ProviderRegistrationKey RegistrationKey => new(_source.ClientName, _source.Instance, _source.SettingsType);
+
+    internal bool IsDisposed => _disposed;
+
     public void Dispose()
     {
         Dispose(true);
@@ -99,7 +103,7 @@ public class FigConfigurationProvider : Microsoft.Extensions.Configuration.Confi
             _statusMonitor.OfflineSettingsDisabled -= OnOfflineSettingsDisabled;
             _statusMonitor.RestartRequested -= OnRestartRequested;
             _statusMonitor.Dispose();
-            RunSession.Release(_source.ClientName);
+            RunSession.Release(_source.ClientName, _source.Instance);
             if (_clientBridge is not null)
                 FigClientBridgeRegistry.Unregister(_source.SettingsType, _clientBridge);
         }

--- a/src/client/Fig.Client/ConfigurationProvider/FigConfigurationSource.cs
+++ b/src/client/Fig.Client/ConfigurationProvider/FigConfigurationSource.cs
@@ -31,7 +31,13 @@ public class FigConfigurationSource : IFigConfigurationSource
 
     public bool LiveReload { get; set; } = true;
 
-    public string? Instance { get; set; }
+    private string? _instance;
+
+    public string? Instance
+    {
+        get => _instance;
+        set => _instance = InstanceNormalization.Normalize(value);
+    }
 
     public string ClientName { get; set; } = null!;
 
@@ -63,7 +69,7 @@ public class FigConfigurationSource : IFigConfigurationSource
 
     public IConfigurationProvider Build(IConfigurationBuilder builder)
     {
-        if (RegisteredProviders.TryGet(ClientName, out var provider))
+        if (RegisteredProviders.TryGet(ClientName, Instance, SettingsType, out var provider))
         {
             return provider!;
         }

--- a/src/client/Fig.Client/ConfigurationProvider/InstanceNormalization.cs
+++ b/src/client/Fig.Client/ConfigurationProvider/InstanceNormalization.cs
@@ -1,0 +1,11 @@
+namespace Fig.Client.ConfigurationProvider;
+
+internal static class InstanceNormalization
+{
+    public static string? Normalize(string? instance)
+    {
+        return string.IsNullOrWhiteSpace(instance)
+            ? null
+            : instance;
+    }
+}

--- a/src/client/Fig.Client/ConfigurationProvider/ProviderRegistrationKey.cs
+++ b/src/client/Fig.Client/ConfigurationProvider/ProviderRegistrationKey.cs
@@ -1,0 +1,42 @@
+using System;
+
+namespace Fig.Client.ConfigurationProvider;
+
+internal readonly struct ProviderRegistrationKey : IEquatable<ProviderRegistrationKey>
+{
+    public ProviderRegistrationKey(string clientName, string? instance, Type settingsType)
+    {
+        ClientName = clientName ?? throw new ArgumentNullException(nameof(clientName));
+        Instance = InstanceNormalization.Normalize(instance);
+        SettingsType = settingsType ?? throw new ArgumentNullException(nameof(settingsType));
+    }
+
+    public string ClientName { get; }
+
+    public string? Instance { get; }
+
+    public Type SettingsType { get; }
+
+    public bool Equals(ProviderRegistrationKey other)
+    {
+        return string.Equals(ClientName, other.ClientName, StringComparison.Ordinal) &&
+               string.Equals(Instance, other.Instance, StringComparison.Ordinal) &&
+               SettingsType == other.SettingsType;
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return obj is ProviderRegistrationKey other && Equals(other);
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hashCode = StringComparer.Ordinal.GetHashCode(ClientName);
+            hashCode = (hashCode * 397) ^ (Instance is null ? 0 : StringComparer.Ordinal.GetHashCode(Instance));
+            hashCode = (hashCode * 397) ^ SettingsType.GetHashCode();
+            return hashCode;
+        }
+    }
+}

--- a/src/client/Fig.Client/ConfigurationProvider/RegisteredProviders.cs
+++ b/src/client/Fig.Client/ConfigurationProvider/RegisteredProviders.cs
@@ -1,44 +1,128 @@
 using System.Collections.Generic;
 using System.Linq;
+using System;
 
 namespace Fig.Client.ConfigurationProvider;
 
 public static class RegisteredProviders
 {
-    private static List<FigConfigurationProvider> _providers = new();
-    private static object _lockObject = new();
+    private static readonly Dictionary<ProviderRegistrationKey, WeakReference<FigConfigurationProvider>> Providers = new();
+    private static readonly object LockObject = new();
 
     public static void Register(FigConfigurationProvider provider)
     {
-        lock (_lockObject)
+        if (provider is null)
+            throw new ArgumentNullException(nameof(provider));
+
+        lock (LockObject)
         {
-            _providers.Add(provider);
+            PruneDeadEntries();
+            Providers[provider.RegistrationKey] = new WeakReference<FigConfigurationProvider>(provider);
         }
     }
 
     public static void Unregister(FigConfigurationProvider provider)
     {
-        lock (_lockObject)
+        if (provider is null)
+            throw new ArgumentNullException(nameof(provider));
+
+        lock (LockObject)
         {
-            _providers.Remove(provider);
+            if (!Providers.TryGetValue(provider.RegistrationKey, out var registration))
+                return;
+
+            if (!registration.TryGetTarget(out var registeredProvider) ||
+                registeredProvider.IsDisposed ||
+                ReferenceEquals(registeredProvider, provider))
+            {
+                Providers.Remove(provider.RegistrationKey);
+            }
         }
     }
 
     public static bool TryGet(string name, out FigConfigurationProvider? provider)
     {
-        lock (_lockObject)
+        if (name is null)
         {
-            provider = _providers.FirstOrDefault(a => a.Name == name);
+            provider = null;
+            return false;
+        }
+
+        lock (LockObject)
+        {
+            PruneDeadEntries();
+            var matchingProviders = Providers
+                .Where(a => string.Equals(a.Key.ClientName, name, StringComparison.Ordinal))
+                .Select(a => a.Value.TryGetTarget(out var target) ? target : null)
+                .Where(a => a is not null && !a.IsDisposed)
+                .ToList();
+
+            if (matchingProviders.Count > 1)
+            {
+                provider = null;
+                return false;
+            }
+
+            provider = matchingProviders.FirstOrDefault();
         }
 
         return provider is not null;
     }
 
+    internal static bool TryGet(
+        string clientName,
+        string? instance,
+        Type settingsType,
+        out FigConfigurationProvider? provider)
+    {
+        var key = new ProviderRegistrationKey(clientName, instance, settingsType);
+
+        lock (LockObject)
+        {
+            PruneDeadEntries();
+            if (Providers.TryGetValue(key, out var registration) &&
+                registration.TryGetTarget(out var registeredProvider) &&
+                !registeredProvider.IsDisposed)
+            {
+                provider = registeredProvider;
+                return true;
+            }
+
+            Providers.Remove(key);
+        }
+
+        provider = null;
+        return false;
+    }
+
     public static void Clear()
     {
-        lock (_lockObject)
+        lock (LockObject)
         {
-            _providers.Clear();
+            Providers.Clear();
+        }
+    }
+
+    internal static int Count
+    {
+        get
+        {
+            lock (LockObject)
+            {
+                PruneDeadEntries();
+                return Providers.Count;
+            }
+        }
+    }
+
+    private static void PruneDeadEntries()
+    {
+        foreach (var key in Providers
+                     .Where(a => !a.Value.TryGetTarget(out var provider) || provider.IsDisposed)
+                     .Select(a => a.Key)
+                     .ToList())
+        {
+            Providers.Remove(key);
         }
     }
 }

--- a/src/client/Fig.Client/ConfigurationProvider/RunSession.cs
+++ b/src/client/Fig.Client/ConfigurationProvider/RunSession.cs
@@ -5,41 +5,45 @@ namespace Fig.Client.ConfigurationProvider;
 
 public static class RunSession
 {
-    private static readonly Dictionary<string, RunSessionEntry> Sessions = new();
+    private static readonly Dictionary<(string ClientName, string? Instance), RunSessionEntry> Sessions = new();
     private static readonly object LockObject = new();
 
-    public static Guid GetId(string clientName)
+    public static Guid GetId(string clientName, string? instance = null)
     {
+        var normalizedInstance = InstanceNormalization.Normalize(instance);
         lock (LockObject)
         {
-            return Sessions.TryGetValue(clientName, out var entry)
+            return Sessions.TryGetValue((clientName, normalizedInstance), out var entry)
                 ? entry.Id
                 : Guid.Empty;
         }
     }
 
-    internal static Guid Acquire(string clientName)
+    internal static Guid Acquire(string clientName, string? instance = null)
     {
+        var normalizedInstance = InstanceNormalization.Normalize(instance);
         lock (LockObject)
         {
-            var entry = GetOrCreateEntry(clientName);
+            var entry = GetOrCreateEntry(clientName, normalizedInstance);
             entry.ReferenceCount++;
             return entry.Id;
         }
     }
 
-    internal static void Release(string clientName)
+    internal static void Release(string clientName, string? instance = null)
     {
+        var normalizedInstance = InstanceNormalization.Normalize(instance);
         lock (LockObject)
         {
-            if (!Sessions.TryGetValue(clientName, out var entry))
+            var key = (clientName, normalizedInstance);
+            if (!Sessions.TryGetValue(key, out var entry))
                 return;
 
             if (entry.ReferenceCount > 0)
                 entry.ReferenceCount--;
 
             if (entry.ReferenceCount == 0)
-                Sessions.Remove(clientName);
+                Sessions.Remove(key);
         }
     }
 
@@ -62,13 +66,14 @@ public static class RunSession
         }
     }
 
-    private static RunSessionEntry GetOrCreateEntry(string clientName)
+    private static RunSessionEntry GetOrCreateEntry(string clientName, string? instance)
     {
-        if (Sessions.TryGetValue(clientName, out var entry))
+        var key = (clientName, InstanceNormalization.Normalize(instance));
+        if (Sessions.TryGetValue(key, out var entry))
             return entry;
 
         entry = new RunSessionEntry(Guid.NewGuid());
-        Sessions[clientName] = entry;
+        Sessions[key] = entry;
         return entry;
     }
 

--- a/src/client/Fig.Client/Status/SettingStatusMonitor.cs
+++ b/src/client/Fig.Client/Status/SettingStatusMonitor.cs
@@ -193,7 +193,7 @@ internal class SettingStatusMonitor : ISettingStatusMonitor
         }
 
         var offlineSettingsEnabled = _config.AllowOfflineSettings && AllowOfflineSettings;
-        var request = new StatusRequestDataContract(RunSession.GetId(_config.ClientName),
+        var request = new StatusRequestDataContract(RunSession.GetId(_config.ClientName, _config.Instance),
             _startTime,
             _lastSettingUpdate,
             _statusTimer.Interval,

--- a/src/tests/Fig.Integration.Test/Api/ValueOnlyImportExportTests.cs
+++ b/src/tests/Fig.Integration.Test/Api/ValueOnlyImportExportTests.cs
@@ -1005,6 +1005,36 @@ public class ValueOnlyImportExportTests : IntegrationTestBase
     }
 
     [Test]
+    public async Task ShallReturnRequiresDecryptionKeyForValueOnlyImportWithWrongCustomDecryptionKey()
+    {
+        await RegisterSettings<SecretSettings>();
+
+        var export = await ExportValueOnlyData();
+
+        var originalServerSecret = Settings.Secret;
+        Settings.PreviousSecret = string.Empty;
+        Settings.Secret = Guid.NewGuid().ToString("N");
+        ConfigReloader.Reload(Settings);
+        await ApiClient.Authenticate();
+
+        try
+        {
+            export.DecryptionKey = Guid.NewGuid().ToString("N");
+            var result = await ImportValueOnlyData(export);
+
+            Assert.That(result.RequiresDecryptionKey, Is.True);
+            Assert.That(result.ErrorMessage, Is.Not.Null);
+        }
+        finally
+        {
+            try { await DeleteAllClients(); } catch { /* Data may be encrypted with original key */ }
+            Settings.Secret = originalServerSecret;
+            ConfigReloader.Reload(Settings);
+            await ApiClient.Authenticate();
+        }
+    }
+
+    [Test]
     public async Task ShallImportValueOnlyWithCustomDecryptionKey()
     {
         // Simulate "source" environment: register settings and export values

--- a/src/tests/Fig.Unit.Test/Api/CheckpointTriggerWorkerTests.cs
+++ b/src/tests/Fig.Unit.Test/Api/CheckpointTriggerWorkerTests.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Fig.Api.Constants;
+using Fig.Api.Datalayer.Repositories;
+using Fig.Api.Utils;
+using Fig.Api.Workers;
+using Fig.Common.Events;
+using Fig.Datalayer.BusinessEntities;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+
+namespace Fig.Unit.Test.Api;
+
+[TestFixture]
+public class CheckpointTriggerWorkerTests
+{
+    [Test]
+    public async Task PublishAsync_WhenTriggerQueued_PersistsTriggerThroughWorkerLoop()
+    {
+        var processed = new TaskCompletionSource<CheckPointTriggerBusinessEntity>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var repository = new Mock<ICheckPointTriggerRepository>();
+        repository.Setup(a => a.AddTrigger(It.IsAny<CheckPointTriggerBusinessEntity>()))
+            .Returns<CheckPointTriggerBusinessEntity>(entity =>
+            {
+                processed.TrySetResult(entity);
+                return Task.CompletedTask;
+            });
+
+        var services = new ServiceCollection();
+        services.AddScoped<ICheckPointTriggerRepository>(_ => repository.Object);
+        await using var serviceProvider = services.BuildServiceProvider();
+
+        var eventDistributor = new EventDistributor(Mock.Of<ILogger<EventDistributor>>());
+        var worker = new CheckpointTriggerWorker(
+            eventDistributor,
+            serviceProvider.GetRequiredService<IServiceScopeFactory>(),
+            NullLogger<CheckpointTriggerWorker>.Instance);
+
+        await worker.StartAsync(CancellationToken.None);
+
+        try
+        {
+            await eventDistributor.PublishAsync(EventConstants.CheckPointTrigger, new CheckPointTrigger("Settings updated", "alice"));
+
+            var storedTrigger = await processed.Task.WaitAsync(TimeSpan.FromSeconds(1));
+
+            Assert.That(storedTrigger.AfterEvent, Is.EqualTo("Settings updated"));
+            Assert.That(storedTrigger.User, Is.EqualTo("alice"));
+            Assert.That(storedTrigger.Timestamp, Is.Not.EqualTo(default(DateTime)));
+            repository.Verify(a => a.AddTrigger(It.IsAny<CheckPointTriggerBusinessEntity>()), Times.Once);
+        }
+        finally
+        {
+            await worker.StopAsync(CancellationToken.None);
+            worker.Dispose();
+        }
+    }
+
+    [Test]
+    public async Task StopAsync_WhenQueuedTriggerIsStillDelayed_DoesNotCreateScope()
+    {
+        var eventDistributor = new EventDistributor(Mock.Of<ILogger<EventDistributor>>());
+        var serviceScopeFactory = new Mock<IServiceScopeFactory>(MockBehavior.Strict);
+        var worker = new CheckpointTriggerWorker(
+            eventDistributor,
+            serviceScopeFactory.Object,
+            NullLogger<CheckpointTriggerWorker>.Instance);
+
+        await worker.StartAsync(CancellationToken.None);
+
+        try
+        {
+            await eventDistributor.PublishAsync(EventConstants.CheckPointTrigger, new CheckPointTrigger("Settings updated", "alice"));
+            await worker.StopAsync(CancellationToken.None);
+            await Task.Delay(100);
+
+            serviceScopeFactory.Verify(a => a.CreateScope(), Times.Never);
+        }
+        finally
+        {
+            worker.Dispose();
+        }
+    }
+
+    [Test]
+    public async Task PublishAsync_AfterStop_LogsDroppedTriggerAndDoesNotCreateScope()
+    {
+        var eventDistributor = new EventDistributor(Mock.Of<ILogger<EventDistributor>>());
+        var serviceScopeFactory = new Mock<IServiceScopeFactory>(MockBehavior.Strict);
+        var logger = new Mock<ILogger<CheckpointTriggerWorker>>();
+        var worker = new CheckpointTriggerWorker(
+            eventDistributor,
+            serviceScopeFactory.Object,
+            logger.Object);
+
+        await worker.StartAsync(CancellationToken.None);
+        await worker.StopAsync(CancellationToken.None);
+
+        try
+        {
+            await eventDistributor.PublishAsync(EventConstants.CheckPointTrigger, new CheckPointTrigger("Settings updated", "alice"));
+
+            serviceScopeFactory.Verify(a => a.CreateScope(), Times.Never);
+            logger.Verify(
+                x => x.Log(
+                    LogLevel.Warning,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("Dropped checkpoint creation")),
+                    It.IsAny<Exception?>(),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Once);
+        }
+        finally
+        {
+            worker.Dispose();
+        }
+    }
+}

--- a/src/tests/Fig.Unit.Test/Client/ApiCommunicationHandlerTests.cs
+++ b/src/tests/Fig.Unit.Test/Client/ApiCommunicationHandlerTests.cs
@@ -309,6 +309,35 @@ public class ApiCommunicationHandlerTests
         Assert.That(responseContent.IsDisposed, Is.True);
     }
 
+    [Test]
+    public async Task RequestConfiguration_WithEmptyInstance_UsesDefaultRunSessionAndOmitsInstanceQueryParameter()
+    {
+        var defaultRunSessionId = RunSession.Acquire("TestClient", null);
+        HttpRequestMessage? capturedRequest = null;
+
+        _httpMessageHandlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync((HttpRequestMessage req, CancellationToken _) =>
+            {
+                capturedRequest = req;
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("[]", Encoding.UTF8, "application/json")
+                };
+            });
+
+        var handler = CreateHandler(instance: string.Empty);
+
+        await handler.RequestConfiguration();
+
+        Assert.That(capturedRequest, Is.Not.Null);
+        Assert.That(capturedRequest!.RequestUri!.ToString(), Does.EndWith($"/clients/TestClient/settings?runSessionId={defaultRunSessionId}"));
+        Assert.That(capturedRequest.RequestUri.ToString(), Does.Not.Contain("instance="));
+    }
+
 #if DEBUG
     [Test]
     public async Task RegisterWithFigApi_WhenMigrateFromSourceStillExists_LogsWarning()
@@ -349,11 +378,11 @@ public class ApiCommunicationHandlerTests
     }
 #endif
 
-    private ApiCommunicationHandler CreateHandler(string clientName = "TestClient")
+    private ApiCommunicationHandler CreateHandler(string clientName = "TestClient", string? instance = null)
     {
         return new ApiCommunicationHandler(
             clientName,
-            null,
+            instance,
             _httpClient,
             _loggerMock.Object,
             _clientSecretProviderMock.Object,

--- a/src/tests/Fig.Unit.Test/Client/ConfigurationProviderTests.cs
+++ b/src/tests/Fig.Unit.Test/Client/ConfigurationProviderTests.cs
@@ -15,6 +15,7 @@ using Fig.Client.ClientSecret;
 using Fig.Contracts.SettingDefinitions;
 using Fig.Client.ConfigurationProvider;
 using Fig.Client.Contracts;
+using Fig.Unit.Test.TestInfrastructure;
 using Microsoft.Extensions.Logging;
 
 namespace Fig.Unit.Test.Client;
@@ -29,6 +30,7 @@ public class ConfigurationProviderTests
     public void SetUp()
     {
         RunSession.Clear();
+        RegisteredProviders.Clear();
     }
 
     [TearDown]
@@ -36,6 +38,7 @@ public class ConfigurationProviderTests
     {
         RunSession.Clear();
         FigClientBridgeRegistry.Clear();
+        RegisteredProviders.Clear();
     }
 
     [Test]
@@ -92,6 +95,120 @@ public class ConfigurationProviderTests
         ((IDisposable)configuration).Dispose();
 
         Assert.That(RunSession.Count, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void Build_WithSameRegistrationKey_ReusesExistingProvider()
+    {
+        var source = CreateSource();
+
+        var firstProvider = source.Build(new ConfigurationBuilder());
+        var secondProvider = source.Build(new ConfigurationBuilder());
+
+        Assert.That(secondProvider, Is.SameAs(firstProvider));
+        Assert.That(RegisteredProviders.Count, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void Build_WithDifferentInstance_DoesNotReuseExistingProvider()
+    {
+        var firstSource = CreateSource();
+        var secondSource = CreateSource();
+        secondSource.Instance = "secondary";
+
+        var firstProvider = firstSource.Build(new ConfigurationBuilder());
+        var secondProvider = secondSource.Build(new ConfigurationBuilder());
+
+        Assert.That(secondProvider, Is.Not.SameAs(firstProvider));
+        Assert.That(RegisteredProviders.Count, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void Build_WithEmptyInstance_ReusesNullInstanceProvider()
+    {
+        var firstSource = CreateSource();
+        var secondSource = CreateSource();
+        secondSource.Instance = string.Empty;
+
+        var firstProvider = firstSource.Build(new ConfigurationBuilder());
+        var secondProvider = secondSource.Build(new ConfigurationBuilder());
+
+        Assert.That(secondProvider, Is.SameAs(firstProvider));
+        Assert.That(RegisteredProviders.Count, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void Build_WithDifferentSettingsType_DoesNotReuseExistingProvider()
+    {
+        var firstSource = CreateSource();
+        var secondSource = CreateSource();
+        secondSource.SettingsType = typeof(SimpleSettings);
+
+        var firstProvider = firstSource.Build(new ConfigurationBuilder());
+        var secondProvider = secondSource.Build(new ConfigurationBuilder());
+
+        Assert.That(secondProvider, Is.Not.SameAs(firstProvider));
+        Assert.That(RegisteredProviders.Count, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void Dispose_UnregistersProvider()
+    {
+        var source = CreateSource();
+
+        var provider = source.Build(new ConfigurationBuilder());
+        var foundBeforeDispose = RegisteredProviders.TryGet(
+            source.ClientName,
+            source.Instance,
+            source.SettingsType,
+            out var registeredProvider);
+
+        ((IDisposable)provider).Dispose();
+        var foundAfterDispose = RegisteredProviders.TryGet(
+            source.ClientName,
+            source.Instance,
+            source.SettingsType,
+            out _);
+
+        Assert.That(foundBeforeDispose, Is.True);
+        Assert.That(registeredProvider, Is.SameAs(provider));
+        Assert.That(foundAfterDispose, Is.False);
+        Assert.That(RegisteredProviders.Count, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void TryGet_WhenProviderIsDisposedAndStillReachable_PrunesProvider()
+    {
+        var source = CreateSource();
+        var provider = source.Build(new ConfigurationBuilder());
+
+        ((IDisposable)provider).Dispose();
+        RegisteredProviders.Register((FigConfigurationProvider)provider);
+
+        var found = RegisteredProviders.TryGet(
+            source.ClientName,
+            source.Instance,
+            source.SettingsType,
+            out _);
+
+        Assert.That(found, Is.False);
+        Assert.That(RegisteredProviders.Count, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void TryGet_ByName_WithMultipleProvidersForSameClientName_ReturnsFalse()
+    {
+        var firstSource = CreateSource();
+        var secondSource = CreateSource();
+        secondSource.Instance = "secondary";
+
+        firstSource.Build(new ConfigurationBuilder());
+        secondSource.Build(new ConfigurationBuilder());
+
+        var found = RegisteredProviders.TryGet(firstSource.ClientName, out var provider);
+
+        Assert.That(found, Is.False);
+        Assert.That(provider, Is.Null);
     }
 
     [Test]

--- a/src/tests/Fig.Unit.Test/Client/RunSessionTests.cs
+++ b/src/tests/Fig.Unit.Test/Client/RunSessionTests.cs
@@ -81,5 +81,48 @@ public class RunSessionTests
         Assert.That(ids.Distinct().Count(), Is.EqualTo(1));
         Assert.That(ids[0], Is.Not.EqualTo(Guid.Empty));
     }
-}
 
+    [Test]
+    public void Acquire_WithSameClientNameDifferentInstances_ReturnsDifferentIds()
+    {
+        var first = RunSession.Acquire("client-a", null);
+        var second = RunSession.Acquire("client-a", "secondary");
+
+        Assert.That(second, Is.Not.EqualTo(first));
+        Assert.That(RunSession.Count, Is.EqualTo(2));
+    }
+
+    [Test]
+    public void GetId_WithInstance_ReturnsInstanceSpecificId()
+    {
+        var primaryId = RunSession.Acquire("client-a", null);
+        var secondaryId = RunSession.Acquire("client-a", "secondary");
+
+        Assert.That(RunSession.GetId("client-a", null), Is.EqualTo(primaryId));
+        Assert.That(RunSession.GetId("client-a", "secondary"), Is.EqualTo(secondaryId));
+        Assert.That(RunSession.GetId("client-a", null), Is.Not.EqualTo(secondaryId));
+    }
+
+    [Test]
+    public void Acquire_WithEmptyInstance_UsesDefaultInstanceSession()
+    {
+        var primaryId = RunSession.Acquire("client-a", null);
+        var emptyInstanceId = RunSession.Acquire("client-a", string.Empty);
+
+        Assert.That(emptyInstanceId, Is.EqualTo(primaryId));
+        Assert.That(RunSession.Count, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void Release_WithInstance_OnlyReleasesMatchingEntry()
+    {
+        RunSession.Acquire("client-a", null);
+        RunSession.Acquire("client-a", "secondary");
+
+        RunSession.Release("client-a", null);
+
+        Assert.That(RunSession.Count, Is.EqualTo(1));
+        Assert.That(RunSession.GetId("client-a", null), Is.EqualTo(Guid.Empty));
+        Assert.That(RunSession.GetId("client-a", "secondary"), Is.Not.EqualTo(Guid.Empty));
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Import now treats cryptographic/decryption failures as a distinct error, logs the failure, and signals that a decryption key is required.

* **Improvements**
  * Session and provider registration now distinguish and normalize instances to prevent cross-instance collisions.
  * Provider registry prunes disposed entries and avoids returning a provider when multiple matches exist.
  * Status payloads include instance-aware session identifiers.

* **New Features**
  * Background queueing and ordered processing for checkpoint triggers with graceful shutdown.

* **Tests**
  * Expanded unit and integration tests covering instance-aware sessions, provider registry behavior, import decryption failure, and checkpoint worker processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->