### PR TITLE
Improve migrate from feature to also include setting value history

### DIFF
--- a/doc/fig-documentation/docs/features/settings-management/21-value-history.md
+++ b/doc/fig-documentation/docs/features/settings-management/21-value-history.md
@@ -6,6 +6,8 @@ sidebar_position: 21
 
 Every value change that occurs in Fig is recorded in the database and is available from within the setting card.
 
+When a setting is renamed with `MigrateFrom`, Fig moves the old setting's value history to the new setting name and adds a history entry that records when the rename happened and which value was carried over. This keeps one continuous history for the renamed setting even after the temporary `MigrateFrom` attribute is removed.
+
 ## Appearance
 
 ![Value History](./img/valuehistory.png)

--- a/doc/fig-documentation/docs/features/settings-management/26-migrate-from.md
+++ b/doc/fig-documentation/docs/features/settings-management/26-migrate-from.md
@@ -14,7 +14,7 @@ When a client registers updated settings, Fig normally preserves values by match
 public string NewSettingName { get; set; } = "Default value";
 ```
 
-During the next updated registration, Fig copies the value from `OldSettingName` into `NewSettingName` if the old setting exists and has the same value type. If the old setting does not exist, Fig keeps the normal default value for the new setting.
+During the next updated registration, Fig copies the value from `OldSettingName` into `NewSettingName` if the old setting exists and has the same value type. It also moves the old setting's value history to `NewSettingName` and adds a history entry that records the rename and the migrated value. If the old setting does not exist, Fig keeps the normal default value for the new setting.
 
 ## Imports
 
@@ -60,4 +60,5 @@ public string NewSetting { get; set; } = "Default value";
 - For value-only imports, exact current-name matches also take precedence. If an import file contains both the old and new setting names, Fig applies the new setting name and warns that the old setting entry should be removed.
 - The source and target setting types must match. If they do not match, Fig keeps the new default value and logs an error.
 - If the source setting still exists in the updated registration, Fig still migrates the value. In DEBUG builds, Fig.Client logs a warning in the source application so developers can remove or correct the ambiguous migration.
+- When migration happens during registration, Fig rewrites the old setting's value history to the new setting name and adds a one-time history row describing the rename. This history stays with the new setting even after `MigrateFrom` is removed later.
 - `MigrateFrom` is intended to be temporary. After all environments have registered the renamed setting and migrated the value, remove the attribute.

--- a/doc/fig-documentation/versioned_docs/version-3.x/features/settings-management/21-value-history.md
+++ b/doc/fig-documentation/versioned_docs/version-3.x/features/settings-management/21-value-history.md
@@ -6,6 +6,8 @@ sidebar_position: 21
 
 Every value change that occurs in Fig is recorded in the database and is available from within the setting card.
 
+When a setting is renamed with `MigrateFrom`, Fig moves the old setting's value history to the new setting name and adds a history entry that records when the rename happened and which value was carried over. This keeps one continuous history for the renamed setting even after the temporary `MigrateFrom` attribute is removed.
+
 ## Appearance
 
 ![Value History](./img/valuehistory.png)

--- a/doc/fig-documentation/versioned_docs/version-3.x/features/settings-management/26-migrate-from.md
+++ b/doc/fig-documentation/versioned_docs/version-3.x/features/settings-management/26-migrate-from.md
@@ -14,7 +14,7 @@ When a client registers updated settings, Fig normally preserves values by match
 public string NewSettingName { get; set; } = "Default value";
 ```
 
-During the next updated registration, Fig copies the value from `OldSettingName` into `NewSettingName` if the old setting exists and has the same value type. If the old setting does not exist, Fig keeps the normal default value for the new setting.
+During the next updated registration, Fig copies the value from `OldSettingName` into `NewSettingName` if the old setting exists and has the same value type. It also moves the old setting's value history to `NewSettingName` and adds a history entry that records the rename and the migrated value. If the old setting does not exist, Fig keeps the normal default value for the new setting.
 
 ## Imports
 
@@ -60,4 +60,5 @@ public string NewSetting { get; set; } = "Default value";
 - For value-only imports, exact current-name matches also take precedence. If an import file contains both the old and new setting names, Fig applies the new setting name and warns that the old setting entry should be removed.
 - The source and target setting types must match. If they do not match, Fig keeps the new default value and logs an error.
 - If the source setting still exists in the updated registration, Fig still migrates the value. In DEBUG builds, Fig.Client logs a warning in the source application so developers can remove or correct the ambiguous migration.
+- When migration happens during registration, Fig rewrites the old setting's value history to the new setting name and adds a one-time history row describing the rename. This history stays with the new setting even after `MigrateFrom` is removed later.
 - `MigrateFrom` is intended to be temporary. After all environments have registered the renamed setting and migrated the value, remove the attribute.

--- a/src/api/Fig.Api/Datalayer/Repositories/ISettingHistoryRepository.cs
+++ b/src/api/Fig.Api/Datalayer/Repositories/ISettingHistoryRepository.cs
@@ -8,6 +8,8 @@ public interface ISettingHistoryRepository
 
     Task<IList<SettingValueBusinessEntity>> GetAll(Guid clientId, string settingName);
 
+    Task<int> RenameSetting(Guid clientId, string sourceSettingName, string targetSettingName);
+
     Task<IList<SettingValueBusinessEntity>> GetLastChangedForAllClients();
 
     Task<IList<SettingValueBusinessEntity>> GetValuesForEncryptionMigration(DateTime secretChangeDate);

--- a/src/api/Fig.Api/Datalayer/Repositories/SettingHistoryRepository.cs
+++ b/src/api/Fig.Api/Datalayer/Repositories/SettingHistoryRepository.cs
@@ -42,6 +42,21 @@ public class SettingHistoryRepository : RepositoryBase<SettingValueBusinessEntit
         return result;
     }
 
+    public async Task<int> RenameSetting(Guid clientId, string sourceSettingName, string targetSettingName)
+    {
+        using Activity? activity = ApiActivitySource.Instance.StartActivity();
+        var updatedRows = await Session.CreateQuery(
+                "update SettingValueBusinessEntity set SettingName = :targetSettingName " +
+                "where ClientId = :clientId and SettingName = :sourceSettingName")
+            .SetParameter("targetSettingName", targetSettingName)
+            .SetParameter("clientId", clientId)
+            .SetParameter("sourceSettingName", sourceSettingName)
+            .ExecuteUpdateAsync();
+
+        await Session.FlushAsync();
+        return updatedRows;
+    }
+
     public async Task<IList<SettingValueBusinessEntity>> GetLastChangedForAllClients()
     {
         using Activity? activity = ApiActivitySource.Instance.StartActivity();

--- a/src/api/Fig.Api/Services/SettingsService.cs
+++ b/src/api/Fig.Api/Services/SettingsService.cs
@@ -11,6 +11,7 @@ using Fig.Api.Observability;
 using Fig.Api.Secrets;
 using Fig.Api.Utils;
 using Fig.Api.Validators;
+using Fig.Common.Constants;
 using Fig.Common.Events;
 using Fig.Common.NetStandard.Json;
 using Fig.Contracts.SettingClients;
@@ -638,14 +639,21 @@ public class SettingsService : AuthenticatedService, ISettingsService
                     newSetting.LastChanged = matchingSetting.LastChanged;
                     if (isMigrateFromMatch)
                     {
-                        renamedHistoryMigrations.Add(new RenamedSettingHistoryMigration(
-                            registration.Id,
-                            updatedSettingDefinitions.Name,
-                            registration.Instance,
-                            matchingSetting.Name,
-                            newSetting.Name,
-                            matchingSetting.Value,
-                            newSetting.Value));
+                        var sourceStillExistsInDefinitions = updatedSettingDefinitions.Settings
+                            .Any(s => s.Name == matchingSetting.Name);
+                        if (!sourceStillExistsInDefinitions)
+                        {
+                            renamedHistoryMigrations.Add(new RenamedSettingHistoryMigration(
+                                registration.Id,
+                                updatedSettingDefinitions.Name,
+                                registration.Instance,
+                                matchingSetting.Name,
+                                newSetting.Name,
+                                matchingSetting.Value,
+                                newSetting.Value,
+                                matchingSetting.IsSecret,
+                                newSetting.IsSecret));
+                        }
                     }
                 }
                 else if (matchingSetting != null && isMigrateFromMatch)
@@ -691,19 +699,33 @@ public class SettingsService : AuthenticatedService, ISettingsService
             migration.SourceSettingName,
             migration.TargetSettingName);
 
-        var sourceValue = ConvertHistoryValueToString(migration.SourceSettingName, migration.SourceValue);
-        var targetValue = ConvertHistoryValueToString(migration.TargetSettingName, migration.TargetValue);
+        string changeMessage;
+        SettingValueBaseBusinessEntity? historyValue;
+
+        if (migration.SourceIsSecret || migration.TargetIsSecret)
+        {
+            changeMessage =
+                $"Setting renamed from '{migration.SourceSettingName}' to '{migration.TargetSettingName}'.";
+            historyValue = new StringSettingBusinessEntity(SecretConstants.SecretPlaceholder);
+        }
+        else
+        {
+            var sourceValue = ConvertHistoryValueToString(migration.SourceSettingName, migration.SourceValue);
+            var targetValue = ConvertHistoryValueToString(migration.TargetSettingName, migration.TargetValue);
+            changeMessage =
+                $"Setting renamed from '{migration.SourceSettingName}' to '{migration.TargetSettingName}'. " +
+                $"Value migrated from '{sourceValue}' to '{targetValue}'.";
+            historyValue = migration.TargetValue;
+        }
 
         await _settingHistoryRepository.Add(new SettingValueBusinessEntity
         {
             ClientId = migration.ClientId,
             SettingName = migration.TargetSettingName,
-            Value = migration.TargetValue,
+            Value = historyValue,
             ChangedAt = DateTime.UtcNow,
             ChangedBy = MigrateFromHistoryChangedBy,
-            ChangeMessage =
-                $"Setting renamed from '{migration.SourceSettingName}' to '{migration.TargetSettingName}'. " +
-                $"Value migrated from '{sourceValue}' to '{targetValue}'."
+            ChangeMessage = changeMessage
         });
 
         _logger.LogInformation(
@@ -890,7 +912,9 @@ public class SettingsService : AuthenticatedService, ISettingsService
             string sourceSettingName,
             string targetSettingName,
             SettingValueBaseBusinessEntity? sourceValue,
-            SettingValueBaseBusinessEntity? targetValue)
+            SettingValueBaseBusinessEntity? targetValue,
+            bool sourceIsSecret,
+            bool targetIsSecret)
         {
             ClientId = clientId;
             ClientName = clientName;
@@ -899,6 +923,8 @@ public class SettingsService : AuthenticatedService, ISettingsService
             TargetSettingName = targetSettingName;
             SourceValue = sourceValue;
             TargetValue = targetValue;
+            SourceIsSecret = sourceIsSecret;
+            TargetIsSecret = targetIsSecret;
         }
 
         public Guid ClientId { get; }
@@ -914,5 +940,9 @@ public class SettingsService : AuthenticatedService, ISettingsService
         public SettingValueBaseBusinessEntity? SourceValue { get; }
 
         public SettingValueBaseBusinessEntity? TargetValue { get; }
+
+        public bool SourceIsSecret { get; }
+
+        public bool TargetIsSecret { get; }
     }
 }

--- a/src/api/Fig.Api/Services/SettingsService.cs
+++ b/src/api/Fig.Api/Services/SettingsService.cs
@@ -24,6 +24,7 @@ namespace Fig.Api.Services;
 
 public class SettingsService : AuthenticatedService, ISettingsService
 {
+    private const string MigrateFromHistoryChangedBy = "MIGRATE_FROM";
     private readonly IConfigurationRepository _configurationRepository;
     private readonly IEventLogFactory _eventLogFactory;
     private readonly IEventLogRepository _eventLogRepository;
@@ -605,13 +606,14 @@ public class SettingsService : AuthenticatedService, ISettingsService
         }
     }
 
-    private void UpdateRegistrationsWithNewDefinitions(
+    private List<RenamedSettingHistoryMigration> UpdateRegistrationsWithNewDefinitions(
         SettingClientBusinessEntity updatedSettingDefinitions,
         List<SettingClientBusinessEntity> existingRegistrations)
     {
         var settingValues = existingRegistrations.ToDictionary(
             a => a.Instance ?? "Default",
             b => b.Settings.ToList());
+        var renamedHistoryMigrations = new List<RenamedSettingHistoryMigration>();
 
         foreach (var registration in existingRegistrations)
         {
@@ -634,6 +636,17 @@ public class SettingsService : AuthenticatedService, ISettingsService
                 {
                     newSetting.Value = matchingSetting.Value;
                     newSetting.LastChanged = matchingSetting.LastChanged;
+                    if (isMigrateFromMatch)
+                    {
+                        renamedHistoryMigrations.Add(new RenamedSettingHistoryMigration(
+                            registration.Id,
+                            updatedSettingDefinitions.Name,
+                            registration.Instance,
+                            matchingSetting.Name,
+                            newSetting.Name,
+                            matchingSetting.Value,
+                            newSetting.Value));
+                    }
                 }
                 else if (matchingSetting != null && isMigrateFromMatch)
                 {
@@ -649,6 +662,8 @@ public class SettingsService : AuthenticatedService, ISettingsService
                 registration.Settings.Add(newSetting);
             }
         }
+
+        return renamedHistoryMigrations;
     }
 
     private async Task RecordInitialSettingValues(SettingClientBusinessEntity client)
@@ -669,6 +684,47 @@ public class SettingsService : AuthenticatedService, ISettingsService
         }
     }
 
+    private async Task PersistRenamedSettingHistory(RenamedSettingHistoryMigration migration)
+    {
+        var renamedEntries = await _settingHistoryRepository.RenameSetting(
+            migration.ClientId,
+            migration.SourceSettingName,
+            migration.TargetSettingName);
+
+        var sourceValue = ConvertHistoryValueToString(migration.SourceSettingName, migration.SourceValue);
+        var targetValue = ConvertHistoryValueToString(migration.TargetSettingName, migration.TargetValue);
+
+        await _settingHistoryRepository.Add(new SettingValueBusinessEntity
+        {
+            ClientId = migration.ClientId,
+            SettingName = migration.TargetSettingName,
+            Value = migration.TargetValue,
+            ChangedAt = DateTime.UtcNow,
+            ChangedBy = MigrateFromHistoryChangedBy,
+            ChangeMessage =
+                $"Setting renamed from '{migration.SourceSettingName}' to '{migration.TargetSettingName}'. " +
+                $"Value migrated from '{sourceValue}' to '{targetValue}'."
+        });
+
+        _logger.LogInformation(
+            "Migrated setting history for client {ClientName} instance {Instance} from {SourceSettingName} to {TargetSettingName}; updated {RenamedEntries} historical rows",
+            migration.ClientName.Sanitize(),
+            migration.Instance,
+            migration.SourceSettingName,
+            migration.TargetSettingName,
+            renamedEntries);
+    }
+
+    private string ConvertHistoryValueToString(string settingName, SettingValueBaseBusinessEntity? value)
+    {
+        return _settingConverter.Convert(new SettingValueBusinessEntity
+        {
+            SettingName = settingName,
+            Value = value,
+            ChangedBy = MigrateFromHistoryChangedBy
+        }).Value;
+    }
+
     private async Task RecordIdenticalRegistration(List<SettingClientBusinessEntity> existingRegistrations)
     {
         using Activity? activity = ApiActivitySource.Instance.StartActivity();
@@ -686,7 +742,7 @@ public class SettingsService : AuthenticatedService, ISettingsService
         using Activity? activity = ApiActivitySource.Instance.StartActivity();
         _logger.LogInformation("Updated registration for client {ClientName}", clientBusinessEntity.Name);
 
-        UpdateRegistrationsWithNewDefinitions(clientBusinessEntity, existingRegistrations);
+        var renamedHistoryMigrations = UpdateRegistrationsWithNewDefinitions(clientBusinessEntity, existingRegistrations);
         foreach (var updatedDefinition in existingRegistrations)
         {
             await _secretStoreHandler.SaveSecrets(updatedDefinition);
@@ -695,6 +751,9 @@ public class SettingsService : AuthenticatedService, ISettingsService
             await _eventLogRepository.Add(
                 _eventLogFactory.UpdatedRegistration(updatedDefinition.Id, updatedDefinition.Name));
         }
+
+        foreach (var migration in renamedHistoryMigrations)
+            await PersistRenamedSettingHistory(migration);
 
         await _settingGroupService.ValidateClientRegistrationGroups(
             clientBusinessEntity.Name,
@@ -820,5 +879,40 @@ public class SettingsService : AuthenticatedService, ISettingsService
         
         // Compare the serialized JSON values
         return businessEntity.ValueAsJson != JsonConvert.SerializeObject(existingSetting.Value, JsonSettings.FigDefault);
+    }
+
+    private sealed class RenamedSettingHistoryMigration
+    {
+        public RenamedSettingHistoryMigration(
+            Guid clientId,
+            string clientName,
+            string? instance,
+            string sourceSettingName,
+            string targetSettingName,
+            SettingValueBaseBusinessEntity? sourceValue,
+            SettingValueBaseBusinessEntity? targetValue)
+        {
+            ClientId = clientId;
+            ClientName = clientName;
+            Instance = instance;
+            SourceSettingName = sourceSettingName;
+            TargetSettingName = targetSettingName;
+            SourceValue = sourceValue;
+            TargetValue = targetValue;
+        }
+
+        public Guid ClientId { get; }
+
+        public string ClientName { get; }
+
+        public string? Instance { get; }
+
+        public string SourceSettingName { get; }
+
+        public string TargetSettingName { get; }
+
+        public SettingValueBaseBusinessEntity? SourceValue { get; }
+
+        public SettingValueBaseBusinessEntity? TargetValue { get; }
     }
 }

--- a/src/tests/Fig.Integration.Test/Api/MigrateFromAttributeTests.cs
+++ b/src/tests/Fig.Integration.Test/Api/MigrateFromAttributeTests.cs
@@ -31,6 +31,82 @@ public class MigrateFromAttributeTests : IntegrationTestBase
     }
 
     [Test]
+    public async Task ShallBringOverSettingHistoryWhenSettingIsRenamed()
+    {
+        var secret = GetNewSecret();
+        await RegisterSettings<OriginalSettings>(secret);
+        await SetSettings(ClientName,
+            [new(nameof(OriginalSettings.OldSetting), new StringSettingDataContract("preserved value"))],
+            message: "history before rename");
+
+        await RegisterSettings<RenamedSettings>(secret);
+
+        var history = (await GetHistory(ClientName, nameof(RenamedSettings.NewSetting)))
+            .OrderBy(a => a.ChangedAt)
+            .ToList();
+
+        Assert.That(history.Count, Is.EqualTo(3));
+        Assert.That(history.All(a => a.Name == nameof(RenamedSettings.NewSetting)), Is.True);
+        Assert.That(history.Select(a => a.Value).ToList(),
+            Is.EqualTo(new[] { "old default", "preserved value", "preserved value" }));
+
+        var renameEntry = history.Single(a => a.ChangedBy == "MIGRATE_FROM");
+        Assert.That(renameEntry.ChangeMessage,
+            Is.EqualTo("Setting renamed from 'OldSetting' to 'NewSetting'. Value migrated from 'preserved value' to 'preserved value'."));
+    }
+
+    [Test]
+    public async Task ShallBringOverSettingHistoryForAllInstancesWhenSettingIsRenamed()
+    {
+        var secret = GetNewSecret();
+        await RegisterSettings<OriginalSettings>(secret);
+        await SetSettings(ClientName, [new(nameof(OriginalSettings.OldSetting), new StringSettingDataContract("default instance"))]);
+        await SetSettings(ClientName, [new(nameof(OriginalSettings.OldSetting), new StringSettingDataContract("named instance"))], "Instance1");
+
+        await RegisterSettings<RenamedSettings>(secret);
+
+        var defaultHistory = (await GetHistory(ClientName, nameof(RenamedSettings.NewSetting)))
+            .OrderBy(a => a.ChangedAt)
+            .ToList();
+        var instanceHistory = (await GetHistory(ClientName, nameof(RenamedSettings.NewSetting), instance: "Instance1"))
+            .OrderBy(a => a.ChangedAt)
+            .ToList();
+
+        Assert.That(defaultHistory.Select(a => a.Value).ToList(),
+            Is.EqualTo(new[] { "old default", "default instance", "default instance" }));
+        Assert.That(defaultHistory.Count(a => a.ChangedBy == "MIGRATE_FROM"), Is.EqualTo(1));
+        Assert.That(defaultHistory.All(a => a.Name == nameof(RenamedSettings.NewSetting)), Is.True);
+
+        Assert.That(instanceHistory.Select(a => a.Value).ToList(),
+            Is.EqualTo(new[] { "old default", "default instance", "named instance", "named instance" }));
+        Assert.That(instanceHistory.Count(a => a.ChangedBy == "MIGRATE_FROM"), Is.EqualTo(1));
+        Assert.That(instanceHistory.All(a => a.Name == nameof(RenamedSettings.NewSetting)), Is.True);
+    }
+
+    [Test]
+    public async Task ShallKeepMigratedHistoryWhenMigrateFromAttributeIsRemoved()
+    {
+        var secret = GetNewSecret();
+        await RegisterSettings<OriginalSettings>(secret);
+        await SetSettings(ClientName,
+            [new(nameof(OriginalSettings.OldSetting), new StringSettingDataContract("preserved value"))],
+            message: "history before rename");
+
+        await RegisterSettings<RenamedSettings>(secret);
+        await RegisterSettings<FinalRenamedSettings>(secret);
+
+        var history = (await GetHistory(ClientName, nameof(FinalRenamedSettings.NewSetting)))
+            .OrderBy(a => a.ChangedAt)
+            .ToList();
+
+        Assert.That(history.Count, Is.EqualTo(3));
+        Assert.That(history.All(a => a.Name == nameof(FinalRenamedSettings.NewSetting)), Is.True);
+        Assert.That(history.Count(a => a.ChangedBy == "MIGRATE_FROM"), Is.EqualTo(1));
+        Assert.That(history.Last().ChangeMessage,
+            Is.EqualTo("Setting renamed from 'OldSetting' to 'NewSetting'. Value migrated from 'preserved value' to 'preserved value'."));
+    }
+
+    [Test]
     public async Task ShallUseDefaultWhenMigrateFromSourceDoesNotExist()
     {
         var secret = GetNewSecret();
@@ -267,6 +343,12 @@ public class MigrateFromAttributeTests : IntegrationTestBase
     {
         [Setting("Renamed setting")]
         [MigrateFrom(nameof(OriginalSettings.OldSetting))]
+        public string NewSetting { get; set; } = "new default";
+    }
+
+    private class FinalRenamedSettings : MigrateFromTestSettingsBase
+    {
+        [Setting("Renamed setting")]
         public string NewSetting { get; set; } = "new default";
     }
 

--- a/src/tests/Fig.Integration.Test/Api/MigrateFromAttributeTests.cs
+++ b/src/tests/Fig.Integration.Test/Api/MigrateFromAttributeTests.cs
@@ -208,12 +208,19 @@ public class MigrateFromAttributeTests : IntegrationTestBase
         await RegisterSettings<AmbiguousSourceSettings>(secret);
 
         var newSettingHistory = await GetHistory(ClientName, nameof(AmbiguousSourceSettings.NewSetting));
-        var oldSettingHistory = await GetHistory(ClientName, nameof(AmbiguousSourceSettings.OldSetting));
+        var oldSettingHistory = (await GetHistory(ClientName, nameof(AmbiguousSourceSettings.OldSetting)))
+            .OrderBy(a => a.ChangedAt)
+            .ToList();
 
         Assert.That(newSettingHistory.Any(h => h.ChangedBy == "MIGRATE_FROM"), Is.False,
             "History should not be migrated when source setting still exists in the updated definitions");
         Assert.That(oldSettingHistory.Any(h => h.Name == nameof(AmbiguousSourceSettings.NewSetting)), Is.False,
             "Original setting history should remain intact");
+        Assert.That(oldSettingHistory.Count, Is.EqualTo(2),
+            "OldSetting history should contain its original entries (initial registration + value set)");
+        Assert.That(oldSettingHistory.Select(h => h.Value).ToList(),
+            Is.EqualTo(new[] { "old default", "source value" }),
+            "OldSetting history values should be unchanged");
     }
 
     [Test]

--- a/src/tests/Fig.Integration.Test/Api/MigrateFromAttributeTests.cs
+++ b/src/tests/Fig.Integration.Test/Api/MigrateFromAttributeTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Fig.Client.Abstractions.Attributes;
+using Fig.Common.Constants;
 using Fig.Contracts.ImportExport;
 using Fig.Contracts.Settings;
 using Fig.Test.Common;
@@ -175,6 +176,44 @@ public class MigrateFromAttributeTests : IntegrationTestBase
 
         var settings = await GetSettingsForClient(ClientName, secret);
         Assert.That(GetValue(settings, nameof(RenamedSecretSettings.NewSecret)), Is.EqualTo("super secret"));
+    }
+
+    [Test]
+    public async Task ShallRedactSecretValuesInHistoryMigrateFromEntry()
+    {
+        var secret = GetNewSecret();
+        await RegisterSettings<OriginalSecretSettings>(secret);
+        await SetSettings(ClientName, [new(nameof(OriginalSecretSettings.OldSecret), new StringSettingDataContract("super secret"))]);
+
+        await RegisterSettings<RenamedSecretSettings>(secret);
+
+        var history = (await GetHistory(ClientName, nameof(RenamedSecretSettings.NewSecret)))
+            .OrderBy(a => a.ChangedAt)
+            .ToList();
+
+        var renameEntry = history.Single(a => a.ChangedBy == "MIGRATE_FROM");
+        Assert.That(renameEntry.Value, Is.EqualTo(SecretConstants.SecretPlaceholder));
+        Assert.That(renameEntry.ChangeMessage,
+            Is.EqualTo($"Setting renamed from '{nameof(OriginalSecretSettings.OldSecret)}' to '{nameof(RenamedSecretSettings.NewSecret)}'."));
+        Assert.That(renameEntry.ChangeMessage, Does.Not.Contain("super secret"));
+    }
+
+    [Test]
+    public async Task ShallNotMigrateHistoryWhenMigrateFromSourceStillExistsInDefinitions()
+    {
+        var secret = GetNewSecret();
+        await RegisterSettings<OriginalSettings>(secret);
+        await SetSettings(ClientName, [new(nameof(OriginalSettings.OldSetting), new StringSettingDataContract("source value"))]);
+
+        await RegisterSettings<AmbiguousSourceSettings>(secret);
+
+        var newSettingHistory = await GetHistory(ClientName, nameof(AmbiguousSourceSettings.NewSetting));
+        var oldSettingHistory = await GetHistory(ClientName, nameof(AmbiguousSourceSettings.OldSetting));
+
+        Assert.That(newSettingHistory.Any(h => h.ChangedBy == "MIGRATE_FROM"), Is.False,
+            "History should not be migrated when source setting still exists in the updated definitions");
+        Assert.That(oldSettingHistory.Any(h => h.Name == nameof(AmbiguousSourceSettings.NewSetting)), Is.False,
+            "Original setting history should remain intact");
     }
 
     [Test]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Setting value history is preserved and migrated when a setting is renamed via MigrateFrom, with a one-time history entry recording the rename and carried value; migrated history persists after MigrateFrom is removed.
  * Secret values are redacted in the migrate history entry; history is not migrated if the source setting still exists.

* **Documentation**
  * Added docs describing value-history behavior during setting migrations.

* **Tests**
  * Added integration tests covering migration, multi-instance behavior, persistence after removal, secret redaction, and no-migrate-when-source-exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->