### PR TITLE
Respect saved group setting order

### DIFF
--- a/src/tests/Fig.Unit.Test/Web/SettingClientFacadeGroupMetadataTests.cs
+++ b/src/tests/Fig.Unit.Test/Web/SettingClientFacadeGroupMetadataTests.cs
@@ -207,6 +207,41 @@ public class SettingClientFacadeGroupMetadataTests
         Assert.That(groupSetting.ValidationRegex, Is.EqualTo("^B+$"));
     }
 
+    [Test]
+    public async Task ShallUseSavedGroupedSettingOrderInsteadOfSourceDisplayOrder()
+    {
+        _clientA.Settings.Add(CreateStringSetting(_clientA, "SettingA", "value-a", displayOrder: 200));
+        _clientA.Settings.Add(CreateStringSetting(_clientA, "SettingB", "value-b", displayOrder: 100));
+
+        SetupGroupsResponse(new List<SettingGroupDataContract>
+        {
+            new(Guid.NewGuid(), "SharedGroup", null, new List<GroupedSettingDataContract>
+            {
+                new("SettingA", null, "System.String",
+                    new List<SourceSettingDataContract>
+                    {
+                        new("ClientA", "SettingA")
+                    }),
+                new("SettingB", null, "System.String",
+                    new List<SourceSettingDataContract>
+                    {
+                        new("ClientA", "SettingB")
+                    })
+            })
+        });
+
+        await _sut.LoadAllClients();
+
+        var groupClient = _sut.SettingClients.Single(client => client.IsGroup && client.Name == "SharedGroup");
+        var orderedSettingNames = groupClient.Settings
+            .OrderBy(setting => setting.DisplayOrder)
+            .Select(setting => setting.Name)
+            .ToList();
+
+        Assert.That(orderedSettingNames, Is.EqualTo(new[] { "SettingA", "SettingB" }));
+        Assert.That(groupClient.Settings.Select(setting => setting.DisplayOrder), Is.EqualTo(new[] { 0, 1 }));
+    }
+
     private void SetupGroupsResponse(List<SettingGroupDataContract> groups)
     {
         _httpService
@@ -226,7 +261,8 @@ public class SettingClientFacadeGroupMetadataTests
         string value,
         string? categoryName = null,
         string? categoryColor = null,
-        string? validationRegex = null)
+        string? validationRegex = null,
+        int? displayOrder = null)
     {
         var definition = new SettingDefinitionDataContract(
             name,
@@ -235,6 +271,7 @@ public class SettingClientFacadeGroupMetadataTests
             false,
             typeof(string),
             validationRegex: validationRegex,
+            displayOrder: displayOrder,
             categoryName: categoryName,
             categoryColor: categoryColor);
 

--- a/src/web/Fig.Web/Facades/SettingClientFacade.cs
+++ b/src/web/Fig.Web/Facades/SettingClientFacade.cs
@@ -585,8 +585,9 @@ public class SettingClientFacade : ISettingClientFacade
 
             var settings = new List<ISetting>();
 
-            foreach (var gs in group.GroupedSettings)
+            for (var groupSettingIndex = 0; groupSettingIndex < group.GroupedSettings.Count; groupSettingIndex++)
             {
+                var gs = group.GroupedSettings[groupSettingIndex];
                 var managedSettings = new List<ISetting>();
                 ISetting? templateSetting = null;
 
@@ -603,6 +604,7 @@ public class SettingClientFacade : ISettingClientFacade
                 if (templateSetting == null) continue;
 
                 var cloned = templateSetting.Clone(settingGroup, false, templateSetting.IsReadOnly);
+                cloned.DisplayOrder = groupSettingIndex;
                 cloned.IsCompactView = _webSettings.DefaultDisplayCollapsed;
 
                 if (!string.IsNullOrWhiteSpace(gs.Name) &&

--- a/src/web/Fig.Web/Models/Setting/ISetting.cs
+++ b/src/web/Fig.Web/Models/Setting/ISetting.cs
@@ -25,7 +25,7 @@ public interface ISetting : IScriptableSetting
     
     new bool Advanced { get; }
 
-    new int? DisplayOrder { get; }
+    new int? DisplayOrder { get; set; }
 
     string? Group { get; }
 


### PR DESCRIPTION
Assign group-cloned setting display order from the persisted GroupedSettings index so the Settings page follows the order configured on the Groups page.

Add unit coverage for conflicting source display-order metadata and expose the DisplayOrder setter on ISetting so existing setting models can preserve the server-defined order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed grouped settings to now respect the saved display order instead of the source display order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->