### PR TITLE
Support typed MigrateFrom migrations

### DIFF
--- a/doc/fig-documentation/docs/features/settings-management/26-migrate-from.md
+++ b/doc/fig-documentation/docs/features/settings-management/26-migrate-from.md
@@ -16,6 +16,59 @@ public string NewSettingName { get; set; } = "Default value";
 
 During the next updated registration, Fig copies the value from `OldSettingName` into `NewSettingName` if the old setting exists and has the same value type. It also moves the old setting's value history to `NewSettingName` and adds a history entry that records the rename and the migrated value. If the old setting does not exist, Fig keeps the normal default value for the new setting.
 
+## Type-changing migrations
+
+If the old and new settings use different value types, add a migration method name to `MigrateFrom`. The method is a `public static` method on the settings class. It runs in your application during registration, not in the Fig API.
+
+```csharp
+[Setting("Request timeout")]
+[MigrateFrom("TimeoutSeconds", migrationMethodName: nameof(MigrateTimeout))]
+public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(30);
+
+public static TimeSpan MigrateTimeout(int timeoutSeconds)
+{
+    return TimeSpan.FromSeconds(timeoutSeconds);
+}
+```
+
+The method must have exactly one parameter and return a value compatible with the new setting type. Use `nameof(...)` so refactoring tools keep the attribute in sync.
+
+Migration methods can also reshape values into complex settings:
+
+```csharp
+[Setting("Endpoint config")]
+[MigrateFrom("LegacyEndpoint", migrationMethodName: nameof(MigrateEndpoint))]
+public EndpointConfig EndpointConfig { get; set; } = new();
+
+public static EndpointConfig MigrateEndpoint(string legacyEndpoint)
+{
+    return new EndpointConfig
+    {
+        Routes = [new EndpointRoute { Url = legacyEndpoint, Enabled = true }]
+    };
+}
+```
+
+If the source setting is a `List<T>` and the target is something else, Fig passes the source value to your migration method as `List<Dictionary<string, object>>`. Each dictionary represents one row from the stored list/data-grid value.
+
+- For `List<string>`, each row uses the key `Values`.
+- For lists of custom objects, the keys match the generated column/property names.
+
+```csharp
+[Setting("Allowed regions summary")]
+[MigrateFrom("AllowedRegions", migrationMethodName: nameof(MigrateRegions))]
+public string AllowedRegionsSummary { get; set; } = string.Empty;
+
+public static string MigrateRegions(List<Dictionary<string, object>> items)
+{
+    return string.Join(", ", items
+        .Select(row => row.TryGetValue("Values", out var value) ? value?.ToString() : null)
+        .Where(value => !string.IsNullOrWhiteSpace(value)));
+}
+```
+
+Custom migration methods are intentionally client-side only. The Fig API sends the old stored value to the registering client, the client runs the static method locally, and the API validates and stores the converted value. Fig never accepts or executes scripts, delegates, or method bodies from clients.
+
 ## Imports
 
 `MigrateFrom` also applies to value-only imports. If an import file contains the old setting name and the registered client only contains the renamed setting, Fig applies the imported value to the renamed setting:
@@ -30,6 +83,8 @@ During the next updated registration, Fig copies the value from `OldSettingName`
 With `[MigrateFrom("OldSettingName")]` on `NewSettingName`, the value above is imported into `NewSettingName`.
 
 When this happens, Fig logs a warning and shows import feedback telling the user to update the import file to use the new setting name. The import still succeeds. Deferred value-only imports use the same migration behavior when they are applied during client registration, but only log the warning at that time.
+
+Custom migration methods do not run for imports because imports are processed by the Fig API and the API does not execute application code. If an old-name import entry requires a custom migration method, Fig reports that the entry could not be applied and tells the user to update or externally migrate the import file to the new setting name and value shape.
 
 ## Nested settings
 
@@ -58,7 +113,10 @@ public string NewSetting { get; set; } = "Default value";
 
 - Exact name matches take precedence. If the new setting name already exists in Fig, that value is preserved instead of the `MigrateFrom` source.
 - For value-only imports, exact current-name matches also take precedence. If an import file contains both the old and new setting names, Fig applies the new setting name and warns that the old setting entry should be removed.
-- The source and target setting types must match. If they do not match, Fig keeps the new default value and logs an error.
+- Without a custom migration method, the source and target setting types must match. If they do not match, Fig keeps the new default value and logs an error.
+- If a custom migration method is supplied, it runs whenever the source setting exists and the target setting does not already have an exact-name match, even if the source and target types are the same.
+- When the source setting is a `List<T>` and the target is a different shape, the migration method parameter should be `List<Dictionary<string, object>>`.
+- Custom migrations from a secret source setting to a non-secret target setting are blocked to avoid downgrading protected data into a visible setting.
 - If the source setting still exists in the updated registration, Fig still migrates the value. In DEBUG builds, Fig.Client logs a warning in the source application so developers can remove or correct the ambiguous migration.
 - When migration happens during registration, Fig rewrites the old setting's value history to the new setting name and adds a one-time history row describing the rename. This history stays with the new setting even after `MigrateFrom` is removed later.
 - `MigrateFrom` is intended to be temporary. After all environments have registered the renamed setting and migrated the value, remove the attribute.

--- a/doc/fig-documentation/versioned_docs/version-3.x/features/settings-management/26-migrate-from.md
+++ b/doc/fig-documentation/versioned_docs/version-3.x/features/settings-management/26-migrate-from.md
@@ -16,6 +16,59 @@ public string NewSettingName { get; set; } = "Default value";
 
 During the next updated registration, Fig copies the value from `OldSettingName` into `NewSettingName` if the old setting exists and has the same value type. It also moves the old setting's value history to `NewSettingName` and adds a history entry that records the rename and the migrated value. If the old setting does not exist, Fig keeps the normal default value for the new setting.
 
+## Type-changing migrations
+
+If the old and new settings use different value types, add a migration method name to `MigrateFrom`. The method is a `public static` method on the settings class. It runs in your application during registration, not in the Fig API.
+
+```csharp
+[Setting("Request timeout")]
+[MigrateFrom("TimeoutSeconds", migrationMethodName: nameof(MigrateTimeout))]
+public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(30);
+
+public static TimeSpan MigrateTimeout(int timeoutSeconds)
+{
+    return TimeSpan.FromSeconds(timeoutSeconds);
+}
+```
+
+The method must have exactly one parameter and return a value compatible with the new setting type. Use `nameof(...)` so refactoring tools keep the attribute in sync.
+
+Migration methods can also reshape values into complex settings:
+
+```csharp
+[Setting("Endpoint config")]
+[MigrateFrom("LegacyEndpoint", migrationMethodName: nameof(MigrateEndpoint))]
+public EndpointConfig EndpointConfig { get; set; } = new();
+
+public static EndpointConfig MigrateEndpoint(string legacyEndpoint)
+{
+    return new EndpointConfig
+    {
+        Routes = [new EndpointRoute { Url = legacyEndpoint, Enabled = true }]
+    };
+}
+```
+
+If the source setting is a `List<T>` and the target is something else, Fig passes the source value to your migration method as `List<Dictionary<string, object>>`. Each dictionary represents one row from the stored list/data-grid value.
+
+- For `List<string>`, each row uses the key `Values`.
+- For lists of custom objects, the keys match the generated column/property names.
+
+```csharp
+[Setting("Allowed regions summary")]
+[MigrateFrom("AllowedRegions", migrationMethodName: nameof(MigrateRegions))]
+public string AllowedRegionsSummary { get; set; } = string.Empty;
+
+public static string MigrateRegions(List<Dictionary<string, object>> items)
+{
+    return string.Join(", ", items
+        .Select(row => row.TryGetValue("Values", out var value) ? value?.ToString() : null)
+        .Where(value => !string.IsNullOrWhiteSpace(value)));
+}
+```
+
+Custom migration methods are intentionally client-side only. The Fig API sends the old stored value to the registering client, the client runs the static method locally, and the API validates and stores the converted value. Fig never accepts or executes scripts, delegates, or method bodies from clients.
+
 ## Imports
 
 `MigrateFrom` also applies to value-only imports. If an import file contains the old setting name and the registered client only contains the renamed setting, Fig applies the imported value to the renamed setting:
@@ -30,6 +83,8 @@ During the next updated registration, Fig copies the value from `OldSettingName`
 With `[MigrateFrom("OldSettingName")]` on `NewSettingName`, the value above is imported into `NewSettingName`.
 
 When this happens, Fig logs a warning and shows import feedback telling the user to update the import file to use the new setting name. The import still succeeds. Deferred value-only imports use the same migration behavior when they are applied during client registration, but only log the warning at that time.
+
+Custom migration methods do not run for imports because imports are processed by the Fig API and the API does not execute application code. If an old-name import entry requires a custom migration method, Fig reports that the entry could not be applied and tells the user to update or externally migrate the import file to the new setting name and value shape.
 
 ## Nested settings
 
@@ -58,7 +113,10 @@ public string NewSetting { get; set; } = "Default value";
 
 - Exact name matches take precedence. If the new setting name already exists in Fig, that value is preserved instead of the `MigrateFrom` source.
 - For value-only imports, exact current-name matches also take precedence. If an import file contains both the old and new setting names, Fig applies the new setting name and warns that the old setting entry should be removed.
-- The source and target setting types must match. If they do not match, Fig keeps the new default value and logs an error.
+- Without a custom migration method, the source and target setting types must match. If they do not match, Fig keeps the new default value and logs an error.
+- If a custom migration method is supplied, it runs whenever the source setting exists and the target setting does not already have an exact-name match, even if the source and target types are the same.
+- When the source setting is a `List<T>` and the target is a different shape, the migration method parameter should be `List<Dictionary<string, object>>`.
+- Custom migrations from a secret source setting to a non-secret target setting are blocked to avoid downgrading protected data into a visible setting.
 - If the source setting still exists in the updated registration, Fig still migrates the value. In DEBUG builds, Fig.Client logs a warning in the source application so developers can remove or correct the ambiguous migration.
 - When migration happens during registration, Fig rewrites the old setting's value history to the new setting name and adds a one-time history row describing the rename. This history stays with the new setting even after `MigrateFrom` is removed later.
 - `MigrateFrom` is intended to be temporary. After all environments have registered the renamed setting and migrated the value, remove the attribute.

--- a/src/api/Fig.Api/Comparers/SettingComparer.cs
+++ b/src/api/Fig.Api/Comparers/SettingComparer.cs
@@ -43,7 +43,8 @@ public class SettingComparer : IEqualityComparer<SettingBusinessEntity>
                 x.Indent == y.Indent &&
                 x.DependsOnProperty == y.DependsOnProperty &&
                 x.InitOnlyExport == y.InitOnlyExport &&
-                x.MigrateFrom == y.MigrateFrom &&
+                 x.MigrateFrom == y.MigrateFrom &&
+                 x.MigrateFromMigrationMethod == y.MigrateFromMigrationMethod &&
                 (x.DependsOnValidValues ?? []).SequenceEqual(y.DependsOnValidValues ?? []) &&
                 SerializeObject(x.Heading) == SerializeObject(y.Heading);
     }
@@ -78,6 +79,7 @@ public class SettingComparer : IEqualityComparer<SettingBusinessEntity>
         hashCode.Add(obj.DependsOnProperty);
         hashCode.Add(obj.InitOnlyExport);
         hashCode.Add(obj.MigrateFrom);
+        hashCode.Add(obj.MigrateFromMigrationMethod);
         if (obj.DependsOnValidValues != null)
         {
             foreach (var value in obj.DependsOnValidValues)

--- a/src/api/Fig.Api/Controllers/CapabilitiesController.cs
+++ b/src/api/Fig.Api/Controllers/CapabilitiesController.cs
@@ -3,40 +3,57 @@ using Fig.Contracts.Capabilities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Caching.Memory;
+using Fig.Api.Datalayer.Repositories;
 
 namespace Fig.Api.Controllers;
 
 [ApiController, Route("capabilities")]
 public class CapabilitiesController : ControllerBase
 {
-    private static readonly string[] SupportedFeatures =
+    private static readonly string[] BaseSupportedFeatures =
     [
         "deferredDescriptionRegistration",
         "requestCompression"
     ];
 
-    private const string CacheKey = "fig_capabilities";
+    private const string CacheKeyPrefix = "fig_capabilities";
     private static readonly TimeSpan CacheDuration = TimeSpan.FromHours(24);
 
     private readonly IVersionHelper _versionHelper;
     private readonly IMemoryCache _memoryCache;
+    private readonly IConfigurationRepository _configurationRepository;
 
-    public CapabilitiesController(IVersionHelper versionHelper, IMemoryCache memoryCache)
+    public CapabilitiesController(
+        IVersionHelper versionHelper,
+        IMemoryCache memoryCache,
+        IConfigurationRepository configurationRepository)
     {
         _versionHelper = versionHelper;
         _memoryCache = memoryCache;
+        _configurationRepository = configurationRepository;
     }
 
     [HttpGet]
     [AllowAnonymous]
-    public IActionResult GetCapabilities()
+    public async Task<IActionResult> GetCapabilities()
     {
-        var result = _memoryCache.GetOrCreate(CacheKey, entry =>
+        var allowMigrateFromMigrations = (await _configurationRepository.GetConfiguration()).AllowMigrateFromMigrations;
+        var result = _memoryCache.GetOrCreate(GetCacheKey(allowMigrateFromMigrations), entry =>
         {
             entry.AbsoluteExpirationRelativeToNow = CacheDuration;
-            return new FigCapabilitiesDataContract(_versionHelper.GetVersion(), SupportedFeatures);
+            return new FigCapabilitiesDataContract(
+                _versionHelper.GetVersion(),
+                GetSupportedFeatures(allowMigrateFromMigrations));
         });
 
         return Ok(result);
     }
+
+    private static string GetCacheKey(bool allowMigrateFromMigrations) =>
+        $"{CacheKeyPrefix}:{allowMigrateFromMigrations}";
+
+    private static IReadOnlyList<string> GetSupportedFeatures(bool allowMigrateFromMigrations) =>
+        allowMigrateFromMigrations
+            ? [.. BaseSupportedFeatures, "migrateFromClientTransforms"]
+            : BaseSupportedFeatures;
 }

--- a/src/api/Fig.Api/Controllers/ClientsController.cs
+++ b/src/api/Fig.Api/Controllers/ClientsController.cs
@@ -107,6 +107,21 @@ public class ClientsController : ControllerBase
         return Ok();
     }
 
+    [LogFigClientCall]
+    [AllowAnonymous]
+    [HttpPost("migrations/preview")]
+    public async Task<IActionResult> PreviewMigrateFromMigrations([FromHeader] string clientSecret,
+        [FromBody] SettingsClientDefinitionDataContract settingsClientDefinition)
+    {
+        if (!_clientSecretValidator.IsValid(clientSecret))
+            throw new InvalidClientSecretException(clientSecret);
+
+        _clientNameValidator.Validate(settingsClientDefinition.Name);
+
+        var requests = await _settingsService.GetMigrateFromMigrationRequests(clientSecret, settingsClientDefinition);
+        return Ok(requests);
+    }
+
     /// <summary>
     ///     Update Settings via web client
     /// </summary>

--- a/src/api/Fig.Api/Converters/ClientExportConverter.cs
+++ b/src/api/Fig.Api/Converters/ClientExportConverter.cs
@@ -160,6 +160,7 @@ public class ClientExportConverter : IClientExportConverter
             DependsOnValidValues = setting.DependsOnValidValues,
             InitOnlyExport = setting.InitOnlyExport,
             MigrateFrom = setting.MigrateFrom,
+            MigrateFromMigrationMethod = setting.MigrateFromMigrationMethod,
             Heading = setting.Heading != null ? new HeadingDataContract(
                 setting.Heading.Text,
                 setting.Heading.Color,
@@ -228,7 +229,8 @@ public class ClientExportConverter : IClientExportConverter
                 setting.Heading.Color,
                 setting.Heading.Advanced) : null,
             setting.InitOnlyExport,
-            setting.MigrateFrom);
+            setting.MigrateFrom,
+            setting.MigrateFromMigrationMethod);
     }
 
     private SettingValueBaseDataContract? GetDecryptedValue(StringSettingDataContract settingValue, Type type, string settingName, string? customDecryptionKey = null)

--- a/src/api/Fig.Api/Converters/FigConfigurationConverter.cs
+++ b/src/api/Fig.Api/Converters/FigConfigurationConverter.cs
@@ -25,7 +25,8 @@ public class FigConfigurationConverter : IFigConfigurationConverter
             TimeMachineCleanupDays = configuration.TimeMachineCleanupDays,
             EventLogsCleanupDays = configuration.EventLogsCleanupDays,
             ApiStatusCleanupDays = configuration.ApiStatusCleanupDays,
-            SettingHistoryCleanupDays = configuration.SettingHistoryCleanupDays
+            SettingHistoryCleanupDays = configuration.SettingHistoryCleanupDays,
+            AllowMigrateFromMigrations = configuration.AllowMigrateFromMigrations
         };
     }
 }

--- a/src/api/Fig.Api/Converters/SettingDefinitionConverter.cs
+++ b/src/api/Fig.Api/Converters/SettingDefinitionConverter.cs
@@ -133,7 +133,8 @@ public class SettingDefinitionConverter : ISettingDefinitionConverter
             businessEntity.DependsOnValidValues,
             businessEntity.Heading,
             businessEntity.InitOnlyExport,
-            businessEntity.MigrateFrom);
+            businessEntity.MigrateFrom,
+            businessEntity.MigrateFromMigrationMethod);
     }
 
     private SettingValueBaseDataContract? GetValue(SettingBusinessEntity setting, IList<string>? validValues,
@@ -190,6 +191,7 @@ public class SettingDefinitionConverter : ISettingDefinitionConverter
             DependsOnValidValues = dataContract.DependsOnValidValues,
             InitOnlyExport = dataContract.InitOnlyExport,
             MigrateFrom = dataContract.MigrateFrom,
+            MigrateFromMigrationMethod = dataContract.MigrateFromMigrationMethod,
             Heading = dataContract.Heading
         };
     }

--- a/src/api/Fig.Api/DataImport/SettingApplier.cs
+++ b/src/api/Fig.Api/DataImport/SettingApplier.cs
@@ -100,6 +100,22 @@ public class SettingApplier : ISettingApplier
         if (migrateFromMatch is null)
             return null;
 
+        if (!string.IsNullOrWhiteSpace(setting.MigrateFromMigrationMethod))
+        {
+            result.HandledImportSettingNames.Add(migrateFromMatch.Name);
+            var unsupportedWarning =
+                $"Imported setting '{migrateFromMatch.Name}' for client '{GetClientIdentifier(client)}' could not be applied to renamed setting '{setting.Name}' because it requires a custom MigrateFrom migration method. Custom migration methods run only in the source application during registration. Update the import file to use '{setting.Name}' with the new value shape.";
+            result.Warnings.Add(unsupportedWarning);
+            _logger.LogWarning(
+                "Imported setting {SourceSettingName} for client {ClientName} and instance {Instance} could not be applied to renamed setting {TargetSettingName} because it requires custom MigrateFrom migration method {MigrationMethod}. Update the import file to use the new setting name and value shape.",
+                migrateFromMatch.Name,
+                client.Name.Sanitize(),
+                client.Instance,
+                setting.Name,
+                setting.MigrateFromMigrationMethod);
+            return null;
+        }
+
         result.HandledImportSettingNames.Add(migrateFromMatch.Name);
         var warning = $"Imported setting '{migrateFromMatch.Name}' for client '{GetClientIdentifier(client)}' was applied to renamed setting '{setting.Name}' because it is configured as MigrateFrom. Update the import file to use '{setting.Name}'.";
         result.Warnings.Add(warning);

--- a/src/api/Fig.Api/DatabaseMigrations/Migrations/Migration_007_EnableMigrateFromMigrationsByDefault.cs
+++ b/src/api/Fig.Api/DatabaseMigrations/Migrations/Migration_007_EnableMigrateFromMigrationsByDefault.cs
@@ -1,0 +1,24 @@
+using Fig.Api.DatabaseMigrations;
+
+namespace Fig.Api.DatabaseMigrations.Migrations;
+
+public class Migration_007_EnableMigrateFromMigrationsByDefault : IDatabaseMigration
+{
+    public int ExecutionNumber => 7;
+
+    public string Description => "Backfill migrate-from migrations to enabled for existing configuration rows";
+
+    public string SqlServerScript =>
+        """
+        UPDATE configuration
+        SET allow_migrate_from_migrations = 1
+        WHERE allow_migrate_from_migrations IS NULL OR allow_migrate_from_migrations = 0;
+        """;
+
+    public string SqliteScript =>
+        """
+        UPDATE configuration
+        SET allow_migrate_from_migrations = 1
+        WHERE allow_migrate_from_migrations IS NULL OR allow_migrate_from_migrations = 0;
+        """;
+}

--- a/src/api/Fig.Api/ExtensionMethods/FigConfigurationBusinessEntityExtensionMethods.cs
+++ b/src/api/Fig.Api/ExtensionMethods/FigConfigurationBusinessEntityExtensionMethods.cs
@@ -24,5 +24,6 @@ public static class FigConfigurationBusinessEntityExtensionMethods
         businessEntity.EventLogsCleanupDays = dataContract.EventLogsCleanupDays;
         businessEntity.ApiStatusCleanupDays = dataContract.ApiStatusCleanupDays;
         businessEntity.SettingHistoryCleanupDays = dataContract.SettingHistoryCleanupDays;
+        businessEntity.AllowMigrateFromMigrations = dataContract.AllowMigrateFromMigrations;
     }
 }

--- a/src/api/Fig.Api/ExtensionMethods/SettingBusinessEntityExtensions.cs
+++ b/src/api/Fig.Api/ExtensionMethods/SettingBusinessEntityExtensions.cs
@@ -46,6 +46,7 @@ public static class SettingBusinessEntityExtensions
             DependsOnValidValues = original.DependsOnValidValues,
             InitOnlyExport = original.InitOnlyExport,
             MigrateFrom = original.MigrateFrom,
+            MigrateFromMigrationMethod = original.MigrateFromMigrationMethod,
             Heading = original.Heading,
         };
     }

--- a/src/api/Fig.Api/Secrets/ISecretStoreHandler.cs
+++ b/src/api/Fig.Api/Secrets/ISecretStoreHandler.cs
@@ -10,6 +10,8 @@ public interface ISecretStoreHandler
     Task SaveSecrets(SettingClientBusinessEntity client, List<ChangedSetting> changes);
     
     Task HydrateSecrets(SettingClientBusinessEntity client);
+
+    Task HydrateSecret(SettingClientBusinessEntity client, string settingName);
     
     Task ClearSecrets(SettingClientBusinessEntity client);
 }

--- a/src/api/Fig.Api/Secrets/SecretStoreHandler.cs
+++ b/src/api/Fig.Api/Secrets/SecretStoreHandler.cs
@@ -61,6 +61,22 @@ public class SecretStoreHandler : ISecretStoreHandler
         }
     }
 
+    public async Task HydrateSecret(SettingClientBusinessEntity client, string settingName)
+    {
+        if (!await UseSecretStore())
+            return;
+
+        var setting = client.Settings.FirstOrDefault(a => a.Name == settingName && a.IsSecret);
+        if (setting is null)
+            return;
+
+        var secretKey = GetSecretKey(client, setting.Name);
+        var secrets = await _secretStore.GetSecrets([secretKey]);
+        var secret = secrets.FirstOrDefault(a => a.Key == secretKey);
+        if (secret.Key is not null)
+            setting.Value = new StringSettingBusinessEntity(secret.Value);
+    }
+
     public async Task ClearSecrets(SettingClientBusinessEntity client)
     {
         if (!await UseSecretStore())
@@ -85,7 +101,7 @@ public class SecretStoreHandler : ISecretStoreHandler
             .Select(a =>
                 new KeyValuePair<string, string>(
                     GetSecretKey(client, a.Name), 
-                    Convert.ToString(a.DefaultValue?.GetValue(), CultureInfo.InvariantCulture) ?? string.Empty))
+                    Convert.ToString(a.Value?.GetValue(), CultureInfo.InvariantCulture) ?? string.Empty))
             .ToList();
         await _secretStore.PersistSecrets(secrets);
     }
@@ -99,7 +115,7 @@ public class SecretStoreHandler : ISecretStoreHandler
             .Select(a =>
                 new KeyValuePair<string, string>(
                     GetSecretKey(client, a.Name), 
-                    Convert.ToString(a.DefaultValue?.GetValue(), CultureInfo.InvariantCulture) ?? string.Empty))
+                    Convert.ToString(a.Value?.GetValue(), CultureInfo.InvariantCulture) ?? string.Empty))
             .ToList();
         await _secretStore.PersistSecrets(secrets);
     }

--- a/src/api/Fig.Api/Services/ISettingsService.cs
+++ b/src/api/Fig.Api/Services/ISettingsService.cs
@@ -1,5 +1,6 @@
 using Fig.Contracts.SettingClients;
 using Fig.Contracts.SettingDefinitions;
+using Fig.Contracts.SettingMigrations;
 using Fig.Contracts.Settings;
 
 namespace Fig.Api.Services;
@@ -11,6 +12,10 @@ public interface ISettingsService : IAuthenticatedService
     Task<IEnumerable<SettingDataContract>> GetSettings(string clientName, string clientSecret, string? instance, Guid runSessionId);
 
     Task RegisterSettings(string clientSecret, SettingsClientDefinitionDataContract clientDefinition);
+
+    Task<List<SettingMigrationRequestDataContract>> GetMigrateFromMigrationRequests(
+        string clientSecret,
+        SettingsClientDefinitionDataContract clientDefinition);
 
     Task DeleteClient(string clientName, string? instance);
 

--- a/src/api/Fig.Api/Services/SettingsService.cs
+++ b/src/api/Fig.Api/Services/SettingsService.cs
@@ -1,4 +1,6 @@
 using System.Diagnostics;
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.RegularExpressions;
 using Fig.Api.Constants;
 using Fig.Api.Converters;
@@ -16,6 +18,7 @@ using Fig.Common.Events;
 using Fig.Common.NetStandard.Json;
 using Fig.Contracts.SettingClients;
 using Fig.Contracts.SettingDefinitions;
+using Fig.Contracts.SettingMigrations;
 using Fig.Contracts.Settings;
 using Fig.Datalayer.BusinessEntities;
 using Fig.Datalayer.BusinessEntities.SettingValues;
@@ -108,6 +111,85 @@ public class SettingsService : AuthenticatedService, ISettingsService
         await RegisterSettingsInternal(clientSecret, client);
     }
 
+    public async Task<List<SettingMigrationRequestDataContract>> GetMigrateFromMigrationRequests(
+        string clientSecret,
+        SettingsClientDefinitionDataContract clientDefinition)
+    {
+        using var lockHandle = await _clientRegistrationLockService.AcquireLockAsync(clientDefinition.Name);
+
+        var configuration = await _configurationRepository.GetConfiguration();
+        if (!configuration.AllowMigrateFromMigrations)
+        {
+            _logger.LogInformation("MigrateFrom migrations are disabled in server configuration. Skipping migration preview for client {ClientName}", clientDefinition.Name.Sanitize());
+            return [];
+        }
+
+        var existingRegistrations = (await _settingClientRepository.GetAllInstancesOfClient(clientDefinition.Name)).ToList();
+        if (!existingRegistrations.Any())
+            return [];
+
+        var registrationStatus = _registrationStatusValidator.GetStatus(existingRegistrations, clientSecret);
+        if (registrationStatus == CurrentRegistrationStatus.DoesNotMatchSecret)
+        {
+            await _eventLogRepository.Add(_eventLogFactory.InvalidClientSecretAttempt(
+                clientDefinition.Name,
+                "preview migrate from migrations",
+                _requestIpAddress,
+                _requesterHostname));
+            throw new UnauthorizedAccessException(
+                $"Settings for client '{clientDefinition.Name}' have already been registered with a different secret.");
+        }
+
+        var updatedSettingDefinitions = _settingDefinitionConverter.Convert(clientDefinition);
+        var customMigrationTargets = updatedSettingDefinitions.Settings
+            .Where(setting => !string.IsNullOrWhiteSpace(setting.MigrateFrom) &&
+                              !string.IsNullOrWhiteSpace(setting.MigrateFromMigrationMethod))
+            .ToList();
+
+        if (!customMigrationTargets.Any())
+            return [];
+
+        var result = new List<SettingMigrationRequestDataContract>();
+        foreach (var registration in existingRegistrations)
+        {
+            foreach (var targetSetting in customMigrationTargets)
+            {
+                if (registration.Settings.Any(setting => setting.Name == targetSetting.Name))
+                    continue;
+
+                var sourceSetting = registration.Settings.FirstOrDefault(setting => setting.Name == targetSetting.MigrateFrom);
+                if (sourceSetting is null)
+                    continue;
+
+                if (sourceSetting.IsSecret && !targetSetting.IsSecret)
+                {
+                    throw new InvalidOperationException(
+                        $"Custom MigrateFrom migration from secret setting '{sourceSetting.Name}' " +
+                        $"to non-secret setting '{targetSetting.Name}' is not allowed.");
+                }
+
+                if (sourceSetting.IsSecret)
+                    await _secretStoreHandler.HydrateSecret(registration, sourceSetting.Name);
+
+                result.Add(new SettingMigrationRequestDataContract(
+                    sourceSetting.Name,
+                    targetSetting.Name,
+                    registration.Instance,
+                    sourceSetting.ValueType,
+                    targetSetting.ValueType,
+                    _settingConverter.Convert(
+                        sourceSetting.Value,
+                        sourceSetting.HasSchema(),
+                        sourceSetting.GetDataGridDefinition()),
+                    sourceSetting.IsSecret,
+                    targetSetting.IsSecret,
+                    ComputeMigrationFingerprint(sourceSetting)));
+            }
+        }
+
+        return result;
+    }
+
     private async Task RegisterSettingsInternal(string clientSecret, SettingsClientDefinitionDataContract client)
     {
         using Activity? activity = ApiActivitySource.Instance.StartActivity();
@@ -142,7 +224,17 @@ public class SettingsService : AuthenticatedService, ISettingsService
         stepSw?.Restart();
         var clientBusinessEntity = _settingDefinitionConverter.Convert(client);
         if (debugEnabled) _logger.LogDebug("SettingDefinitionConverter.Convert completed in {ElapsedMs} ms for client {ClientName}", stepSw!.ElapsedMilliseconds, sanitizedClientName);
-        
+
+        if (!configuration.AllowMigrateFromMigrations)
+        {
+            client.SettingMigrationResults.Clear();
+            foreach (var setting in clientBusinessEntity.Settings)
+            {
+                setting.MigrateFrom = null;
+                setting.MigrateFromMigrationMethod = null;
+            }
+        }
+
         clientBusinessEntity.Settings.ToList().ForEach(a => a.Validate());
 
         clientBusinessEntity.LastRegistration = DateTime.UtcNow;
@@ -184,7 +276,7 @@ public class SettingsService : AuthenticatedService, ISettingsService
         {
             if (debugEnabled) _logger.LogDebug("Starting updated registration for client {ClientName}", sanitizedClientName);
             stepSw?.Restart();
-            await HandleUpdatedRegistration(clientBusinessEntity, existingRegistrations);
+            await HandleUpdatedRegistration(clientBusinessEntity, existingRegistrations, client.SettingMigrationResults);
             if (debugEnabled) _logger.LogDebug("HandleUpdatedRegistration completed in {ElapsedMs} ms for client {ClientName}", stepSw!.ElapsedMilliseconds, sanitizedClientName);
             try
             {
@@ -609,7 +701,9 @@ public class SettingsService : AuthenticatedService, ISettingsService
 
     private List<RenamedSettingHistoryMigration> UpdateRegistrationsWithNewDefinitions(
         SettingClientBusinessEntity updatedSettingDefinitions,
-        List<SettingClientBusinessEntity> existingRegistrations)
+        List<SettingClientBusinessEntity> existingRegistrations,
+        List<SettingMigrationResultDataContract> migrationResults,
+        Dictionary<Guid, List<ChangedSetting>> secretChanges)
     {
         var settingValues = existingRegistrations.ToDictionary(
             a => a.Instance ?? "Default",
@@ -633,27 +727,43 @@ public class SettingsService : AuthenticatedService, ISettingsService
                     isMigrateFromMatch = matchingSetting != null;
                 }
 
-                if (matchingSetting != null && matchingSetting.ValueType == newSetting.ValueType)
+                var hasCustomMigrationMethod = !string.IsNullOrWhiteSpace(newSetting.MigrateFromMigrationMethod);
+                var customMigrationResult = isMigrateFromMatch && matchingSetting is not null && hasCustomMigrationMethod
+                    ? GetCustomMigrationResult(registration, matchingSetting, newSetting, migrationResults)
+                    : null;
+
+                if (matchingSetting != null && customMigrationResult is not null)
+                {
+                    ApplyCustomMigrationResult(newSetting, matchingSetting, customMigrationResult);
+                    AddSecretChangeIfRequired(secretChanges, registration, newSetting, matchingSetting.Value);
+                    AddRenamedHistoryMigrationIfRequired(
+                        renamedHistoryMigrations,
+                        updatedSettingDefinitions,
+                        registration,
+                        matchingSetting,
+                        newSetting);
+                }
+                else if (matchingSetting != null &&
+                         isMigrateFromMatch &&
+                         hasCustomMigrationMethod)
+                {
+                    throw new InvalidOperationException(
+                        $"Custom MigrateFrom migration result was not supplied for client '{updatedSettingDefinitions.Name}' " +
+                        $"setting '{newSetting.Name}' from source '{matchingSetting.Name}'.");
+                }
+                else if (matchingSetting != null && matchingSetting.ValueType == newSetting.ValueType)
                 {
                     newSetting.Value = matchingSetting.Value;
                     newSetting.LastChanged = matchingSetting.LastChanged;
                     if (isMigrateFromMatch)
                     {
-                        var sourceStillExistsInDefinitions = updatedSettingDefinitions.Settings
-                            .Any(s => s.Name == matchingSetting.Name);
-                        if (!sourceStillExistsInDefinitions)
-                        {
-                            renamedHistoryMigrations.Add(new RenamedSettingHistoryMigration(
-                                registration.Id,
-                                updatedSettingDefinitions.Name,
-                                registration.Instance,
-                                matchingSetting.Name,
-                                newSetting.Name,
-                                matchingSetting.Value,
-                                newSetting.Value,
-                                matchingSetting.IsSecret,
-                                newSetting.IsSecret));
-                        }
+                        AddSecretChangeIfRequired(secretChanges, registration, newSetting, matchingSetting.Value);
+                        AddRenamedHistoryMigrationIfRequired(
+                            renamedHistoryMigrations,
+                            updatedSettingDefinitions,
+                            registration,
+                            matchingSetting,
+                            newSetting);
                     }
                 }
                 else if (matchingSetting != null && isMigrateFromMatch)
@@ -666,12 +776,147 @@ public class SettingsService : AuthenticatedService, ISettingsService
                         matchingSetting.ValueType,
                         newSetting.ValueType);
                 }
+                else if (matchingSetting is null)
+                {
+                    AddSecretChangeIfRequired(secretChanges, registration, newSetting, null);
+                }
 
                 registration.Settings.Add(newSetting);
             }
         }
 
         return renamedHistoryMigrations;
+    }
+
+    private async Task HydrateSecretMigrateFromSources(
+        SettingClientBusinessEntity updatedSettingDefinitions,
+        List<SettingClientBusinessEntity> existingRegistrations)
+    {
+        var migrateFromTargets = updatedSettingDefinitions.Settings
+            .Where(setting => !string.IsNullOrWhiteSpace(setting.MigrateFrom))
+            .ToList();
+        if (!migrateFromTargets.Any())
+            return;
+
+        foreach (var registration in existingRegistrations)
+        {
+            var existingSettingNames = registration.Settings
+                .Select(setting => setting.Name)
+                .ToHashSet(StringComparer.Ordinal);
+            var hydratedSourceSettings = new HashSet<string>(StringComparer.Ordinal);
+
+            foreach (var targetSetting in migrateFromTargets)
+            {
+                if (existingSettingNames.Contains(targetSetting.Name) || !targetSetting.IsSecret)
+                    continue;
+
+                var sourceSetting = registration.Settings.FirstOrDefault(setting => setting.Name == targetSetting.MigrateFrom);
+                if (sourceSetting is not { IsSecret: true } || sourceSetting.Value?.GetValue() is not null)
+                    continue;
+
+                if (hydratedSourceSettings.Add(sourceSetting.Name))
+                    await _secretStoreHandler.HydrateSecret(registration, sourceSetting.Name);
+            }
+        }
+    }
+
+    private void ApplyCustomMigrationResult(
+        SettingBusinessEntity newSetting,
+        SettingBusinessEntity matchingSetting,
+        SettingMigrationResultDataContract migrationResult)
+    {
+        if (matchingSetting.IsSecret && !newSetting.IsSecret)
+        {
+            throw new InvalidOperationException(
+                $"Custom MigrateFrom migration from secret setting '{matchingSetting.Name}' " +
+                $"to non-secret setting '{newSetting.Name}' is not allowed.");
+        }
+
+        var currentFingerprint = ComputeMigrationFingerprint(matchingSetting);
+        if (!string.Equals(currentFingerprint, migrationResult.SourceValueFingerprint, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                $"Unable to apply custom MigrateFrom migration for setting '{newSetting.Name}' because " +
+                $"the source setting '{matchingSetting.Name}' changed while registration was in progress.");
+        }
+
+        var migratedValue = _settingConverter.Convert(migrationResult.MigratedValue, newSetting);
+        newSetting.Value = migratedValue;
+        newSetting.LastChanged = matchingSetting.LastChanged;
+        newSetting.Validate();
+    }
+
+    private static SettingMigrationResultDataContract? GetCustomMigrationResult(
+        SettingClientBusinessEntity registration,
+        SettingBusinessEntity matchingSetting,
+        SettingBusinessEntity newSetting,
+        List<SettingMigrationResultDataContract> migrationResults)
+    {
+        return migrationResults.FirstOrDefault(result =>
+            result.SourceSettingName == matchingSetting.Name &&
+            result.TargetSettingName == newSetting.Name &&
+            result.Instance == registration.Instance);
+    }
+
+    private static void AddSecretChangeIfRequired(
+        Dictionary<Guid, List<ChangedSetting>> secretChanges,
+        SettingClientBusinessEntity registration,
+        SettingBusinessEntity setting,
+        SettingValueBaseBusinessEntity? originalValue)
+    {
+        if (!setting.IsSecret || setting.Value?.GetValue() is null)
+            return;
+
+        if (!secretChanges.TryGetValue(registration.Id, out var changes))
+        {
+            changes = [];
+            secretChanges[registration.Id] = changes;
+        }
+
+        changes.Add(new ChangedSetting(
+            setting.Name,
+            originalValue,
+            setting.Value,
+            setting.IsSecret,
+            setting.GetDataGridDefinition(),
+            setting.IsExternallyManaged));
+    }
+
+    private static void AddRenamedHistoryMigrationIfRequired(
+        List<RenamedSettingHistoryMigration> renamedHistoryMigrations,
+        SettingClientBusinessEntity updatedSettingDefinitions,
+        SettingClientBusinessEntity registration,
+        SettingBusinessEntity matchingSetting,
+        SettingBusinessEntity newSetting)
+    {
+        var sourceStillExistsInDefinitions = updatedSettingDefinitions.Settings
+            .Any(s => s.Name == matchingSetting.Name);
+        if (sourceStillExistsInDefinitions)
+            return;
+
+        renamedHistoryMigrations.Add(new RenamedSettingHistoryMigration(
+            registration.Id,
+            updatedSettingDefinitions.Name,
+            registration.Instance,
+            matchingSetting.Name,
+            newSetting.Name,
+            matchingSetting.Value,
+            newSetting.Value,
+            matchingSetting.IsSecret,
+            newSetting.IsSecret));
+    }
+
+    private static string ComputeMigrationFingerprint(SettingBusinessEntity setting)
+    {
+        var payload = JsonConvert.SerializeObject(new
+        {
+            setting.Name,
+            ValueType = setting.ValueType?.AssemblyQualifiedName,
+            Value = setting.IsSecret ? null : setting.Value,
+            LastChangedUtcTicks = setting.LastChanged?.ToUniversalTime().Ticks
+        }, JsonSettings.FigDefault);
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(payload));
+        return Convert.ToHexString(hash);
     }
 
     private async Task RecordInitialSettingValues(SettingClientBusinessEntity client)
@@ -758,16 +1003,27 @@ public class SettingsService : AuthenticatedService, ISettingsService
         }
     }
 
-    private async Task HandleUpdatedRegistration(SettingClientBusinessEntity clientBusinessEntity,
-        List<SettingClientBusinessEntity> existingRegistrations)
+    private async Task HandleUpdatedRegistration(
+        SettingClientBusinessEntity clientBusinessEntity,
+        List<SettingClientBusinessEntity> existingRegistrations,
+        List<SettingMigrationResultDataContract> migrationResults)
     {
         using Activity? activity = ApiActivitySource.Instance.StartActivity();
         _logger.LogInformation("Updated registration for client {ClientName}", clientBusinessEntity.Name);
 
-        var renamedHistoryMigrations = UpdateRegistrationsWithNewDefinitions(clientBusinessEntity, existingRegistrations);
+        var secretChanges = new Dictionary<Guid, List<ChangedSetting>>();
+        await HydrateSecretMigrateFromSources(clientBusinessEntity, existingRegistrations);
+        var renamedHistoryMigrations = UpdateRegistrationsWithNewDefinitions(
+            clientBusinessEntity,
+            existingRegistrations,
+            migrationResults,
+            secretChanges);
         foreach (var updatedDefinition in existingRegistrations)
         {
-            await _secretStoreHandler.SaveSecrets(updatedDefinition);
+            if (secretChanges.TryGetValue(updatedDefinition.Id, out var changes) && changes.Any())
+                await _secretStoreHandler.SaveSecrets(updatedDefinition, changes);
+
+            await _secretStoreHandler.ClearSecrets(updatedDefinition);
             updatedDefinition.LastRegistration = DateTime.UtcNow;
             await _settingClientRepository.UpdateClient(updatedDefinition);
             await _eventLogRepository.Add(

--- a/src/api/Fig.Datalayer/BusinessEntities/FigConfigurationBusinessEntity.cs
+++ b/src/api/Fig.Datalayer/BusinessEntities/FigConfigurationBusinessEntity.cs
@@ -38,4 +38,6 @@ public class FigConfigurationBusinessEntity
     public virtual int? ApiStatusCleanupDays { get; set; } = 90;
     
     public virtual int? SettingHistoryCleanupDays { get; set; }
+    
+    public virtual bool AllowMigrateFromMigrations { get; set; } = true;
 }

--- a/src/api/Fig.Datalayer/BusinessEntities/SettingBusinessEntity.cs
+++ b/src/api/Fig.Datalayer/BusinessEntities/SettingBusinessEntity.cs
@@ -142,6 +142,8 @@ public class SettingBusinessEntity
 
     public virtual string? MigrateFrom { get; set; }
 
+    public virtual string? MigrateFromMigrationMethod { get; set; }
+
     public virtual string? DependsOnValidValuesAsJson
     {
         get

--- a/src/api/Fig.Datalayer/Mappings/FigConfigurationMapping.cs
+++ b/src/api/Fig.Datalayer/Mappings/FigConfigurationMapping.cs
@@ -28,5 +28,6 @@ public class FigConfigurationMapping : ClassMapping<FigConfigurationBusinessEnti
         Property(x => x.EventLogsCleanupDays, x => x.Column("event_logs_cleanup_days"));
         Property(x => x.ApiStatusCleanupDays, x => x.Column("api_status_cleanup_days"));
         Property(x => x.SettingHistoryCleanupDays, x => x.Column("setting_history_cleanup_days"));
+        Property(x => x.AllowMigrateFromMigrations, x => x.Column("allow_migrate_from_migrations"));
     }
 }

--- a/src/api/Fig.Datalayer/Mappings/SettingMap.cs
+++ b/src/api/Fig.Datalayer/Mappings/SettingMap.cs
@@ -96,6 +96,7 @@ public class SettingMap : ClassMapping<SettingBusinessEntity>
         });
         Property(x => x.InitOnlyExport, x => x.Column("init_only_export"));
         Property(x => x.MigrateFrom, x => x.Column("migrate_from"));
+        Property(x => x.MigrateFromMigrationMethod, x => x.Column("migrate_from_migration_method"));
         Property(x => x.HeadingAsJson, x =>
         {
             x.Column("heading_json");

--- a/src/client/Fig.Client.Abstractions/Attributes/MigrateFromAttribute.cs
+++ b/src/client/Fig.Client.Abstractions/Attributes/MigrateFromAttribute.cs
@@ -8,10 +8,13 @@ namespace Fig.Client.Abstractions.Attributes;
 [AttributeUsage(AttributeTargets.Property)]
 public class MigrateFromAttribute : Attribute
 {
-    public MigrateFromAttribute(string previousSettingName)
+    public MigrateFromAttribute(string previousSettingName, string? migrationMethodName = null)
     {
         PreviousSettingName = previousSettingName;
+        MigrationMethodName = migrationMethodName;
     }
 
     public string PreviousSettingName { get; }
+
+    public string? MigrationMethodName { get; }
 }

--- a/src/client/Fig.Client/ConfigurationProvider/ApiCommunicationHandler.cs
+++ b/src/client/Fig.Client/ConfigurationProvider/ApiCommunicationHandler.cs
@@ -17,6 +17,7 @@ using Fig.Contracts.CustomActions;
 using Fig.Contracts.LookupTable;
 using Fig.Contracts.SettingClients;
 using Fig.Contracts.SettingDefinitions;
+using Fig.Contracts.SettingMigrations;
 using Fig.Contracts.Settings;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
@@ -78,7 +79,8 @@ public class ApiCommunicationHandler : IApiCommunicationHandler, IFigClientBridg
                 settings.Settings,
                 settings.ClientSettingOverrides,
                 settings.CustomActions,
-                settings.ClientVersion);
+                settings.ClientVersion,
+                settings.SettingMigrationResults);
         }
         else
         {
@@ -156,6 +158,38 @@ public class ApiCommunicationHandler : IApiCommunicationHandler, IFigClientBridg
         }
     }
 
+    public async Task<List<SettingMigrationRequestDataContract>> GetMigrateFromMigrationRequests(SettingsClientDefinitionDataContract settings)
+    {
+        if (!settings.Settings.Any(HasCustomMigrateFromMigration))
+            return [];
+
+        await _capabilityProvider.FetchAsync(force: true).ConfigureAwait(false);
+        if (!_capabilityProvider.Supports("migrateFromClientTransforms"))
+        {
+            throw new FigRegistrationException(new ErrorResultDataContract(
+                "UnsupportedCapability",
+                "The Fig API does not support custom MigrateFrom migration methods.",
+                "Upgrade the Fig API or remove the migration method from the MigrateFrom attribute.",
+                null));
+        }
+
+        var secret = await _clientSecretProvider.GetSecret(_clientName);
+        var json = JsonConvert.SerializeObject(settings, JsonSettings.FigDefault);
+        using var request = new HttpRequestMessage(HttpMethod.Post, "/clients/migrations/preview");
+        request.Content = BuildContent(json);
+        request.Headers.TryAddWithoutValidation("ClientSecret", secret);
+
+        using var response = await _httpClient.SendAsync(request);
+        if (!response.IsSuccessStatusCode)
+        {
+            var error = await GetErrorResult(response);
+            throw new FigRegistrationException(error);
+        }
+
+        var result = await response.Content.ReadAsStringAsync();
+        return JsonConvert.DeserializeObject<List<SettingMigrationRequestDataContract>>(result, JsonSettings.FigDefault) ?? [];
+    }
+
     [Conditional("DEBUG")]
     private void LogAmbiguousMigrateFromSources(SettingsClientDefinitionDataContract settings)
     {
@@ -169,6 +203,12 @@ public class ApiCommunicationHandler : IApiCommunicationHandler, IFigClientBridg
                 settings.Name,
                 setting.MigrateFrom);
         }
+    }
+
+    private static bool HasCustomMigrateFromMigration(SettingDefinitionDataContract setting)
+    {
+        return !string.IsNullOrWhiteSpace(setting.MigrateFrom) &&
+               !string.IsNullOrWhiteSpace(setting.MigrateFromMigrationMethod);
     }
 
     private async Task PostDescriptionAsync(string clientName, string? instance, string description, string secret)

--- a/src/client/Fig.Client/ConfigurationProvider/FigConfigurationProvider.cs
+++ b/src/client/Fig.Client/ConfigurationProvider/FigConfigurationProvider.cs
@@ -11,6 +11,8 @@ using Fig.Client.Events;
 using Fig.Client.Exceptions;
 using Fig.Client.OfflineSettings;
 using Fig.Client.Status;
+using Fig.Client.Migration;
+using Fig.Contracts.SettingDefinitions;
 using Fig.Common.NetStandard.IpAddress;
 using Fig.Client.ExtensionMethods;
 using Fig.Client.Parsers;
@@ -120,6 +122,7 @@ public class FigConfigurationProvider : Microsoft.Extensions.Configuration.Confi
     private void RegisterSettings()
     {
         var settingsDataContract = _settings.CreateDataContract(_source.ClientName, _source.AutomaticallyGenerateHeadings);
+        var migrateFromDisabled = IsMigrateFromDisabled();
         _secretSettings = settingsDataContract.Settings
             .Where(a => a.IsSecret)
             .Select(a => a.Name)
@@ -138,27 +141,70 @@ public class FigConfigurationProvider : Microsoft.Extensions.Configuration.Confi
                 "Consider reducing the size of the description by removing or resizing images", sizeInMb);
         }
 
+        if (migrateFromDisabled)
+        {
+            _logger.LogInformation("MigrateFrom is disabled via FIG_DISABLE_MIGRATE_FROM environment variable. Clearing migration metadata before registration.");
+            foreach (var setting in settingsDataContract.Settings)
+            {
+                setting.MigrateFrom = null;
+                setting.MigrateFromMigrationMethod = null;
+                setting.MigrateFromMigrationMethodInfo = null;
+            }
+        }
+
         try
         {
+            if (!migrateFromDisabled)
+                TryApplyMigrateFromMigrations(settingsDataContract);
             _apiCommunicationHandler.RegisterWithFigApi(settingsDataContract).GetAwaiter()
                 .GetResult();
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
         {
-            if (ex is HttpRequestException or TaskCanceledException)
-            {
-                _logger.LogError("Failed to register settings with Fig API. {ExceptionMessage}", ex.Message);
-            }
-            else if (ex is FigRegistrationException registrationException)
-            {
-                var message = $"Failed to register settings with Fig API: {registrationException.Result}";
-                _statusMonitor.SetFailedRegistration(message);
-                _logger.LogError(ex, "{Message}", message);
-            }
-            else
-            {
-                _logger.LogError(ex, "Failed to register settings with Fig API");
-            }
+            _logger.LogError(ex, "Failed to register settings with Fig API. {ExceptionMessage}", ex.Message);
+        }
+        catch (FigRegistrationException registrationException)
+        {
+            var message = $"Failed to register settings with Fig API: {registrationException.Result}";
+            _statusMonitor.SetFailedRegistration(message);
+            _logger.LogError(registrationException, "{Message}", message);
+        }
+    }
+
+    private static bool IsMigrateFromDisabled()
+    {
+        var value = Environment.GetEnvironmentVariable("FIG_DISABLE_MIGRATE_FROM");
+        return !string.IsNullOrWhiteSpace(value) &&
+               (value.Equals("true", StringComparison.OrdinalIgnoreCase) || value == "1");
+    }
+
+    private void ApplyMigrateFromMigrations(SettingsClientDefinitionDataContract settingsDataContract)
+    {
+        if (!settingsDataContract.Settings.Any(setting => setting.MigrateFromMigrationMethodInfo is not null))
+            return;
+
+        var migrationRequests = _apiCommunicationHandler.GetMigrateFromMigrationRequests(settingsDataContract)
+            .GetAwaiter()
+            .GetResult();
+        if (migrationRequests == null || !migrationRequests.Any())
+            return;
+
+        settingsDataContract.SettingMigrationResults =
+            new MigrateFromMigrationConverter().Convert(settingsDataContract, migrationRequests);
+    }
+
+    private void TryApplyMigrateFromMigrations(SettingsClientDefinitionDataContract settingsDataContract)
+    {
+        try
+        {
+            ApplyMigrateFromMigrations(settingsDataContract);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or FigRegistrationException)
+        {
+            _logger.LogWarning(
+                ex,
+                "Skipping MigrateFrom preview for client {ClientName}; registration will continue without previewed migration results",
+                _source.ClientName);
         }
     }
 

--- a/src/client/Fig.Client/ConfigurationProvider/IApiCommunicationHandler.cs
+++ b/src/client/Fig.Client/ConfigurationProvider/IApiCommunicationHandler.cs
@@ -1,4 +1,5 @@
 ﻿using Fig.Contracts.SettingDefinitions;
+using Fig.Contracts.SettingMigrations;
 using Fig.Contracts.Settings;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -8,6 +9,8 @@ namespace Fig.Client.ConfigurationProvider;
 public interface IApiCommunicationHandler
 {
     Task RegisterWithFigApi(SettingsClientDefinitionDataContract settings);
+
+    Task<List<SettingMigrationRequestDataContract>> GetMigrateFromMigrationRequests(SettingsClientDefinitionDataContract settings);
 
     Task<List<SettingDataContract>> RequestConfiguration();
 }

--- a/src/client/Fig.Client/Migration/MigrateFromMigrationConverter.cs
+++ b/src/client/Fig.Client/Migration/MigrateFromMigrationConverter.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using Fig.Client.DefaultValue;
+using Fig.Common.NetStandard.Json;
+using Fig.Contracts;
+using Fig.Contracts.ExtensionMethods;
+using Fig.Contracts.SettingDefinitions;
+using Fig.Contracts.SettingMigrations;
+using Fig.Contracts.Settings;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Fig.Client.Migration;
+
+internal class MigrateFromMigrationConverter
+{
+    private static readonly JsonSerializerSettings SafeJsonSettings = new()
+    {
+        Culture = CultureInfo.InvariantCulture,
+        TypeNameHandling = TypeNameHandling.None
+    };
+
+    private readonly IDataGridDefaultValueProvider _dataGridDefaultValueProvider;
+
+    public MigrateFromMigrationConverter()
+        : this(new DataGridDefaultValueProvider())
+    {
+    }
+
+    internal MigrateFromMigrationConverter(IDataGridDefaultValueProvider dataGridDefaultValueProvider)
+    {
+        _dataGridDefaultValueProvider = dataGridDefaultValueProvider;
+    }
+
+    public List<SettingMigrationResultDataContract> Convert(
+        SettingsClientDefinitionDataContract settings,
+        IEnumerable<SettingMigrationRequestDataContract> requests)
+    {
+        var targetSettings = settings.Settings
+            .Where(setting => setting.MigrateFromMigrationMethodInfo is not null)
+            .ToDictionary(setting => setting.Name, StringComparer.Ordinal);
+
+        var results = new List<SettingMigrationResultDataContract>();
+        foreach (var request in requests)
+        {
+            if (!targetSettings.TryGetValue(request.TargetSettingName, out var targetSetting))
+                continue;
+
+            if (request.SourceIsSecret && !request.TargetIsSecret)
+            {
+                throw new InvalidOperationException(
+                    $"Custom MigrateFrom migration from secret setting '{request.SourceSettingName}' " +
+                    $"to non-secret setting '{request.TargetSettingName}' is not allowed.");
+            }
+
+            var method = targetSetting.MigrateFromMigrationMethodInfo!;
+            var migratedValue = InvokeMigrationMethod(method, request.SourceValue);
+            var contractValue = ConvertResultToContract(migratedValue, targetSetting);
+
+            results.Add(new SettingMigrationResultDataContract(
+                request.SourceSettingName,
+                request.TargetSettingName,
+                request.Instance,
+                contractValue,
+                request.SourceValueFingerprint));
+        }
+
+        return results;
+    }
+
+    private static object? InvokeMigrationMethod(MethodInfo method, SettingValueBaseDataContract? sourceValue)
+    {
+        var parameterType = method.GetParameters()[0].ParameterType;
+        var parameter = ConvertParameter(sourceValue?.GetValue(), parameterType);
+
+        try
+        {
+            return method.Invoke(null, [parameter]);
+        }
+        catch (TargetInvocationException ex) when (ex.InnerException is not null)
+        {
+            throw new InvalidOperationException(
+                $"MigrateFrom migration method '{method.Name}' failed: {ex.InnerException.Message}",
+                ex.InnerException);
+        }
+    }
+
+    private SettingValueBaseDataContract ConvertResultToContract(object? migratedValue, SettingDefinitionDataContract targetSetting)
+    {
+        if (targetSetting.DataGridDefinition is not null)
+        {
+            if (migratedValue is List<Dictionary<string, object?>> rows)
+                return new DataGridSettingDataContract(rows);
+
+            var dataGridValue = _dataGridDefaultValueProvider.Convert(migratedValue, targetSetting.DataGridDefinition.Columns);
+            if (dataGridValue is null)
+            {
+                throw new InvalidOperationException(
+                    $"Migration result for setting '{targetSetting.Name}' could not be converted to a data grid value.");
+            }
+
+            return new DataGridSettingDataContract(dataGridValue);
+        }
+
+        if (!string.IsNullOrWhiteSpace(targetSetting.JsonSchema))
+        {
+            var json = migratedValue as string ??
+                       JsonConvert.SerializeObject(migratedValue, Formatting.Indented, SafeJsonSettings);
+            return new JsonSettingDataContract(json);
+        }
+
+        var targetType = targetSetting.ValueType ?? migratedValue?.GetType();
+        if (targetType is null)
+            return new StringSettingDataContract(null);
+
+        return ValueDataContractFactory.CreateContract(migratedValue, targetType);
+    }
+
+    private static object? ConvertParameter(object? value, Type parameterType)
+    {
+        if (parameterType == typeof(object))
+            return value;
+
+        if (value is null)
+        {
+            if (parameterType.IsValueType && Nullable.GetUnderlyingType(parameterType) is null)
+                throw new InvalidOperationException($"Cannot pass null to non-nullable migration parameter type {parameterType.FullName}.");
+
+            return null;
+        }
+
+        var targetType = Nullable.GetUnderlyingType(parameterType) ?? parameterType;
+        if (targetType.IsInstanceOfType(value))
+            return value;
+
+        if (value is JToken token)
+            return token.ToObject(targetType, JsonSerializer.Create(SafeJsonSettings));
+
+        if (targetType.IsEnum())
+        {
+            var enumStringValue = System.Convert.ToString(value, CultureInfo.InvariantCulture)!;
+            try
+            {
+                return Enum.Parse(targetType, enumStringValue, ignoreCase: true);
+            }
+            catch (ArgumentException)
+            {
+                throw new InvalidOperationException(
+                    $"Cannot convert value '{enumStringValue}' to enum type '{targetType.FullName}'. " +
+                    $"Valid values are: {string.Join(", ", Enum.GetNames(targetType))}");
+            }
+        }
+
+        if (value is string stringValue)
+        {
+            if (targetType == typeof(string))
+                return stringValue;
+
+            var figPropertyType = targetType.FigPropertyType();
+            if (figPropertyType is not FigPropertyType.Unsupported and not FigPropertyType.DataGrid and not FigPropertyType.StringList)
+                return ConvertSimpleValue(stringValue, targetType);
+
+            return JsonConvert.DeserializeObject(stringValue, targetType, SafeJsonSettings);
+        }
+
+        var converter = TypeDescriptor.GetConverter(targetType);
+        if (converter.CanConvertFrom(value.GetType()))
+            return converter.ConvertFrom(null, CultureInfo.InvariantCulture, value);
+
+        return System.Convert.ChangeType(value, targetType, CultureInfo.InvariantCulture);
+    }
+
+    private static object? ConvertSimpleValue(string value, Type targetType)
+    {
+        var converter = TypeDescriptor.GetConverter(targetType);
+        if (converter.CanConvertFrom(typeof(string)))
+            return converter.ConvertFromInvariantString(value);
+
+        return System.Convert.ChangeType(value, targetType, CultureInfo.InvariantCulture);
+    }
+}

--- a/src/client/Fig.Client/SettingDefinitionFactory.cs
+++ b/src/client/Fig.Client/SettingDefinitionFactory.cs
@@ -232,6 +232,8 @@ internal class SettingDefinitionFactory : ISettingDefinitionFactory
                 break;
             case MigrateFromAttribute migrateFromAttribute:
                 setting.MigrateFrom = ResolveMigrateFromName(migrateFromAttribute, settingDetails.Name);
+                setting.MigrateFromMigrationMethodInfo = ValidateMigrateFromMigrationMethod(migrateFromAttribute, settingDetails);
+                setting.MigrateFromMigrationMethod = setting.MigrateFromMigrationMethodInfo?.Name;
                 break;
         }
     }
@@ -478,6 +480,79 @@ internal class SettingDefinitionFactory : ISettingDefinitionFactory
 
         var nestedPrefix = propertyName.Substring(0, lastSeparatorIndex);
         return $"{nestedPrefix}{Constants.SettingPathSeparator}{attribute.PreviousSettingName}";
+    }
+
+    private static MethodInfo? ValidateMigrateFromMigrationMethod(MigrateFromAttribute attribute, SettingDetails settingDetails)
+    {
+        if (attribute.MigrationMethodName is null)
+            return null;
+
+        if (string.IsNullOrWhiteSpace(attribute.MigrationMethodName))
+        {
+            throw new InvalidSettingException(
+                $"[MigrateFrom] on '{settingDetails.Name}': Migration method name cannot be empty. " +
+                $"Use nameof(YourMigrationMethod) or omit the migration method for same-type renames.");
+        }
+
+        var parentType = settingDetails.ParentInstance.GetType();
+        var matchingMethods = parentType
+            .GetMethods(BindingFlags.Public | BindingFlags.Static)
+            .Where(method => method.Name == attribute.MigrationMethodName)
+            .ToList();
+
+        if (matchingMethods.Count == 0)
+        {
+            throw new InvalidSettingException(
+                $"[MigrateFrom] on '{settingDetails.Name}': Migration method '{attribute.MigrationMethodName}' " +
+                $"was not found as a public static method on {parentType.FullName}.");
+        }
+
+        if (matchingMethods.Count > 1)
+        {
+            throw new InvalidSettingException(
+                $"[MigrateFrom] on '{settingDetails.Name}': Migration method '{attribute.MigrationMethodName}' " +
+                $"has multiple overloads on {parentType.FullName}. Use a unique method name.");
+        }
+
+        var method = matchingMethods[0];
+        if (method.ContainsGenericParameters)
+        {
+            throw new InvalidSettingException(
+                $"[MigrateFrom] on '{settingDetails.Name}': Migration method '{attribute.MigrationMethodName}' cannot be generic.");
+        }
+
+        var parameters = method.GetParameters();
+        if (parameters.Length != 1)
+        {
+            throw new InvalidSettingException(
+                $"[MigrateFrom] on '{settingDetails.Name}': Migration method '{attribute.MigrationMethodName}' " +
+                $"must have exactly one parameter.");
+        }
+
+        if (!IsReturnTypeCompatible(settingDetails.Property.PropertyType, method.ReturnType))
+        {
+            throw new InvalidSettingException(
+                $"[MigrateFrom] on '{settingDetails.Name}': Migration method '{attribute.MigrationMethodName}' " +
+                $"returns {method.ReturnType.FullName}, which is not compatible with target setting type " +
+                $"{settingDetails.Property.PropertyType.FullName}.");
+        }
+
+        return method;
+    }
+
+    private static bool IsReturnTypeCompatible(Type targetType, Type returnType)
+    {
+        if (returnType == typeof(void))
+            return false;
+
+        if (targetType.IsAssignableFrom(returnType))
+            return true;
+
+        var targetUnderlyingType = Nullable.GetUnderlyingType(targetType);
+        if (targetUnderlyingType is not null && targetUnderlyingType == returnType)
+            return true;
+
+        return targetType.IsSupportedDataGridType() && returnType.IsSupportedDataGridType();
     }
 
     private void ThrowIfNotString(PropertyInfo settingProperty)

--- a/src/common/Fig.Contracts/Capabilities/FigCapabilitiesDataContract.cs
+++ b/src/common/Fig.Contracts/Capabilities/FigCapabilitiesDataContract.cs
@@ -19,7 +19,8 @@ public class FigCapabilitiesDataContract
 
     /// <summary>
     /// Stable feature tokens that clients may check.
-    /// Current tokens: "deferredDescriptionRegistration", "requestCompression".
+    /// Current tokens: "deferredDescriptionRegistration", "requestCompression",
+    /// and "migrateFromClientTransforms" when custom migrate-from preview is enabled.
     /// </summary>
     public IReadOnlyList<string> SupportedFeatures { get; }
 }

--- a/src/common/Fig.Contracts/Configuration/FigConfigurationDataContract.cs
+++ b/src/common/Fig.Contracts/Configuration/FigConfigurationDataContract.cs
@@ -38,6 +38,8 @@ namespace Fig.Contracts.Configuration
         
         public int? SettingHistoryCleanupDays { get; set; }
 
+        public bool AllowMigrateFromMigrations { get; set; } = true;
+
         public override string ToString()
         {
             StringBuilder sb = new StringBuilder();

--- a/src/common/Fig.Contracts/ImportExport/SettingExportDataContract.cs
+++ b/src/common/Fig.Contracts/ImportExport/SettingExportDataContract.cs
@@ -40,7 +40,8 @@ namespace Fig.Contracts.ImportExport
             IList<string>? dependsOnValidValues = null,
             HeadingExportDataContract? heading = null,
             bool? initOnlyExport = null,
-            string? migrateFrom = null)
+            string? migrateFrom = null,
+            string? migrateFromMigrationMethod = null)
         {
             Name = name;
             Description = description;
@@ -75,6 +76,7 @@ namespace Fig.Contracts.ImportExport
             InitOnlyExport = initOnlyExport;
             Heading = heading;
             MigrateFrom = migrateFrom;
+            MigrateFromMigrationMethod = migrateFromMigrationMethod;
         }
 
         public string Name { get; }
@@ -144,6 +146,9 @@ namespace Fig.Contracts.ImportExport
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string? MigrateFrom { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public string? MigrateFromMigrationMethod { get; set; }
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public SettingLastChangedDataContract? LastChangedDetails { get; set; }

--- a/src/common/Fig.Contracts/SettingDefinitions/SettingDefinitionDataContract.cs
+++ b/src/common/Fig.Contracts/SettingDefinitions/SettingDefinitionDataContract.cs
@@ -1,7 +1,9 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.Reflection;
 using Fig.Client.Abstractions.Data;
 using Fig.Contracts.Settings;
+using Newtonsoft.Json;
 
 namespace Fig.Contracts.SettingDefinitions
 {
@@ -38,7 +40,8 @@ namespace Fig.Contracts.SettingDefinitions
             IList<string>? dependsOnValidValues = null,
             HeadingDataContract? heading = null,
             bool? initOnlyExport = null,
-            string? migrateFrom = null)
+            string? migrateFrom = null,
+            string? migrateFromMigrationMethod = null)
         {
             Name = name;
             Description = description;
@@ -72,6 +75,7 @@ namespace Fig.Contracts.SettingDefinitions
             Heading = heading;
             InitOnlyExport = initOnlyExport;
             MigrateFrom = migrateFrom;
+            MigrateFromMigrationMethod = migrateFromMigrationMethod;
         }
 
         public string Name { get; }
@@ -137,5 +141,10 @@ namespace Fig.Contracts.SettingDefinitions
         public bool? InitOnlyExport { get; set; }
 
         public string? MigrateFrom { get; set; }
+
+        public string? MigrateFromMigrationMethod { get; set; }
+
+        [JsonIgnore]
+        public MethodInfo? MigrateFromMigrationMethodInfo { get; set; }
     }
 }

--- a/src/common/Fig.Contracts/SettingDefinitions/SettingsClientDefinitionDataContract.cs
+++ b/src/common/Fig.Contracts/SettingDefinitions/SettingsClientDefinitionDataContract.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Fig.Contracts.CustomActions;
+using Fig.Contracts.SettingMigrations;
 using Fig.Contracts.Settings;
 using Fig.Contracts.SettingVerification;
 
@@ -15,7 +16,8 @@ namespace Fig.Contracts.SettingDefinitions
             List<SettingDefinitionDataContract> settings,
             IEnumerable<SettingDataContract> clientSettingOverrides,
             List<CustomActionDefinitionDataContract>? customActions = null,
-            string? clientVersion = null)
+            string? clientVersion = null,
+            List<SettingMigrationResultDataContract>? settingMigrationResults = null)
         {
             Name = name;
             Description = description;
@@ -25,6 +27,7 @@ namespace Fig.Contracts.SettingDefinitions
             ClientSettingOverrides = clientSettingOverrides;
             CustomActions = customActions ?? new List<CustomActionDefinitionDataContract>();
             ClientVersion = clientVersion;
+            SettingMigrationResults = settingMigrationResults ?? new List<SettingMigrationResultDataContract>();
         }
 
         public string Name { get; }
@@ -45,6 +48,8 @@ namespace Fig.Contracts.SettingDefinitions
         /// The version of the client application at the time of registration.
         /// </summary>
         public string? ClientVersion { get; }
+
+        public List<SettingMigrationResultDataContract> SettingMigrationResults { get; set; }
         
         [Obsolete("Removed in Fig 2.0")]
         public List<SettingVerificationDefinitionDataContract> Verifications { get; } = [];

--- a/src/common/Fig.Contracts/SettingMigrations/SettingMigrationRequestDataContract.cs
+++ b/src/common/Fig.Contracts/SettingMigrations/SettingMigrationRequestDataContract.cs
@@ -1,0 +1,47 @@
+using System;
+using Fig.Contracts.Settings;
+
+namespace Fig.Contracts.SettingMigrations;
+
+public class SettingMigrationRequestDataContract
+{
+    public SettingMigrationRequestDataContract(
+        string sourceSettingName,
+        string targetSettingName,
+        string? instance,
+        Type? sourceValueType,
+        Type? targetValueType,
+        SettingValueBaseDataContract? sourceValue,
+        bool sourceIsSecret,
+        bool targetIsSecret,
+        string sourceValueFingerprint)
+    {
+        SourceSettingName = sourceSettingName;
+        TargetSettingName = targetSettingName;
+        Instance = instance;
+        SourceValueType = sourceValueType;
+        TargetValueType = targetValueType;
+        SourceValue = sourceValue;
+        SourceIsSecret = sourceIsSecret;
+        TargetIsSecret = targetIsSecret;
+        SourceValueFingerprint = sourceValueFingerprint;
+    }
+
+    public string SourceSettingName { get; set; }
+
+    public string TargetSettingName { get; set; }
+
+    public string? Instance { get; set; }
+
+    public Type? SourceValueType { get; set; }
+
+    public Type? TargetValueType { get; set; }
+
+    public SettingValueBaseDataContract? SourceValue { get; set; }
+
+    public bool SourceIsSecret { get; set; }
+
+    public bool TargetIsSecret { get; set; }
+
+    public string SourceValueFingerprint { get; set; }
+}

--- a/src/common/Fig.Contracts/SettingMigrations/SettingMigrationResultDataContract.cs
+++ b/src/common/Fig.Contracts/SettingMigrations/SettingMigrationResultDataContract.cs
@@ -1,0 +1,30 @@
+using Fig.Contracts.Settings;
+
+namespace Fig.Contracts.SettingMigrations;
+
+public class SettingMigrationResultDataContract
+{
+    public SettingMigrationResultDataContract(
+        string sourceSettingName,
+        string targetSettingName,
+        string? instance,
+        SettingValueBaseDataContract? migratedValue,
+        string sourceValueFingerprint)
+    {
+        SourceSettingName = sourceSettingName;
+        TargetSettingName = targetSettingName;
+        Instance = instance;
+        MigratedValue = migratedValue;
+        SourceValueFingerprint = sourceValueFingerprint;
+    }
+
+    public string SourceSettingName { get; set; }
+
+    public string TargetSettingName { get; set; }
+
+    public string? Instance { get; set; }
+
+    public SettingValueBaseDataContract? MigratedValue { get; set; }
+
+    public string SourceValueFingerprint { get; set; }
+}

--- a/src/tests/Fig.Integration.Test/Api/CapabilitiesTests.cs
+++ b/src/tests/Fig.Integration.Test/Api/CapabilitiesTests.cs
@@ -32,6 +32,17 @@ public class CapabilitiesTests : IntegrationTestBase
         Assert.That(result!.SupportedFeatures, Is.Not.Null);
         Assert.That(result.SupportedFeatures, Contains.Item("deferredDescriptionRegistration"));
         Assert.That(result.SupportedFeatures, Contains.Item("requestCompression"));
+        Assert.That(result.SupportedFeatures, Contains.Item("migrateFromClientTransforms"));
+    }
+
+    [Test]
+    public async Task GetCapabilities_DoesNotIncludeMigrateFromToken_WhenServerSettingDisablesIt()
+    {
+        await SetConfiguration(CreateConfiguration(allowMigrateFromMigrations: false));
+
+        var result = await ApiClient.Get<FigCapabilitiesDataContract>("/capabilities", authenticate: false);
+
+        Assert.That(result!.SupportedFeatures, Does.Not.Contain("migrateFromClientTransforms"));
     }
 
     [Test]

--- a/src/tests/Fig.Integration.Test/Api/MigrateFromAttributeTests.cs
+++ b/src/tests/Fig.Integration.Test/Api/MigrateFromAttributeTests.cs
@@ -1,12 +1,16 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Fig.Client.Abstractions.Attributes;
 using Fig.Common.Constants;
 using Fig.Contracts.ImportExport;
+using Fig.Contracts.SettingMigrations;
 using Fig.Contracts.Settings;
 using Fig.Test.Common;
 using Fig.Test.Common.TestSettings;
+using Moq;
+using Newtonsoft.Json;
 using NUnit.Framework;
 
 namespace Fig.Integration.Test.Api;
@@ -166,6 +170,75 @@ public class MigrateFromAttributeTests : IntegrationTestBase
     }
 
     [Test]
+    public async Task ShallMigrateValueWhenSettingTypeChangesWithCustomMigrationMethod()
+    {
+        var secret = GetNewSecret();
+        await RegisterSettings<OriginalIntSettings>(secret);
+        await SetSettings(ClientName, [new(nameof(OriginalIntSettings.TimeoutSeconds), new IntSettingDataContract(90))]);
+
+        InitializeConfigurationProvider<TimeSpanMigrationSettings>(secret);
+
+        var settings = await GetSettingsForClient(ClientName, secret);
+        Assert.That(GetValue(settings, nameof(TimeSpanMigrationSettings.Timeout)), Is.EqualTo(TimeSpan.FromSeconds(90)));
+    }
+
+    [Test]
+    public async Task ShallMigrateStringIntoComplexObjectWithCustomMigrationMethod()
+    {
+        var secret = GetNewSecret();
+        await RegisterSettings<OriginalEndpointSettings>(secret);
+        await SetSettings(ClientName, [new(nameof(OriginalEndpointSettings.LegacyEndpoint), new StringSettingDataContract("https://legacy.example"))]);
+
+        InitializeConfigurationProvider<ComplexEndpointMigrationSettings>(secret);
+
+        var settings = await GetSettingsForClient(ClientName, secret);
+        var json = (string?)GetValue(settings, nameof(ComplexEndpointMigrationSettings.EndpointConfig));
+        var config = JsonConvert.DeserializeObject<EndpointConfig>(json!);
+
+        Assert.That(config?.Routes, Has.Count.EqualTo(1));
+        Assert.That(config!.Routes[0].Url, Is.EqualTo("https://legacy.example"));
+    }
+
+    [Test]
+    public async Task ShallIgnoreCustomMigrationResultWhenNoCustomMigrationMethodIsDeclared()
+    {
+        var secret = GetNewSecret();
+        await RegisterSettings<OriginalSettings>(secret);
+        await SetSettings(ClientName, [new(nameof(OriginalSettings.OldSetting), new StringSettingDataContract("preserved value"))]);
+
+        var updatedDefinitions = new RenamedSettings().CreateDataContract(ClientName);
+        updatedDefinitions.SettingMigrationResults =
+        [
+            new SettingMigrationResultDataContract(
+                nameof(OriginalSettings.OldSetting),
+                nameof(RenamedSettings.NewSetting),
+                null,
+                new StringSettingDataContract("tampered value"),
+                "invalid fingerprint")
+        ];
+
+        await ApiClient.Post("/clients", updatedDefinitions, secret);
+
+        var settings = await GetSettingsForClient(ClientName, secret);
+        Assert.That(GetValue(settings, nameof(RenamedSettings.NewSetting)), Is.EqualTo("preserved value"));
+    }
+
+    [Test]
+    public async Task ShallMigrateSecretValueWithCustomMigrationMethodWhenSecretStoreIsEnabled()
+    {
+        await SetConfiguration(CreateConfiguration(useAzureKeyVault: true));
+        SetupInMemorySecretStore();
+        var secret = GetNewSecret();
+        await RegisterSettings<OriginalSecretSettings>(secret);
+        await SetSettings(ClientName, [new(nameof(OriginalSecretSettings.OldSecret), new StringSettingDataContract("super secret"))]);
+
+        InitializeConfigurationProvider<CustomRenamedSecretSettings>(secret);
+
+        var settings = await GetSettingsForClient(ClientName, secret);
+        Assert.That(GetValue(settings, nameof(CustomRenamedSecretSettings.NewSecret)), Is.EqualTo("super secret migrated"));
+    }
+
+    [Test]
     public async Task ShallMigrateSecretSettingValue()
     {
         var secret = GetNewSecret();
@@ -176,6 +249,28 @@ public class MigrateFromAttributeTests : IntegrationTestBase
 
         var settings = await GetSettingsForClient(ClientName, secret);
         Assert.That(GetValue(settings, nameof(RenamedSecretSettings.NewSecret)), Is.EqualTo("super secret"));
+    }
+
+    [Test]
+    public async Task ShallMigrateSecretSettingValueForAllInstancesWhenSecretStoreIsEnabled()
+    {
+        await SetConfiguration(CreateConfiguration(useAzureKeyVault: true));
+        SetupInMemorySecretStore();
+        var secret = GetNewSecret();
+        await RegisterSettings<OriginalSecretSettings>(secret);
+        await SetSettings(ClientName, [new(nameof(OriginalSecretSettings.OldSecret), new StringSettingDataContract("default secret"))]);
+        await SetSettings(
+            ClientName,
+            [new(nameof(OriginalSecretSettings.OldSecret), new StringSettingDataContract("instance secret"))],
+            "Instance1");
+
+        await RegisterSettings<RenamedSecretSettings>(secret);
+
+        var defaultSettings = await GetSettingsForClient(ClientName, secret);
+        var instanceSettings = await GetSettingsForClient(ClientName, secret, "Instance1");
+
+        Assert.That(GetValue(defaultSettings, nameof(RenamedSecretSettings.NewSecret)), Is.EqualTo("default secret"));
+        Assert.That(GetValue(instanceSettings, nameof(RenamedSecretSettings.NewSecret)), Is.EqualTo("instance secret"));
     }
 
     [Test]
@@ -370,6 +465,23 @@ public class MigrateFromAttributeTests : IntegrationTestBase
             [new SettingClientValueExportDataContract(ClientName, null, settings.ToList())]);
     }
 
+    private void SetupInMemorySecretStore()
+    {
+        var secrets = new Dictionary<string, string>();
+        SecretStoreMock.Setup(store => store.PersistSecrets(It.IsAny<List<KeyValuePair<string, string>>>()))
+            .Callback<List<KeyValuePair<string, string>>>(items =>
+            {
+                foreach (var item in items)
+                    secrets[item.Key] = item.Value;
+            })
+            .Returns(Task.CompletedTask);
+        SecretStoreMock.Setup(store => store.GetSecrets(It.IsAny<List<string>>()))
+            .ReturnsAsync((List<string> keys) => keys
+                .Where(secrets.ContainsKey)
+                .Select(key => new KeyValuePair<string, string>(key, secrets[key]))
+                .ToList());
+    }
+
     private abstract class MigrateFromTestSettingsBase : TestSettingsBase
     {
         public override string ClientName => MigrateFromAttributeTests.ClientName;
@@ -427,6 +539,54 @@ public class MigrateFromAttributeTests : IntegrationTestBase
         public int NewSetting { get; set; } = 42;
     }
 
+    private class OriginalIntSettings : MigrateFromTestSettingsBase
+    {
+        [Setting("Original timeout seconds")]
+        public int TimeoutSeconds { get; set; } = 30;
+    }
+
+    private class TimeSpanMigrationSettings : MigrateFromTestSettingsBase
+    {
+        [Setting("Timeout")]
+        [MigrateFrom(nameof(OriginalIntSettings.TimeoutSeconds), nameof(MigrateTimeout))]
+        public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(5);
+
+        public static TimeSpan MigrateTimeout(int timeoutSeconds) => TimeSpan.FromSeconds(timeoutSeconds);
+    }
+
+    private class OriginalEndpointSettings : MigrateFromTestSettingsBase
+    {
+        [Setting("Legacy endpoint")]
+        public string LegacyEndpoint { get; set; } = "https://default.example";
+    }
+
+    private class ComplexEndpointMigrationSettings : MigrateFromTestSettingsBase
+    {
+        [Setting("Endpoint config")]
+        [MigrateFrom(nameof(OriginalEndpointSettings.LegacyEndpoint), nameof(MigrateEndpoint))]
+        public EndpointConfig EndpointConfig { get; set; } = new();
+
+        public static EndpointConfig MigrateEndpoint(string legacyEndpoint)
+        {
+            return new EndpointConfig
+            {
+                Routes = [new EndpointRoute { Url = legacyEndpoint, Enabled = true }]
+            };
+        }
+    }
+
+    private class EndpointConfig
+    {
+        public List<EndpointRoute> Routes { get; set; } = [];
+    }
+
+    private class EndpointRoute
+    {
+        public string Url { get; set; } = string.Empty;
+
+        public bool Enabled { get; set; }
+    }
+
     private class OriginalSecretSettings : MigrateFromTestSettingsBase
     {
         [Secret]
@@ -440,6 +600,16 @@ public class MigrateFromAttributeTests : IntegrationTestBase
         [Setting("Renamed secret")]
         [MigrateFrom(nameof(OriginalSecretSettings.OldSecret))]
         public string NewSecret { get; set; } = "new secret";
+    }
+
+    private class CustomRenamedSecretSettings : MigrateFromTestSettingsBase
+    {
+        [Secret]
+        [Setting("Renamed secret")]
+        [MigrateFrom(nameof(OriginalSecretSettings.OldSecret), nameof(MigrateSecret))]
+        public string NewSecret { get; set; } = "new secret";
+
+        public static string MigrateSecret(string oldSecret) => $"{oldSecret} migrated";
     }
 
     private class OriginalNestedSettings : MigrateFromTestSettingsBase

--- a/src/tests/Fig.Integration.Test/Api/SecretHandlingTests.cs
+++ b/src/tests/Fig.Integration.Test/Api/SecretHandlingTests.cs
@@ -41,10 +41,17 @@ public class SecretHandlingTests : IntegrationTestBase
     public async Task ShallPersistSecretsInAzureOnUpdatedRegistrationWhenEnabled()
     {
         await SetConfiguration(CreateConfiguration(useAzureKeyVault: true));
+        var persistedSecrets = new List<List<KeyValuePair<string, string>>>();
+        SecretStoreMock.Setup(a => a.PersistSecrets(It.IsAny<List<KeyValuePair<string, string>>>()))
+            .Callback<List<KeyValuePair<string, string>>>(items => persistedSecrets.Add(items))
+            .Returns(Task.CompletedTask);
         var secret = GetNewSecret();
         await RegisterSettings<SecretSettings>(secret);
         await RegisterSettings<SecretSettingsWithExtraSecret>(secret);
-        SecretStoreMock.Verify(a => a.PersistSecrets(It.IsAny<List<KeyValuePair<string, string>>>()), Times.Exactly(2));
+
+        Assert.That(persistedSecrets, Has.Count.EqualTo(2));
+        Assert.That(persistedSecrets[0].Select(item => item.Key), Has.Some.Contains(nameof(SecretSettings.SecretWithDefault)));
+        Assert.That(persistedSecrets[1].Select(item => item.Key).Single(), Does.Contain(nameof(SecretSettingsWithExtraSecret.ExtraSecret)));
     }
 
     [Test]

--- a/src/tests/Fig.Test.Common/IntegrationTestBase.cs
+++ b/src/tests/Fig.Test.Common/IntegrationTestBase.cs
@@ -759,7 +759,8 @@ public abstract class IntegrationTestBase
         int? timeMachineCleanupDays = 90,
         int? eventLogsCleanupDays = null,
         int? apiStatusCleanupDays = 90,
-        int? settingHistoryCleanupDays = null)
+        int? settingHistoryCleanupDays = null,
+        bool allowMigrateFromMigrations = true)
     {
         return new FigConfigurationDataContract
         {
@@ -778,7 +779,8 @@ public abstract class IntegrationTestBase
             TimeMachineCleanupDays = timeMachineCleanupDays,
             EventLogsCleanupDays = eventLogsCleanupDays,
             ApiStatusCleanupDays = apiStatusCleanupDays,
-            SettingHistoryCleanupDays = settingHistoryCleanupDays
+            SettingHistoryCleanupDays = settingHistoryCleanupDays,
+            AllowMigrateFromMigrations = allowMigrateFromMigrations
         };
     }
 

--- a/src/tests/Fig.Unit.Test/Client/ApiCommunicationHandlerTests.cs
+++ b/src/tests/Fig.Unit.Test/Client/ApiCommunicationHandlerTests.cs
@@ -6,11 +6,15 @@ using System.Text;
 using Fig.Client.Capabilities;
 using Fig.Client.ConfigurationProvider;
 using Fig.Client.Contracts;
+using Fig.Client.Exceptions;
+using Fig.Common.NetStandard.Json;
+using Fig.Contracts.SettingMigrations;
 using Fig.Contracts.Settings;
 using Fig.Contracts.SettingDefinitions;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Moq.Protected;
+using Newtonsoft.Json;
 using NUnit.Framework;
 
 namespace Fig.Unit.Test.Client;
@@ -338,6 +342,82 @@ public class ApiCommunicationHandlerTests
         Assert.That(capturedRequest.RequestUri.ToString(), Does.Not.Contain("instance="));
     }
 
+    [Test]
+    public void GetMigrateFromMigrationRequests_WhenCapabilityIsMissing_ShouldThrow()
+    {
+        var handler = CreateHandler();
+        var settings = CreateSettingsWithMigrationMethod();
+
+        var ex = Assert.ThrowsAsync<FigRegistrationException>(() =>
+            handler.GetMigrateFromMigrationRequests(settings));
+
+        Assert.That(ex!.Result?.ErrorType, Is.EqualTo("UnsupportedCapability"));
+    }
+
+    [Test]
+    public async Task GetMigrateFromMigrationRequests_ShouldForceRefreshCapabilities()
+    {
+        _capabilityProviderMock.Setup(x => x.Supports("migrateFromClientTransforms")).Returns(true);
+        _httpMessageHandlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("[]", Encoding.UTF8, "application/json")
+            });
+
+        var handler = CreateHandler();
+
+        await handler.GetMigrateFromMigrationRequests(CreateSettingsWithMigrationMethod());
+
+        _capabilityProviderMock.Verify(x => x.FetchAsync(true), Times.Once);
+    }
+
+    [Test]
+    public async Task GetMigrateFromMigrationRequests_WhenCapabilityIsSupported_ShouldPostPreviewRequest()
+    {
+        _capabilityProviderMock.Setup(x => x.Supports("migrateFromClientTransforms")).Returns(true);
+        HttpRequestMessage? capturedRequest = null;
+        var response = new List<SettingMigrationRequestDataContract>
+        {
+            new(
+                "OldSetting",
+                "NewSetting",
+                null,
+                typeof(string),
+                typeof(TimeSpan),
+                new StringSettingDataContract("15"),
+                false,
+                false,
+                "fingerprint")
+        };
+
+        _httpMessageHandlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync((HttpRequestMessage req, CancellationToken _) =>
+            {
+                capturedRequest = req;
+                return new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(JsonConvert.SerializeObject(response, JsonSettings.FigDefault), Encoding.UTF8, "application/json")
+                };
+            });
+
+        var handler = CreateHandler();
+        var result = await handler.GetMigrateFromMigrationRequests(CreateSettingsWithMigrationMethod());
+
+        Assert.That(capturedRequest, Is.Not.Null);
+        Assert.That(capturedRequest!.Method, Is.EqualTo(HttpMethod.Post));
+        Assert.That(capturedRequest.RequestUri!.ToString(), Is.EqualTo("http://localhost/clients/migrations/preview"));
+        Assert.That(result, Has.Count.EqualTo(1));
+        Assert.That(result[0].SourceValueFingerprint, Is.EqualTo("fingerprint"));
+    }
+
 #if DEBUG
     [Test]
     public async Task RegisterWithFigApi_WhenMigrateFromSourceStillExists_LogsWarning()
@@ -403,6 +483,24 @@ public class ApiCommunicationHandlerTests
             instance: null,
             hasDisplayScripts: false,
             settings: settings,
+            clientSettingOverrides: Array.Empty<SettingDataContract>());
+    }
+
+    private static SettingsClientDefinitionDataContract CreateSettingsWithMigrationMethod()
+    {
+        return new SettingsClientDefinitionDataContract(
+            name: "TestClient",
+            description: "A test client",
+            instance: null,
+            hasDisplayScripts: false,
+            settings:
+            [
+                new SettingDefinitionDataContract(
+                    "NewSetting",
+                    "New setting",
+                    migrateFrom: "OldSetting",
+                    migrateFromMigrationMethod: "Migrate")
+            ],
             clientSettingOverrides: Array.Empty<SettingDataContract>());
     }
 

--- a/src/tests/Fig.Unit.Test/Client/AttributeValidationTests.cs
+++ b/src/tests/Fig.Unit.Test/Client/AttributeValidationTests.cs
@@ -148,6 +148,35 @@ public class AttributeValidationTests
     }
 
     [Test]
+    public void CreateDataContract_WithMigrateFromMigrationMethod_ShouldSetMethodMetadata()
+    {
+        var settings = new SettingsWithMigrateFromMigrationMethod();
+
+        var dataContract = settings.CreateDataContract("TestClient");
+
+        var renamedSetting = dataContract.Settings.First(s => s.Name == nameof(SettingsWithMigrateFromMigrationMethod.NewSetting));
+        Assert.That(renamedSetting.MigrateFrom, Is.EqualTo("OldSetting"));
+        Assert.That(renamedSetting.MigrateFromMigrationMethod, Is.EqualTo(nameof(SettingsWithMigrateFromMigrationMethod.MigrateOldSetting)));
+        Assert.That(renamedSetting.MigrateFromMigrationMethodInfo?.Name, Is.EqualTo(nameof(SettingsWithMigrateFromMigrationMethod.MigrateOldSetting)));
+    }
+
+    [TestCase(typeof(SettingsWithMissingMigrateFromMigrationMethod), "was not found as a public static method")]
+    [TestCase(typeof(SettingsWithPrivateMigrateFromMigrationMethod), "was not found as a public static method")]
+    [TestCase(typeof(SettingsWithInstanceMigrateFromMigrationMethod), "was not found as a public static method")]
+    [TestCase(typeof(SettingsWithTwoParameterMigrateFromMigrationMethod), "must have exactly one parameter")]
+    [TestCase(typeof(SettingsWithIncompatibleMigrateFromMigrationMethod), "is not compatible with target setting type")]
+    public void CreateDataContract_WithInvalidMigrateFromMigrationMethod_ShouldThrow(Type settingsType, string expectedMessage)
+    {
+        var settings = (SettingsBase)Activator.CreateInstance(settingsType)!;
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            settings.CreateDataContract("TestClient"));
+
+        Assert.That(ex!.Message, Does.Contain("[MigrateFrom]"));
+        Assert.That(ex.Message, Does.Contain(expectedMessage));
+    }
+
+    [Test]
     public void CreateDataContract_WithNestedMigrateFromUsingUnqualifiedName_ShouldResolveToNestedSettingName()
     {
         var settings = new SettingsWithNestedMigrateFrom();
@@ -420,6 +449,82 @@ public class AttributeValidationTests
         [Setting("Renamed setting")]
         [MigrateFrom("OldSetting")]
         public string NewSetting { get; set; } = "new";
+
+        public override IEnumerable<string> GetValidationErrors() => [];
+    }
+
+    private class SettingsWithMigrateFromMigrationMethod : SettingsBase
+    {
+        public override string ClientDescription => "Test settings";
+
+        [Setting("Renamed setting")]
+        [MigrateFrom("OldSetting", nameof(MigrateOldSetting))]
+        public string NewSetting { get; set; } = "new";
+
+        public static string MigrateOldSetting(string oldValue) => oldValue;
+
+        public override IEnumerable<string> GetValidationErrors() => [];
+    }
+
+    private class SettingsWithMissingMigrateFromMigrationMethod : SettingsBase
+    {
+        public override string ClientDescription => "Test settings";
+
+        [Setting("Renamed setting")]
+        [MigrateFrom("OldSetting", "MissingMigration")]
+        public string NewSetting { get; set; } = "new";
+
+        public override IEnumerable<string> GetValidationErrors() => [];
+    }
+
+    private class SettingsWithPrivateMigrateFromMigrationMethod : SettingsBase
+    {
+        public override string ClientDescription => "Test settings";
+
+        [Setting("Renamed setting")]
+        [MigrateFrom("OldSetting", nameof(MigrateOldSetting))]
+        public string NewSetting { get; set; } = "new";
+
+        private static string MigrateOldSetting(string oldValue) => oldValue;
+
+        public override IEnumerable<string> GetValidationErrors() => [];
+    }
+
+    private class SettingsWithInstanceMigrateFromMigrationMethod : SettingsBase
+    {
+        public override string ClientDescription => "Test settings";
+
+        [Setting("Renamed setting")]
+        [MigrateFrom("OldSetting", nameof(MigrateOldSetting))]
+        public string NewSetting { get; set; } = "new";
+
+        public string MigrateOldSetting(string oldValue) => oldValue;
+
+        public override IEnumerable<string> GetValidationErrors() => [];
+    }
+
+    private class SettingsWithTwoParameterMigrateFromMigrationMethod : SettingsBase
+    {
+        public override string ClientDescription => "Test settings";
+
+        [Setting("Renamed setting")]
+        [MigrateFrom("OldSetting", nameof(MigrateOldSetting))]
+        public string NewSetting { get; set; } = "new";
+
+        public static string MigrateOldSetting(string oldValue, string other) => oldValue + other;
+
+        public override IEnumerable<string> GetValidationErrors() => [];
+    }
+
+    private class SettingsWithIncompatibleMigrateFromMigrationMethod : SettingsBase
+    {
+        public override string ClientDescription => "Test settings";
+
+        [Setting("Renamed setting")]
+        [MigrateFrom("OldSetting", nameof(MigrateOldSetting))]
+        public string NewSetting { get; set; } = "new";
+
+        public static int MigrateOldSetting(string oldValue) => oldValue.Length;
 
         public override IEnumerable<string> GetValidationErrors() => [];
     }

--- a/src/tests/Fig.Unit.Test/Client/ConfigurationProviderTests.cs
+++ b/src/tests/Fig.Unit.Test/Client/ConfigurationProviderTests.cs
@@ -6,17 +6,21 @@ using Microsoft.Extensions.Options;
 using NUnit.Framework;
 using Fig.Common.NetStandard.IpAddress;
 using System.Net.Http;
+using Fig.Client;
 using Fig.Contracts.Settings;
 using Moq;
 using Fig.Client.Status;
 using System;
 using System.Linq;
+using Fig.Client.Abstractions.Attributes;
 using Fig.Client.ClientSecret;
 using Fig.Contracts.SettingDefinitions;
 using Fig.Client.ConfigurationProvider;
 using Fig.Client.Contracts;
+using Fig.Client.Exceptions;
 using Fig.Unit.Test.TestInfrastructure;
 using Microsoft.Extensions.Logging;
+using Fig.Contracts.SettingMigrations;
 
 namespace Fig.Unit.Test.Client;
 
@@ -29,6 +33,8 @@ public class ConfigurationProviderTests
     [SetUp]
     public void SetUp()
     {
+        _apiCommunicationHandlerMock.Reset();
+        _settingStatusMonitorMock.Reset();
         RunSession.Clear();
         RegisteredProviders.Clear();
     }
@@ -73,12 +79,119 @@ public class ConfigurationProviderTests
     public void ShallRegisterSettingsWithApi()
     {
         var source = CreateSource();
+        _apiCommunicationHandlerMock.Setup(a => a.RequestConfiguration()).ReturnsAsync([]);
 
         var builder = new ConfigurationBuilder();
         builder.Add(source);
         builder.Build();
 
         _apiCommunicationHandlerMock.Verify(a => a.RegisterWithFigApi(It.Is<SettingsClientDefinitionDataContract>(definition => VerifyDefinition(definition))));
+    }
+
+    [Test]
+    public void ShallRegisterSettingsWhenMigrateFromPreviewReturnsNull()
+    {
+        var source = CreateSource();
+        source.SettingsType = typeof(SettingsWithPreviewMigration);
+        _apiCommunicationHandlerMock
+            .Setup(a => a.GetMigrateFromMigrationRequests(It.IsAny<SettingsClientDefinitionDataContract>()))
+            .Returns(Task.FromResult<List<SettingMigrationRequestDataContract>>(null!));
+        _apiCommunicationHandlerMock
+            .Setup(a => a.RegisterWithFigApi(It.IsAny<SettingsClientDefinitionDataContract>()))
+            .Returns(Task.CompletedTask);
+        _apiCommunicationHandlerMock
+            .Setup(a => a.RequestConfiguration())
+            .ReturnsAsync([]);
+
+        var builder = new ConfigurationBuilder();
+        builder.Add(source);
+
+        Assert.DoesNotThrow(() => builder.Build());
+        _apiCommunicationHandlerMock.Verify(
+            a => a.RegisterWithFigApi(It.IsAny<SettingsClientDefinitionDataContract>()),
+            Times.Once);
+    }
+
+    [Test]
+    public void ShallRegisterSettingsWhenMigrateFromPreviewFailsWithTransportError()
+    {
+        var source = CreateSource();
+        source.SettingsType = typeof(SettingsWithPreviewMigration);
+        _apiCommunicationHandlerMock
+            .Setup(a => a.GetMigrateFromMigrationRequests(It.IsAny<SettingsClientDefinitionDataContract>()))
+            .ThrowsAsync(new HttpRequestException("Preview failed"));
+        _apiCommunicationHandlerMock
+            .Setup(a => a.RegisterWithFigApi(It.IsAny<SettingsClientDefinitionDataContract>()))
+            .Returns(Task.CompletedTask);
+        _apiCommunicationHandlerMock
+            .Setup(a => a.RequestConfiguration())
+            .ReturnsAsync([]);
+
+        var builder = new ConfigurationBuilder();
+        builder.Add(source);
+
+        Assert.DoesNotThrow(() => builder.Build());
+        _apiCommunicationHandlerMock.Verify(
+            a => a.RegisterWithFigApi(It.IsAny<SettingsClientDefinitionDataContract>()),
+            Times.Once);
+    }
+
+    [Test]
+    public void ShallRegisterSettingsWhenMigrateFromPreviewFailsWithCompatibilityError()
+    {
+        var source = CreateSource();
+        source.SettingsType = typeof(SettingsWithPreviewMigration);
+        _apiCommunicationHandlerMock
+            .Setup(a => a.GetMigrateFromMigrationRequests(It.IsAny<SettingsClientDefinitionDataContract>()))
+            .ThrowsAsync(new FigRegistrationException(null));
+        _apiCommunicationHandlerMock
+            .Setup(a => a.RegisterWithFigApi(It.IsAny<SettingsClientDefinitionDataContract>()))
+            .Returns(Task.CompletedTask);
+        _apiCommunicationHandlerMock
+            .Setup(a => a.RequestConfiguration())
+            .ReturnsAsync([]);
+
+        var builder = new ConfigurationBuilder();
+        builder.Add(source);
+
+        Assert.DoesNotThrow(() => builder.Build());
+        _apiCommunicationHandlerMock.Verify(
+            a => a.RegisterWithFigApi(It.IsAny<SettingsClientDefinitionDataContract>()),
+            Times.Once);
+    }
+
+    [Test]
+    public void ShallFailFastWhenLocalMigrateFromConversionFails()
+    {
+        var source = CreateSource();
+        source.SettingsType = typeof(SettingsWithThrowingPreviewMigration);
+        _apiCommunicationHandlerMock
+            .Setup(a => a.GetMigrateFromMigrationRequests(It.IsAny<SettingsClientDefinitionDataContract>()))
+            .ReturnsAsync([
+                new SettingMigrationRequestDataContract(
+                    "OldSetting",
+                    "NewSetting",
+                    null,
+                    typeof(string),
+                    typeof(string),
+                    new StringSettingDataContract("legacy"),
+                    false,
+                    false,
+                    "fingerprint")
+            ]);
+        _apiCommunicationHandlerMock
+            .Setup(a => a.RequestConfiguration())
+            .ReturnsAsync([]);
+
+        var builder = new ConfigurationBuilder();
+        builder.Add(source);
+
+        var ex = Assert.Throws<InvalidOperationException>(() => builder.Build());
+
+        Assert.That(ex!.Message, Does.Contain("Local migration failed"));
+        _apiCommunicationHandlerMock.Verify(
+            a => a.RegisterWithFigApi(It.IsAny<SettingsClientDefinitionDataContract>()),
+            Times.Never);
     }
 
     [Test]
@@ -453,4 +566,31 @@ public class TestableConfigurationSource : FigConfigurationSource
     {
         return new HttpClient();
     }
+}
+
+public class SettingsWithPreviewMigration : SettingsBase
+{
+    public override string ClientDescription => "Test settings";
+
+    [Setting("Renamed setting")]
+    [MigrateFrom("OldSetting", nameof(MigrateOldSetting))]
+    public string NewSetting { get; set; } = "new";
+
+    public static string MigrateOldSetting(string oldValue) => oldValue;
+
+    public override IEnumerable<string> GetValidationErrors() => [];
+}
+
+public class SettingsWithThrowingPreviewMigration : SettingsBase
+{
+    public override string ClientDescription => "Test settings";
+
+    [Setting("Renamed setting")]
+    [MigrateFrom("OldSetting", nameof(MigrateOldSetting))]
+    public string NewSetting { get; set; } = "new";
+
+    public static string MigrateOldSetting(string oldValue) =>
+        throw new InvalidOperationException("Local migration failed");
+
+    public override IEnumerable<string> GetValidationErrors() => [];
 }

--- a/src/tests/Fig.Unit.Test/Client/MigrateFromMigrationConverterTests.cs
+++ b/src/tests/Fig.Unit.Test/Client/MigrateFromMigrationConverterTests.cs
@@ -1,0 +1,120 @@
+using Fig.Client.Migration;
+using Fig.Contracts.SettingDefinitions;
+using Fig.Contracts.SettingMigrations;
+using Fig.Contracts.Settings;
+using NUnit.Framework;
+
+namespace Fig.Unit.Test.Client;
+
+[TestFixture]
+public class MigrateFromMigrationConverterTests
+{
+    [Test]
+    public void Convert_WithScalarMigrationMethod_ShouldReturnConvertedValue()
+    {
+        var settings = CreateSettings(
+            typeof(MigrateFromMigrationConverterTests).GetMethod(nameof(ConvertSeconds))!,
+            typeof(TimeSpan));
+        var request = new SettingMigrationRequestDataContract(
+            "TimeoutSeconds",
+            "Timeout",
+            null,
+            typeof(int),
+            typeof(TimeSpan),
+            new IntSettingDataContract(15),
+            false,
+            false,
+            "fingerprint");
+
+        var result = new MigrateFromMigrationConverter().Convert(settings, [request]);
+
+        Assert.That(result, Has.Count.EqualTo(1));
+        Assert.That(result[0].MigratedValue, Is.TypeOf<TimeSpanSettingDataContract>());
+        Assert.That(result[0].MigratedValue!.GetValue(), Is.EqualTo(TimeSpan.FromSeconds(15)));
+    }
+
+    [Test]
+    public void Convert_WithJsonSourceAndComplexParameter_ShouldDeserializeBeforeInvokingMethod()
+    {
+        var settings = CreateSettings(
+            typeof(MigrateFromMigrationConverterTests).GetMethod(nameof(ExtractName))!,
+            typeof(string));
+        var request = new SettingMigrationRequestDataContract(
+            "OldJson",
+            "NewName",
+            null,
+            typeof(string),
+            typeof(string),
+            new JsonSettingDataContract("""{"Name":"legacy"}"""),
+            false,
+            false,
+            "fingerprint");
+
+        var result = new MigrateFromMigrationConverter().Convert(settings, [request]);
+
+        Assert.That(result[0].MigratedValue, Is.TypeOf<StringSettingDataContract>());
+        Assert.That(result[0].MigratedValue!.GetValue(), Is.EqualTo("legacy"));
+    }
+
+    [Test]
+    public void Convert_WithSecretSourceAndNonSecretTarget_ShouldThrow()
+    {
+        var settings = CreateSettings(
+            typeof(MigrateFromMigrationConverterTests).GetMethod(nameof(Copy))!,
+            typeof(string));
+        var request = new SettingMigrationRequestDataContract(
+            "OldSecret",
+            "NewSetting",
+            null,
+            typeof(string),
+            typeof(string),
+            new StringSettingDataContract("secret"),
+            true,
+            false,
+            "fingerprint");
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            new MigrateFromMigrationConverter().Convert(settings, [request]));
+
+        Assert.That(ex!.Message, Does.Contain("not allowed"));
+    }
+
+    public static TimeSpan ConvertSeconds(int seconds) => TimeSpan.FromSeconds(seconds);
+
+    public static string ExtractName(LegacyValue value) => value.Name;
+
+    public static string Copy(string value) => value;
+
+    private static SettingsClientDefinitionDataContract CreateSettings(System.Reflection.MethodInfo method, Type targetType)
+    {
+        var (targetName, sourceName) = method.Name switch
+        {
+            nameof(ExtractName) => ("NewName", "OldJson"),
+            nameof(Copy) => ("NewSetting", "OldSecret"),
+            _ => ("Timeout", "TimeoutSeconds")
+        };
+
+        var target = new SettingDefinitionDataContract(
+            targetName,
+            "Target setting",
+            valueType: targetType,
+            migrateFrom: sourceName,
+            migrateFromMigrationMethod: method.Name)
+        {
+            MigrateFromMigrationMethodInfo = method
+        };
+
+        return new SettingsClientDefinitionDataContract(
+            "TestClient",
+            "Test client",
+            null,
+            false,
+            [target],
+            []);
+    }
+
+    public class LegacyValue
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+}

--- a/src/tests/Fig.Unit.Test/DatabaseMigrations/MigrationDiscoveryTests.cs
+++ b/src/tests/Fig.Unit.Test/DatabaseMigrations/MigrationDiscoveryTests.cs
@@ -50,6 +50,47 @@ public class MigrationDiscoveryTests
         Assert.That(script, Does.Contain("UPDATE configuration"));
         Assert.That(script, Does.Contain("enable_time_machine = 0"));
     }
+
+    [Test]
+    public void Migration_007_ShouldBeDiscoverable()
+    {
+        // Arrange & Act
+        var migration = new Migration_007_EnableMigrateFromMigrationsByDefault();
+
+        // Assert
+        Assert.That(migration.ExecutionNumber, Is.EqualTo(7));
+        Assert.That(migration.Description, Is.EqualTo("Backfill migrate-from migrations to enabled for existing configuration rows"));
+        Assert.That(migration.SqlServerScript, Is.Not.Empty);
+        Assert.That(migration.SqliteScript, Is.Not.Empty);
+    }
+
+    [Test]
+    public void Migration_007_SqlServerScript_ShouldUpdateAllowMigrateFromMigrations()
+    {
+        // Arrange
+        var migration = new Migration_007_EnableMigrateFromMigrationsByDefault();
+
+        // Act
+        var script = migration.SqlServerScript;
+
+        // Assert
+        Assert.That(script, Does.Contain("UPDATE configuration"));
+        Assert.That(script, Does.Contain("allow_migrate_from_migrations = 1"));
+    }
+
+    [Test]
+    public void Migration_007_SqliteScript_ShouldUpdateAllowMigrateFromMigrations()
+    {
+        // Arrange
+        var migration = new Migration_007_EnableMigrateFromMigrationsByDefault();
+
+        // Act
+        var script = migration.SqliteScript;
+
+        // Assert
+        Assert.That(script, Does.Contain("UPDATE configuration"));
+        Assert.That(script, Does.Contain("allow_migrate_from_migrations = 1"));
+    }
     
     [Test]
     public void AllMigrations_ShouldHaveSequentialNumbers()

--- a/src/tests/Fig.Unit.Test/Web/SettingClientConfigurationModelTests.cs
+++ b/src/tests/Fig.Unit.Test/Web/SettingClientConfigurationModelTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using Fig.Common.NetStandard.Scripting;
 using Fig.Web.Events;
@@ -54,5 +55,21 @@ public class SettingClientConfigurationModelTests
         await model.SettingEvent(new SettingEventModel("Parent->Child", SettingEventType.RunScript, "good script"));
 
         Assert.That(model.ScriptErrors.ContainsKey("Parent->Child"), Is.False);
+    }
+
+    [Test]
+    public async Task CreateInstance_CopiesMigrateFromSettingCount()
+    {
+        var model = new SettingClientConfigurationModel("ClientA", "Description", null, hasDisplayScripts: false, Mock.Of<IScriptRunner>())
+        {
+            MigrateFromSettingCount = 3
+        };
+
+        var createInstanceMethod = typeof(SettingClientConfigurationModel)
+            .GetMethod("CreateInstance", BindingFlags.Instance | BindingFlags.NonPublic);
+        var instanceTask = (Task<SettingClientConfigurationModel>)createInstanceMethod!.Invoke(model, ["Instance1"])!;
+        var instance = await instanceTask;
+
+        Assert.That(instance.MigrateFromSettingCount, Is.EqualTo(3));
     }
 }

--- a/src/web/Fig.Web/Converters/SettingsDefinitionConverter.cs
+++ b/src/web/Fig.Web/Converters/SettingsDefinitionConverter.cs
@@ -101,6 +101,9 @@ public class SettingsDefinitionConverter : ISettingsDefinitionConverter
             customAction.IsCompactView = _webSettings.DefaultDisplayCollapsed;
         }
         
+        model.MigrateFromSettingCount = settingClientDataContract.Settings
+            .Count(s => !string.IsNullOrWhiteSpace(s.MigrateFrom));
+        
         return model;
     }
 

--- a/src/web/Fig.Web/Models/Configuration/FigConfigurationModel.cs
+++ b/src/web/Fig.Web/Models/Configuration/FigConfigurationModel.cs
@@ -36,6 +36,8 @@ public class FigConfigurationModel
     
     public int? SettingHistoryCleanupDays { get; set; }
 
+    public bool AllowMigrateFromMigrations { get; set; } = true;
+
     public FigConfigurationModel Clone()
     {
         return new FigConfigurationModel
@@ -56,7 +58,8 @@ public class FigConfigurationModel
             TimeMachineCleanupDays = TimeMachineCleanupDays,
             EventLogsCleanupDays = EventLogsCleanupDays,
             ApiStatusCleanupDays = ApiStatusCleanupDays,
-            SettingHistoryCleanupDays = SettingHistoryCleanupDays
+            SettingHistoryCleanupDays = SettingHistoryCleanupDays,
+            AllowMigrateFromMigrations = AllowMigrateFromMigrations
         };
     }
 
@@ -79,5 +82,6 @@ public class FigConfigurationModel
         EventLogsCleanupDays = model.EventLogsCleanupDays;
         ApiStatusCleanupDays = model.ApiStatusCleanupDays;
         SettingHistoryCleanupDays = model.SettingHistoryCleanupDays;
+        AllowMigrateFromMigrations = model.AllowMigrateFromMigrations;
     }
 }

--- a/src/web/Fig.Web/Models/Setting/SettingClientConfigurationModel.cs
+++ b/src/web/Fig.Web/Models/Setting/SettingClientConfigurationModel.cs
@@ -65,6 +65,8 @@ public class SettingClientConfigurationModel
 
     public bool AllRunSessionsRunningLatest { get; set; }
     
+    public int MigrateFromSettingCount { get; set; }
+    
     public DateTime? LastRunSessionDisconnected { get; set; }
     
     public string? LastRunSessionMachineName { get; set; }
@@ -248,7 +250,8 @@ public class SettingClientConfigurationModel
     {
         var instance = new SettingClientConfigurationModel(Name, Description, instanceName, HasDisplayScripts, _scriptRunner, displayScriptStatusService: _displayScriptStatusService)
         {
-            CustomActions = CustomActions.Select(a => a.Clone()).ToList()
+            CustomActions = CustomActions.Select(a => a.Clone()).ToList(),
+            MigrateFromSettingCount = MigrateFromSettingCount
         };
 
         instance.Settings = Settings.Select(a => a.Clone(instance, true, false)).ToList();

--- a/src/web/Fig.Web/Pages/Configuration.razor
+++ b/src/web/Fig.Web/Pages/Configuration.razor
@@ -103,6 +103,16 @@
             </RadzenCard>
 
             <RadzenCard class="m-3">
+                <h3 class="h5">Allow MigrateFrom Migrations</h3>
+                <p>The MigrateFrom attribute allows settings to be renamed or transformed when a client registers with Fig.</p>
+                <p>Once all migrations are complete, this feature can be disabled to prevent unnecessary processing on every client startup. Existing migrated setting values are not affected by disabling this setting.</p>
+                <p>When disabled, migration metadata sent by clients is ignored and no migration processing occurs server-side.</p>
+                <div class="p-1">
+                    <RadzenSwitch @bind-Value="ConfigurationModel.AllowMigrateFromMigrations" Change="OnConfigurationValueChanged"/>
+                </div>
+            </RadzenCard>
+
+            <RadzenCard class="m-3">
                 <h3 class="h5">Web Application Base Address</h3>
                 <p>This is the address that users use to access the web application. It is used to generate links for web hooks.</p>
                 <div class="p-1">

--- a/src/web/Fig.Web/Pages/Setting/SettingEditors/BoolSetting.razor
+++ b/src/web/Fig.Web/Pages/Setting/SettingEditors/BoolSetting.razor
@@ -1,8 +1,10 @@
 ﻿@using Fig.Web.Models.Setting.ConfigurationModels
-<RadzenSwitch @bind-Value="@Setting.Value" 
-              Change="@(args => Setting.ValueChanged(args.ToString()))"
-              Disabled="@Setting.IsReadOnly"/>
-<SettingAnnotations Setting="@Setting"/>
+<div class="d-flex flex-column">
+    <RadzenSwitch @bind-Value="@Setting.Value" 
+                  Change="@(args => Setting.ValueChanged(args.ToString()))"
+                  Disabled="@Setting.IsReadOnly"/>
+    <SettingAnnotations Setting="@Setting"/>
+</div>
 
 @code
 {

--- a/src/web/Fig.Web/Pages/Setting/SettingEditors/DateTimeSetting.razor
+++ b/src/web/Fig.Web/Pages/Setting/SettingEditors/DateTimeSetting.razor
@@ -1,10 +1,12 @@
 @using Fig.Web.Models.Setting.ConfigurationModels
-<RadzenDatePicker TValue="DateTime?" @bind-Value="@Setting.Value" Disabled="@Setting.IsReadOnly"
-                  ShowTime="true" ShowSeconds="true" HoursStep="1"
-                  MinutesStep="5" SecondsStep="10"
-                  DateFormat="dd/MM/yyyy HH:mm" Class="w-100"
-                  Change="@(args => Setting.ValueChanged(args?.ToString() ?? string.Empty))"/>
-<SettingAnnotations Setting="@Setting"/>
+<div class="d-flex flex-column w-100">
+    <RadzenDatePicker TValue="DateTime?" @bind-Value="@Setting.Value" Disabled="@Setting.IsReadOnly"
+                      ShowTime="true" ShowSeconds="true" HoursStep="1"
+                      MinutesStep="5" SecondsStep="10"
+                      DateFormat="dd/MM/yyyy HH:mm" Class="w-100"
+                      Change="@(args => Setting.ValueChanged(args?.ToString() ?? string.Empty))"/>
+    <SettingAnnotations Setting="@Setting"/>
+</div>
 
 @code
 {

--- a/src/web/Fig.Web/Pages/Setting/SettingEditors/DropDownSetting.razor
+++ b/src/web/Fig.Web/Pages/Setting/SettingEditors/DropDownSetting.razor
@@ -1,12 +1,14 @@
-﻿@using Fig.Web.Models.Setting.ConfigurationModels
-<RadzenDropDown AllowClear="false" TValue="string" Class="w-100"
-                FilterCaseSensitivity="FilterCaseSensitivity.CaseInsensitive"
-                FilterOperator="StringFilterOperator.StartsWith" AllowFiltering="true"
-                Data="@Setting.ValidValues"
-                @bind-Value="@Setting.DisplayValue"
-                Change="@(args => Setting.ValueChanged(args?.ToString()))"
-                Disabled="@Setting.IsReadOnly"/>
-<SettingAnnotations Setting="@Setting"/>
+@using Fig.Web.Models.Setting.ConfigurationModels
+<div class="d-flex flex-column w-100">
+    <RadzenDropDown AllowClear="false" TValue="string" Class="w-100"
+                    FilterCaseSensitivity="FilterCaseSensitivity.CaseInsensitive"
+                    FilterOperator="StringFilterOperator.StartsWith" AllowFiltering="true"
+                    Data="@Setting.ValidValues"
+                    @bind-Value="@Setting.DisplayValue"
+                    Change="@(args => Setting.ValueChanged(args?.ToString()))"
+                    Disabled="@Setting.IsReadOnly"/>
+    <SettingAnnotations Setting="@Setting"/>
+</div>
 
 @code
 {

--- a/src/web/Fig.Web/Pages/Setting/SettingEditors/TimeSpanSetting.razor
+++ b/src/web/Fig.Web/Pages/Setting/SettingEditors/TimeSpanSetting.razor
@@ -1,10 +1,12 @@
 @using Fig.Web.Models.Setting.ConfigurationModels
-<RadzenTimeSpanPicker TValue="TimeSpan?" 
-                      @bind-Value="@Setting.Value"
-                      Disabled="@Setting.IsReadOnly"
-                      AllowClear = "true" class="w-100"
-                      Change="@(args => Setting.ValueChanged(args?.ToString() ?? string.Empty))"/>
-<SettingAnnotations Setting="@Setting"/>
+<div class="d-flex flex-column w-100">
+    <RadzenTimeSpanPicker TValue="TimeSpan?" 
+                          @bind-Value="@Setting.Value"
+                          Disabled="@Setting.IsReadOnly"
+                          AllowClear="true" class="w-100"
+                          Change="@(args => Setting.ValueChanged(args?.ToString() ?? string.Empty))"/>
+    <SettingAnnotations Setting="@Setting"/>
+</div>
 
 @code
 {

--- a/src/web/Fig.Web/Pages/Setting/Settings.razor
+++ b/src/web/Fig.Web/Pages/Setting/Settings.razor
@@ -252,7 +252,7 @@
                     </div>
                     <div class="p-1">
                         <RadzenButton
-                            Click=@(_ => ShowDescription(SelectedSettingClient?.Name, SelectedSettingClient?.Description))
+                            Click=@(_ => ShowDescription(SelectedSettingClient?.Name, SelectedSettingClient?.Description, SelectedSettingClient?.MigrateFromSettingCount ?? 0))
                             Icon="description" Disabled=@IsToolbarDescriptionDisabled ButtonStyle="ButtonStyle.Warning"
                             MouseEnter="@(args => ShowTooltip(args, "Client description"))"/>
                     </div>
@@ -896,7 +896,7 @@
             </div>) ?? false;
     }
 
-    async Task ShowDescription(string? clientName, string? description)
+    async Task ShowDescription(string? clientName, string? description, int migrateFromCount = 0)
     {
         if (clientName is null || description is null)
             return;
@@ -908,7 +908,18 @@
             new DialogOptions
             {
                 Height = "90%",
-                Width = "90%"
+                Width = "90%",
+                TitleContent = _ =>
+                    @<div style="display: flex; align-items: center; gap: 8px;">
+                        <span>Description for @clientName</span>
+                        @if (migrateFromCount > 0)
+                        {
+                            <RadzenIcon Icon="transform" Style="color: orange; margin-left: 4px;"
+                                        title="@($"This client has {migrateFromCount} setting(s) with MigrateFrom migration configured")"/>
+                            <RadzenBadge Text="@migrateFromCount.ToString()" BadgeStyle="BadgeStyle.Warning" IsPill="true"
+                                         title="@($"This client has {migrateFromCount} setting(s) with MigrateFrom migration configured")"/>
+                        }
+                    </div>
             });
     }
 

--- a/src/web/Fig.Web/Pages/Setting/Settings.razor.cs
+++ b/src/web/Fig.Web/Pages/Setting/Settings.razor.cs
@@ -532,7 +532,7 @@ public partial class Settings : ComponentBase, IAsyncDisposable
         _hotKeysContext.Add(ModCode.Alt, Code.S, (Func<ValueTask>)(async () => await OnSave()));
         _hotKeysContext.Add(ModCode.Alt, Code.A, (Func<ValueTask>)(async () => await OnSaveAll()));
         _hotKeysContext.Add(ModCode.Alt, Code.I, (Func<ValueTask>)(async () => await OnAddInstance()));
-        _hotKeysContext.Add(ModCode.Alt, Code.D, (Func<ValueTask>)(async () => await ShowDescription(SelectedSettingClient?.Name, SelectedSettingClient?.Description)));
+        _hotKeysContext.Add(ModCode.Alt, Code.D, (Func<ValueTask>)(async () => await ShowDescription(SelectedSettingClient?.Name, SelectedSettingClient?.Description, SelectedSettingClient?.MigrateFromSettingCount ?? 0)));
         _hotKeysContext.Add(ModCode.Alt, Code.E, () => SelectedSettingClient?.ExpandAll());
         _hotKeysContext.Add(ModCode.Alt, Code.C, () => SelectedSettingClient?.CollapseAll());
         _hotKeysContext.Add(ModCode.Alt, Code.F, ShowSearchDialog);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preview/apply custom "migrate-from" transformations during registration; server toggle to enable/disable; UI shows migrate-from badge/count and capability advertised.

* **Documentation**
  * Expanded guidance for type-changing migrations, migration-method shape/limitations, List<T> handling, and note that custom methods do not run during imports.

* **Bug Fixes**
  * Prevents downgrading secrets (secret → non-secret) via migrations.

* **Behavior**
  * Imports that require custom migrations are reported as not applied and must be updated or migrated externally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->