### PR TITLE
Fix problem with ordering group setting groups

### DIFF
--- a/src/tests/Fig.Integration.Test/Api/SettingGroupTests.cs
+++ b/src/tests/Fig.Integration.Test/Api/SettingGroupTests.cs
@@ -336,6 +336,43 @@ public class SettingGroupTests : IntegrationTestBase
     }
 
     [Test]
+    public async Task ShallPreserveGroupedSettingOrderWhenGroupIsUpdated()
+    {
+        var group = CreateTestGroupWithSettings("OrderedGroup", "Order test");
+
+        var created = await CreateSettingGroup(group);
+        Assert.That(created.GroupedSettings.Select(setting => setting.Name),
+            Is.EqualTo(new[] { "ConnectionString", "MaxRetries" }));
+
+        var reorderedGroup = new SettingGroupDataContract(
+            created.Id,
+            created.Name,
+            created.Description,
+            new List<GroupedSettingDataContract>
+            {
+                new(
+                    created.GroupedSettings[1].Name,
+                    created.GroupedSettings[1].Description,
+                    created.GroupedSettings[1].ValueType,
+                    created.GroupedSettings[1].SourceSettings),
+                new(
+                    created.GroupedSettings[0].Name,
+                    created.GroupedSettings[0].Description,
+                    created.GroupedSettings[0].ValueType,
+                    created.GroupedSettings[0].SourceSettings)
+            });
+
+        var updated = await UpdateSettingGroup(created.Id!.Value, reorderedGroup);
+        Assert.That(updated.GroupedSettings.Select(setting => setting.Name),
+            Is.EqualTo(new[] { "MaxRetries", "ConnectionString" }));
+
+        var fetched = await GetSettingGroup(created.Id.Value);
+        Assert.That(fetched, Is.Not.Null);
+        Assert.That(fetched!.GroupedSettings.Select(setting => setting.Name),
+            Is.EqualTo(new[] { "MaxRetries", "ConnectionString" }));
+    }
+
+    [Test]
     public async Task ShallPreserveSourceSettingOrderWhenGroupIsUpdated()
     {
         var group = new SettingGroupDataContract(

--- a/src/web/Fig.Web/Pages/Groups.razor
+++ b/src/web/Fig.Web/Pages/Groups.razor
@@ -188,10 +188,11 @@
                     <div class="grouped-settings-list">
                         @for (var groupedSettingIndex = 0; groupedSettingIndex < _selectedGroup.GroupedSettings.Count; groupedSettingIndex++)
                         {
-                            var groupedSetting = _selectedGroup.GroupedSettings[groupedSettingIndex];
+                            var currentGroupedSettingIndex = groupedSettingIndex;
+                            var groupedSetting = _selectedGroup.GroupedSettings[currentGroupedSettingIndex];
                             var isEditing = ReferenceEquals(_editingGroupedSetting, groupedSetting);
 
-                            <RadzenCard class="grouped-setting-card custom-card">
+                            <RadzenCard @key="groupedSetting" class="grouped-setting-card custom-card">
                                 <div class="grouped-setting-accent" style="background-color: @(groupedSetting.CategoryColor ?? "transparent");"></div>
                                 <div class="card-inner">
                                     @if (isEditing)
@@ -253,16 +254,16 @@
                                                  <div class="gs-card-actions">
                                                      @if (IsAdmin)
                                                      {
-                                                         <RadzenButton Icon="arrow_upward" ButtonStyle="ButtonStyle.Light"
-                                                                       Size="ButtonSize.ExtraSmall" Class="groups-icon-button"
-                                                                       Disabled="@(groupedSettingIndex == 0)"
-                                                                       title="Move grouped setting up" aria-label="Move grouped setting up"
-                                                                       Click="@(() => MoveGroupedSettingUp(groupedSettingIndex))" />
-                                                         <RadzenButton Icon="arrow_downward" ButtonStyle="ButtonStyle.Light"
-                                                                       Size="ButtonSize.ExtraSmall" Class="groups-icon-button"
-                                                                       Disabled="@(groupedSettingIndex == _selectedGroup.GroupedSettings.Count - 1)"
-                                                                       title="Move grouped setting down" aria-label="Move grouped setting down"
-                                                                       Click="@(() => MoveGroupedSettingDown(groupedSettingIndex))" />
+                                                          <RadzenButton Icon="arrow_upward" ButtonStyle="ButtonStyle.Light"
+                                                                        Size="ButtonSize.ExtraSmall" Class="groups-icon-button"
+                                                                        Disabled="@(currentGroupedSettingIndex == 0)"
+                                                                        title="Move grouped setting up" aria-label="Move grouped setting up"
+                                                                        Click="@(() => MoveGroupedSettingUp(currentGroupedSettingIndex))" />
+                                                          <RadzenButton Icon="arrow_downward" ButtonStyle="ButtonStyle.Light"
+                                                                        Size="ButtonSize.ExtraSmall" Class="groups-icon-button"
+                                                                        Disabled="@(currentGroupedSettingIndex == _selectedGroup.GroupedSettings.Count - 1)"
+                                                                        title="Move grouped setting down" aria-label="Move grouped setting down"
+                                                                        Click="@(() => MoveGroupedSettingDown(currentGroupedSettingIndex))" />
                                                          <RadzenButton Icon="edit" ButtonStyle="ButtonStyle.Light"
                                                                        Size="ButtonSize.Small" Class="groups-icon-button"
                                                                        title="Edit grouped setting" aria-label="Edit grouped setting"

--- a/src/web/Fig.Web/Shared/MainLayout.razor
+++ b/src/web/Fig.Web/Shared/MainLayout.razor
@@ -97,9 +97,9 @@
                     }
                 </div>
                 
-                <div class="align-content-center p-1 fig-connection-status">
+                <div class="d-flex flex-column align-items-center justify-content-center p-1 fig-connection-status">
                     <ConnectionStatus/>
-                    <p>@Settings.Value.Environment</p>
+                    <p class="mb-0">@Settings.Value.Environment</p>
                 </div>
 
                 <RadzenProfileMenu class="fig-profile-menu">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed grouped settings reordering functionality in the settings group management interface. Move up and move down buttons now correctly update item positions and preserve the intended order when modifying grouped settings within a setting group.

* **Tests**
  * Added integration test to verify grouped settings maintain their order when setting groups are updated and reloaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->