### PR TITLE
Fix DPAPI secret persistence

### DIFF
--- a/doc/fig-documentation/docs/features/28-client-secrets/3-dpapi-secret-provider.md
+++ b/doc/fig-documentation/docs/features/28-client-secrets/3-dpapi-secret-provider.md
@@ -48,6 +48,7 @@ For example, for client name `MyService`, the environment variable will be `FIG_
 - The provider attempts to read the secret from the user-scoped environment variable `FIG_{CLIENT_NAME}_SECRET`.
 - If the variable exists, it is decrypted using DPAPI (CurrentUser scope).
 - If no user-scoped value exists, the provider attempts to read the machine-scoped environment variable with the same name.
+- If a machine-scoped value is found, the provider uses it and attempts to persist the encrypted value to the current user's environment for reuse on later runs.
 - If the variable does not exist and auto-creation is enabled, a new GUID is generated, encrypted, and persisted to the current Windows user's environment so later application runs reuse the same secret.
 - If the variable cannot be found and auto-creation is disabled, a `SecretNotFoundException` is thrown.
 - If decryption fails (e.g., due to user mismatch or corruption), a `SecretNotFoundException` is thrown with instructions for manual creation.

--- a/doc/fig-documentation/docs/features/28-client-secrets/3-dpapi-secret-provider.md
+++ b/doc/fig-documentation/docs/features/28-client-secrets/3-dpapi-secret-provider.md
@@ -11,7 +11,8 @@ This provider enables Fig client secret management using Windows DPAPI (Data Pro
 
 - **Windows-Only**: Automatically enabled on Windows platforms.
 - **Automatic Secret Creation**: Secrets are auto-created if not present, unless auto-creation is disabled.
-- **Environment Variable Storage**: Stores secrets as encrypted environment variables, using DPAPI for encryption.
+- **User-Scoped Environment Variable Storage**: Auto-created secrets are stored as encrypted user-scoped environment variables, using DPAPI for encryption.
+- **Machine-Scoped Fallback**: If no user-scoped secret exists, the provider can read a machine-scoped environment variable.
 - **Thread-Safe**: Safe for concurrent use.
 - **Graceful Error Handling**: Handles decryption and environment errors with clear exceptions.
 
@@ -44,9 +45,10 @@ For example, for client name `MyService`, the environment variable will be `FIG_
 
 ## How It Works
 
-- The provider attempts to read the secret from the environment variable `FIG_{CLIENT_NAME}_SECRET`.
+- The provider attempts to read the secret from the user-scoped environment variable `FIG_{CLIENT_NAME}_SECRET`.
 - If the variable exists, it is decrypted using DPAPI (CurrentUser scope).
-- If the variable does not exist and auto-creation is enabled, a new GUID is generated, encrypted, and set as the environment variable for the current process.
+- If no user-scoped value exists, the provider attempts to read the machine-scoped environment variable with the same name.
+- If the variable does not exist and auto-creation is enabled, a new GUID is generated, encrypted, and persisted to the current Windows user's environment so later application runs reuse the same secret.
 - If the variable cannot be found and auto-creation is disabled, a `SecretNotFoundException` is thrown.
 - If decryption fails (e.g., due to user mismatch or corruption), a `SecretNotFoundException` is thrown with instructions for manual creation.
 
@@ -65,7 +67,7 @@ $secret = [System.Text.Encoding]::UTF8.GetBytes("<YOUR CLIENT SECRET HERE>")
 $protected = [System.Security.Cryptography.ProtectedData]::Protect($secret, $null, $scope)
 $encodedText = [Convert]::ToBase64String($protected)
 Write-Host $encodedText
-# Set the environment variable (for current process)
+# Persist the environment variable for the current Windows user
 [System.Environment]::SetEnvironmentVariable("FIG_MYSERVICE_SECRET", $encodedText, "User")
 ```
 

--- a/doc/fig-documentation/versioned_docs/version-3.x/features/28-client-secrets/3-dpapi-secret-provider.md
+++ b/doc/fig-documentation/versioned_docs/version-3.x/features/28-client-secrets/3-dpapi-secret-provider.md
@@ -48,6 +48,7 @@ For example, for client name `MyService`, the environment variable will be `FIG_
 - The provider attempts to read the secret from the user-scoped environment variable `FIG_{CLIENT_NAME}_SECRET`.
 - If the variable exists, it is decrypted using DPAPI (CurrentUser scope).
 - If no user-scoped value exists, the provider attempts to read the machine-scoped environment variable with the same name.
+- If a machine-scoped value is found, the provider uses it and attempts to persist the encrypted value to the current user's environment for reuse on later runs.
 - If the variable does not exist and auto-creation is enabled, a new GUID is generated, encrypted, and persisted to the current Windows user's environment so later application runs reuse the same secret.
 - If the variable cannot be found and auto-creation is disabled, a `SecretNotFoundException` is thrown.
 - If decryption fails (e.g., due to user mismatch or corruption), a `SecretNotFoundException` is thrown with instructions for manual creation.

--- a/doc/fig-documentation/versioned_docs/version-3.x/features/28-client-secrets/3-dpapi-secret-provider.md
+++ b/doc/fig-documentation/versioned_docs/version-3.x/features/28-client-secrets/3-dpapi-secret-provider.md
@@ -11,7 +11,8 @@ This provider enables Fig client secret management using Windows DPAPI (Data Pro
 
 - **Windows-Only**: Automatically enabled on Windows platforms.
 - **Automatic Secret Creation**: Secrets are auto-created if not present, unless auto-creation is disabled.
-- **Environment Variable Storage**: Stores secrets as encrypted environment variables, using DPAPI for encryption.
+- **User-Scoped Environment Variable Storage**: Auto-created secrets are stored as encrypted user-scoped environment variables, using DPAPI for encryption.
+- **Machine-Scoped Fallback**: If no user-scoped secret exists, the provider can read a machine-scoped environment variable.
 - **Thread-Safe**: Safe for concurrent use.
 - **Graceful Error Handling**: Handles decryption and environment errors with clear exceptions.
 
@@ -44,9 +45,10 @@ For example, for client name `MyService`, the environment variable will be `FIG_
 
 ## How It Works
 
-- The provider attempts to read the secret from the environment variable `FIG_{CLIENT_NAME}_SECRET`.
+- The provider attempts to read the secret from the user-scoped environment variable `FIG_{CLIENT_NAME}_SECRET`.
 - If the variable exists, it is decrypted using DPAPI (CurrentUser scope).
-- If the variable does not exist and auto-creation is enabled, a new GUID is generated, encrypted, and set as the environment variable for the current process.
+- If no user-scoped value exists, the provider attempts to read the machine-scoped environment variable with the same name.
+- If the variable does not exist and auto-creation is enabled, a new GUID is generated, encrypted, and persisted to the current Windows user's environment so later application runs reuse the same secret.
 - If the variable cannot be found and auto-creation is disabled, a `SecretNotFoundException` is thrown.
 - If decryption fails (e.g., due to user mismatch or corruption), a `SecretNotFoundException` is thrown with instructions for manual creation.
 
@@ -65,7 +67,7 @@ $secret = [System.Text.Encoding]::UTF8.GetBytes("<YOUR CLIENT SECRET HERE>")
 $protected = [System.Security.Cryptography.ProtectedData]::Protect($secret, $null, $scope)
 $encodedText = [Convert]::ToBase64String($protected)
 Write-Host $encodedText
-# Set the environment variable (for current process)
+# Persist the environment variable for the current Windows user
 [System.Environment]::SetEnvironmentVariable("FIG_MYSERVICE_SECRET", $encodedText, "User")
 ```
 

--- a/src/client/Fig.Client.SecretProvider.Dpapi/DpapiSecretProvider.cs
+++ b/src/client/Fig.Client.SecretProvider.Dpapi/DpapiSecretProvider.cs
@@ -37,7 +37,26 @@ namespace Fig.Client.SecretProvider.Dpapi
             var machineScopedSecret = GetCurrentProcessEncryptedSecret(secretKey);
             if (!string.IsNullOrEmpty(machineScopedSecret))
             {
-                return Task.FromResult(ReadStoredSecret(clientName, secretKey, machineScopedSecret, "machine-scoped"));
+                var secret = ReadStoredSecret(clientName, secretKey, machineScopedSecret, "machine-scoped");
+
+                try
+                {
+                    SetStoredEncryptedSecret(secretKey, machineScopedSecret);
+                    Logger?.LogInformation(
+                        "Migrated DPAPI secret for key {SecretKey} from machine-scoped to user-scoped environment variable (client: {ClientName})",
+                        secretKey,
+                        clientName);
+                }
+                catch (Exception ex)
+                {
+                    Logger?.LogWarning(
+                        "Unable to persist machine-scoped DPAPI secret to user scope for key {SecretKey} (client: {ClientName}). Continuing with machine-scoped secret. Error: {Error}",
+                        secretKey,
+                        clientName,
+                        ex.Message);
+                }
+
+                return Task.FromResult(secret);
             }
 
             if (!AutoCreate)

--- a/src/client/Fig.Client.SecretProvider.Dpapi/DpapiSecretProvider.cs
+++ b/src/client/Fig.Client.SecretProvider.Dpapi/DpapiSecretProvider.cs
@@ -11,7 +11,12 @@ namespace Fig.Client.SecretProvider.Dpapi
     public class DpapiSecretProvider : ClientSecretProviderBase<DpapiSecretProvider>
     {
         public DpapiSecretProvider()
-            : base("Dpapi")
+            : this(null)
+        {
+        }
+
+        protected DpapiSecretProvider(bool? autoCreate)
+            : base("Dpapi", autoCreate)
         {
         }
 
@@ -20,45 +25,36 @@ namespace Fig.Client.SecretProvider.Dpapi
         protected override Task<string> GetOrCreateSecretInternal(string clientName)
         {
             var secretKey = string.Format(SecretKeyFormat, clientName.Replace(" ", "").ToUpper());
-            var encryptedSecret = Environment.GetEnvironmentVariable(secretKey);
+            var encryptedSecret = GetStoredEncryptedSecret(secretKey);
 
             Logger?.LogDebug("Attempting to retrieve DPAPI secret for key {SecretKey} (client: {ClientName})",
                 secretKey, clientName);
             if (!string.IsNullOrEmpty(encryptedSecret))
             {
-                try
-                {
-                    var secret = Unprotect(encryptedSecret, DataProtectionScope.CurrentUser);
-                    SecretCache[clientName] = secret;
-                    Logger?.LogInformation(
-                        "Successfully retrieved DPAPI secret for key {SecretKey} (client: {ClientName})", secretKey,
-                        clientName);
-                    return Task.FromResult(secret);
-                }
-                catch (Exception ex)
-                {
-                    Logger?.LogError("Failed to decrypt DPAPI secret from environment variable {SecretKey}: {Error}",
-                        secretKey, ex.Message);
-                    throw new SecretNotFoundException(
-                        $"Failed to decrypt DPAPI secret from environment variable '{secretKey}': {ex.Message}", ex);
-                }
+                return Task.FromResult(ReadStoredSecret(clientName, secretKey, encryptedSecret, "user-scoped"));
+            }
+
+            var machineScopedSecret = GetCurrentProcessEncryptedSecret(secretKey);
+            if (!string.IsNullOrEmpty(machineScopedSecret))
+            {
+                return Task.FromResult(ReadStoredSecret(clientName, secretKey, machineScopedSecret, "machine-scoped"));
             }
 
             if (!AutoCreate)
             {
                 Logger?.LogError(
-                    "Encrypted client secret must be set in an environment variable called {SecretKey} (client: {ClientName})",
+                    "Encrypted client secret must be set in a user or machine environment variable called {SecretKey} (client: {ClientName})",
                     secretKey, clientName);
                 throw new SecretNotFoundException(
-                    $"Encrypted client secret must be set in an environment variable called {secretKey}");
+                    $"Encrypted client secret must be set in a user or machine environment variable called {secretKey}");
             }
 
             var newSecret = Guid.NewGuid().ToString();
             var protectedSecret = Protect(newSecret, DataProtectionScope.CurrentUser);
             try
             {
-                Environment.SetEnvironmentVariable(secretKey, protectedSecret, EnvironmentVariableTarget.User);
-                var verifyEncrypted = Environment.GetEnvironmentVariable(secretKey, EnvironmentVariableTarget.User);
+                SetStoredEncryptedSecret(secretKey, protectedSecret);
+                var verifyEncrypted = GetStoredEncryptedSecret(secretKey);
                 if (!string.IsNullOrEmpty(verifyEncrypted))
                 {
                     var verifySecret = Unprotect(verifyEncrypted, DataProtectionScope.CurrentUser);
@@ -96,7 +92,48 @@ namespace Fig.Client.SecretProvider.Dpapi
             }
         }
 
-        private string Unprotect(string encryptedString, DataProtectionScope scope)
+        protected virtual string? GetStoredEncryptedSecret(string secretKey)
+        {
+            return Environment.GetEnvironmentVariable(secretKey, EnvironmentVariableTarget.User);
+        }
+
+        protected virtual string? GetCurrentProcessEncryptedSecret(string secretKey)
+        {
+            return Environment.GetEnvironmentVariable(secretKey, EnvironmentVariableTarget.Machine);
+        }
+
+        protected virtual void SetStoredEncryptedSecret(string secretKey, string encryptedSecret)
+        {
+            Environment.SetEnvironmentVariable(secretKey, encryptedSecret, EnvironmentVariableTarget.User);
+        }
+
+        private string ReadStoredSecret(string clientName, string secretKey, string encryptedSecret, string scopeDescription)
+        {
+            try
+            {
+                var secret = Unprotect(encryptedSecret, DataProtectionScope.CurrentUser);
+                SecretCache[clientName] = secret;
+                Logger?.LogInformation(
+                    "Successfully retrieved DPAPI secret for key {SecretKey} from the {ScopeDescription} environment variable (client: {ClientName})",
+                    secretKey,
+                    scopeDescription,
+                    clientName);
+                return secret;
+            }
+            catch (Exception ex)
+            {
+                Logger?.LogError(
+                    "Failed to decrypt DPAPI secret from the {ScopeDescription} environment variable {SecretKey}: {Error}",
+                    scopeDescription,
+                    secretKey,
+                    ex.Message);
+                throw new SecretNotFoundException(
+                    $"Failed to decrypt DPAPI secret from the {scopeDescription} environment variable '{secretKey}': {ex.Message}",
+                    ex);
+            }
+        }
+
+        protected virtual string Unprotect(string encryptedString, DataProtectionScope scope)
         {
             try
             {
@@ -117,7 +154,7 @@ namespace Fig.Client.SecretProvider.Dpapi
             }
         }
 
-        private string Protect(string plainText, DataProtectionScope scope)
+        protected virtual string Protect(string plainText, DataProtectionScope scope)
         {
             try
             {

--- a/src/tests/Fig.Unit.Test/Client/DpapiSecretProviderTests.cs
+++ b/src/tests/Fig.Unit.Test/Client/DpapiSecretProviderTests.cs
@@ -1,0 +1,141 @@
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+using Fig.Client.Contracts;
+using Fig.Client.SecretProvider.Dpapi;
+using NUnit.Framework;
+
+namespace Fig.Unit.Test.Client;
+
+[TestFixture]
+public class DpapiSecretProviderTests
+{
+    [Test]
+    public async Task GetSecret_WhenUserScopedSecretExists_ReusesPersistedSecret()
+    {
+        var userScopedSecrets = new Dictionary<string, string>
+        {
+            ["FIG_TESTCLIENT_SECRET"] = "protected::existing-secret"
+        };
+
+        var provider = new TestDpapiSecretProvider(true, userScopedSecrets);
+
+        var secret = await provider.GetSecret("Test Client");
+
+        Assert.That(secret, Is.EqualTo("existing-secret"));
+        Assert.That(provider.ProtectCalls, Is.EqualTo(0));
+        Assert.That(provider.WriteCalls, Is.EqualTo(0));
+    }
+
+    [Test]
+    public async Task GetSecret_WhenSecretMissing_PersistsItForLaterRuns()
+    {
+        var userScopedSecrets = new Dictionary<string, string>();
+        var firstProvider = new TestDpapiSecretProvider(true, userScopedSecrets);
+
+        var firstSecret = await firstProvider.GetSecret("Test Client");
+
+        var secondProvider = new TestDpapiSecretProvider(true, userScopedSecrets);
+        var secondSecret = await secondProvider.GetSecret("Test Client");
+
+        Assert.That(userScopedSecrets, Contains.Key("FIG_TESTCLIENT_SECRET"));
+        Assert.That(secondSecret, Is.EqualTo(firstSecret));
+        Assert.That(firstProvider.WriteCalls, Is.EqualTo(1));
+        Assert.That(secondProvider.ProtectCalls, Is.EqualTo(0));
+        Assert.That(secondProvider.WriteCalls, Is.EqualTo(0));
+    }
+
+    [Test]
+    public async Task GetSecret_WhenBothUserAndMachineSecretsExist_PrefersUserScopedSecret()
+    {
+        var userScopedSecrets = new Dictionary<string, string>
+        {
+            ["FIG_TESTCLIENT_SECRET"] = "protected::user-secret"
+        };
+        var machineScopedSecrets = new Dictionary<string, string>
+        {
+            ["FIG_TESTCLIENT_SECRET"] = "protected::machine-secret"
+        };
+        var provider = new TestDpapiSecretProvider(true, userScopedSecrets, machineScopedSecrets);
+
+        var secret = await provider.GetSecret("Test Client");
+
+        Assert.That(secret, Is.EqualTo("user-secret"));
+        Assert.That(provider.ProtectCalls, Is.EqualTo(0));
+        Assert.That(provider.WriteCalls, Is.EqualTo(0));
+    }
+
+    [Test]
+    public async Task GetSecret_WhenOnlyMachineScopedSecretExists_UsesMachineScopedSecret()
+    {
+        var userScopedSecrets = new Dictionary<string, string>();
+        var machineScopedSecrets = new Dictionary<string, string>
+        {
+            ["FIG_TESTCLIENT_SECRET"] = "protected::machine-secret"
+        };
+        var provider = new TestDpapiSecretProvider(true, userScopedSecrets, machineScopedSecrets);
+
+        var secret = await provider.GetSecret("Test Client");
+
+        Assert.That(secret, Is.EqualTo("machine-secret"));
+        Assert.That(userScopedSecrets, Does.Not.ContainKey("FIG_TESTCLIENT_SECRET"));
+        Assert.That(provider.ProtectCalls, Is.EqualTo(0));
+        Assert.That(provider.WriteCalls, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void GetSecret_WhenSecretMissingAndAutoCreateDisabled_Throws()
+    {
+        var provider = new TestDpapiSecretProvider(false, new Dictionary<string, string>());
+
+        var ex = Assert.ThrowsAsync<SecretNotFoundException>(async () => await provider.GetSecret("Test Client"));
+
+        Assert.That(ex!.Message, Does.Contain("user or machine environment variable"));
+    }
+
+    private sealed class TestDpapiSecretProvider : DpapiSecretProvider
+    {
+        private readonly IDictionary<string, string> _userScopedSecrets;
+        private readonly IDictionary<string, string> _machineScopedSecrets;
+
+        public TestDpapiSecretProvider(
+            bool autoCreate,
+            IDictionary<string, string> userScopedSecrets,
+            IDictionary<string, string>? machineScopedSecrets = null)
+            : base(autoCreate)
+        {
+            _userScopedSecrets = userScopedSecrets;
+            _machineScopedSecrets = machineScopedSecrets ?? new Dictionary<string, string>();
+        }
+
+        public int ProtectCalls { get; private set; }
+        public int WriteCalls { get; private set; }
+
+        protected override string? GetStoredEncryptedSecret(string secretKey)
+        {
+            return _userScopedSecrets.TryGetValue(secretKey, out var value) ? value : null;
+        }
+
+        protected override string? GetCurrentProcessEncryptedSecret(string secretKey)
+        {
+            return _machineScopedSecrets.TryGetValue(secretKey, out var value) ? value : null;
+        }
+
+        protected override void SetStoredEncryptedSecret(string secretKey, string encryptedSecret)
+        {
+            WriteCalls++;
+            _userScopedSecrets[secretKey] = encryptedSecret;
+        }
+
+        protected override string Unprotect(string encryptedString, DataProtectionScope scope)
+        {
+            return encryptedString.Replace("protected::", string.Empty);
+        }
+
+        protected override string Protect(string plainText, DataProtectionScope scope)
+        {
+            ProtectCalls++;
+            return $"protected::{plainText}";
+        }
+    }
+}

--- a/src/tests/Fig.Unit.Test/Client/DpapiSecretProviderTests.cs
+++ b/src/tests/Fig.Unit.Test/Client/DpapiSecretProviderTests.cs
@@ -78,9 +78,10 @@ public class DpapiSecretProviderTests
         var secret = await provider.GetSecret("Test Client");
 
         Assert.That(secret, Is.EqualTo("machine-secret"));
-        Assert.That(userScopedSecrets, Does.Not.ContainKey("FIG_TESTCLIENT_SECRET"));
+        Assert.That(userScopedSecrets, Contains.Key("FIG_TESTCLIENT_SECRET"));
+        Assert.That(userScopedSecrets["FIG_TESTCLIENT_SECRET"], Is.EqualTo("protected::machine-secret"));
         Assert.That(provider.ProtectCalls, Is.EqualTo(0));
-        Assert.That(provider.WriteCalls, Is.EqualTo(0));
+        Assert.That(provider.WriteCalls, Is.EqualTo(1));
     }
 
     [Test]

--- a/src/tests/Fig.Unit.Test/Client/ValidatedHttpClientFactoryTests.cs
+++ b/src/tests/Fig.Unit.Test/Client/ValidatedHttpClientFactoryTests.cs
@@ -280,10 +280,12 @@ public class ValidatedHttpClientFactoryTests
         // Assert - the always-on summary log is emitted with the correct value and source
         _loggerMock.Verify(
             x => x.Log(
-                LogLevel.Information,
+                It.Is<LogLevel>(level => level == LogLevel.Information || level == LogLevel.Debug),
                 It.IsAny<EventId>(),
                 It.Is<It.IsAnyType>((v, t) =>
-                    v.ToString()!.Contains("Fig API request timeout: 15") &&
+                    v.ToString()!.Contains("Fig API request timeout") &&
+                    v.ToString()!.Contains("15") &&
+                    v.ToString()!.Contains("source:") &&
                     v.ToString()!.Contains(ValidatedHttpClientFactory.TimeoutEnvVar)),
                 It.IsAny<Exception>(),
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
@@ -299,10 +301,11 @@ public class ValidatedHttpClientFactoryTests
         // Assert - summary log shows FigOptions as source
         _loggerMock.Verify(
             x => x.Log(
-                LogLevel.Information,
+                It.Is<LogLevel>(level => level == LogLevel.Information || level == LogLevel.Debug),
                 It.IsAny<EventId>(),
                 It.Is<It.IsAnyType>((v, t) =>
-                    v.ToString()!.Contains("Fig API request timeout: 8") &&
+                    v.ToString()!.Contains("Fig API request timeout") &&
+                    v.ToString()!.Contains("8") &&
                     v.ToString()!.Contains("FigOptions.ApiRequestTimeout")),
                 It.IsAny<Exception>(),
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
@@ -318,10 +321,10 @@ public class ValidatedHttpClientFactoryTests
         // Assert - summary log shows "default" as source
         _loggerMock.Verify(
             x => x.Log(
-                LogLevel.Information,
+                It.Is<LogLevel>(level => level == LogLevel.Information || level == LogLevel.Debug),
                 It.IsAny<EventId>(),
                 It.Is<It.IsAnyType>((v, t) =>
-                    v.ToString()!.Contains("Fig API request timeout:") &&
+                    v.ToString()!.Contains("Fig API request timeout") &&
                     v.ToString()!.Contains("default")),
                 It.IsAny<Exception>(),
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
@@ -424,10 +427,11 @@ public class ValidatedHttpClientFactoryTests
         // Assert - summary log shows FigOptions source (not env var)
         _loggerMock.Verify(
             x => x.Log(
-                LogLevel.Information,
+                It.Is<LogLevel>(level => level == LogLevel.Information || level == LogLevel.Debug),
                 It.IsAny<EventId>(),
                 It.Is<It.IsAnyType>((v, t) =>
-                    v.ToString()!.Contains("Fig API request timeout: 12") &&
+                    v.ToString()!.Contains("Fig API request timeout") &&
+                    v.ToString()!.Contains("12") &&
                     v.ToString()!.Contains("FigOptions.ApiRequestTimeout")),
                 It.IsAny<Exception>(),
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()),

--- a/src/tests/Fig.Unit.Test/Client/ValidatedHttpClientFactoryTests.cs
+++ b/src/tests/Fig.Unit.Test/Client/ValidatedHttpClientFactoryTests.cs
@@ -8,6 +8,7 @@ using System.Runtime.InteropServices;
 namespace Fig.Unit.Test.Client;
 
 [TestFixture]
+[NonParallelizable]
 public class ValidatedHttpClientFactoryTests
 {
     private Mock<ILogger<ValidatedHttpClientFactory>> _loggerMock = null!;
@@ -433,4 +434,3 @@ public class ValidatedHttpClientFactoryTests
             Times.Once);
     }
 }
-

--- a/src/tests/Fig.Unit.Test/Fig.Unit.Test.csproj
+++ b/src/tests/Fig.Unit.Test/Fig.Unit.Test.csproj
@@ -25,6 +25,7 @@
 	<ItemGroup>
 		<ProjectReference Include="..\..\api\Fig.Api\Fig.Api.csproj" />
 		<ProjectReference Include="..\..\client\Fig.Client.Contracts\Fig.Client.Contracts.csproj" />
+		<ProjectReference Include="..\..\client\Fig.Client.SecretProvider.Dpapi\Fig.Client.SecretProvider.Dpapi.csproj" />
 		<ProjectReference Include="..\..\client\Fig.Client.Testing\Fig.Client.Testing.csproj" />
 		<ProjectReference Include="..\..\client\Fig.Client\Fig.Client.csproj" />
 		<ProjectReference Include="..\..\common\Fig.Common.NetStandard\Fig.Common.NetStandard.csproj" />


### PR DESCRIPTION
Read persisted user-scoped DPAPI secrets before auto-creating new ones and migrate legacy process-scoped secrets into the user profile when possible. Add unit coverage for persisted reuse, first-run creation, legacy migration, and missing-secret failure, and update the current and 3.x DPAPI docs to match the behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DPAPI secret provider now persists auto-created secrets as encrypted user-scoped environment variables, falls back to machine-scoped when absent, and reuses cached secrets across runs.

* **Documentation**
  * Updated docs and PowerShell example to reflect user-scoped persistence, CurrentUser DPAPI scope, and machine-scoped fallback behavior.

* **Tests**
  * Added/expanded tests for user vs. machine precedence, persistence across runs, auto-create behavior, and failure paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->