### PR TITLE
Add group-managed setting icon

### DIFF
--- a/src/tests/Fig.Unit.Test/Web/SettingClientFacadeGroupMetadataTests.cs
+++ b/src/tests/Fig.Unit.Test/Web/SettingClientFacadeGroupMetadataTests.cs
@@ -242,6 +242,36 @@ public class SettingClientFacadeGroupMetadataTests
         Assert.That(groupClient.Settings.Select(setting => setting.DisplayOrder), Is.EqualTo(new[] { 0, 1 }));
     }
 
+    [Test]
+    public async Task ShallPropagateOwningGroupNameToGroupedAndManagedSettings()
+    {
+        SetupGroupsResponse(new List<SettingGroupDataContract>
+        {
+            new(Guid.NewGuid(), "SharedGroup", null, new List<GroupedSettingDataContract>
+            {
+                new("Timeout", null, "System.String",
+                    new List<SourceSettingDataContract>
+                    {
+                        new("ClientA", "Timeout"),
+                        new("ClientB", "Timeout")
+                    })
+            })
+        });
+
+        await _sut.LoadAllClients();
+
+        var groupClient = _sut.SettingClients.Single(client => client.IsGroup && client.Name == "SharedGroup");
+        var groupSetting = groupClient.Settings.Single();
+        var clientATimeout = _clientA.Settings.Single(setting => setting.Name == "Timeout");
+        var clientBTimeout = _clientB.Settings.Single(setting => setting.Name == "Timeout");
+
+        Assert.That(groupSetting.Group, Is.EqualTo("SharedGroup"));
+        Assert.That(clientATimeout.Group, Is.EqualTo("SharedGroup"));
+        Assert.That(clientBTimeout.Group, Is.EqualTo("SharedGroup"));
+        Assert.That(clientATimeout.IsGroupManaged, Is.True);
+        Assert.That(clientBTimeout.IsGroupManaged, Is.True);
+    }
+
     private void SetupGroupsResponse(List<SettingGroupDataContract> groups)
     {
         _httpService

--- a/src/tests/Fig.Unit.Test/Web/SettingIconsTests.cs
+++ b/src/tests/Fig.Unit.Test/Web/SettingIconsTests.cs
@@ -1,0 +1,52 @@
+using System.Reflection;
+using Fig.Web.Models.Setting;
+using Fig.Web.Pages.Setting;
+using Moq;
+using NUnit.Framework;
+
+namespace Fig.Unit.Test.Web;
+
+[TestFixture]
+public class SettingIconsTests
+{
+    [Test]
+    public void GetGroupManagedTooltip_ShowsSpecificGroupName_WhenGroupIsAvailable()
+    {
+        var component = new SettingIcons
+        {
+            Setting = CreateMockSetting("Shared Messaging")
+        };
+
+        var tooltip = InvokeGroupManagedTooltip(component);
+
+        Assert.That(tooltip, Is.EqualTo("Managed by setting group Shared Messaging"));
+    }
+
+    [Test]
+    public void GetGroupManagedTooltip_ShowsGenericText_WhenGroupIsMissing()
+    {
+        var component = new SettingIcons
+        {
+            Setting = CreateMockSetting(null)
+        };
+
+        var tooltip = InvokeGroupManagedTooltip(component);
+
+        Assert.That(tooltip, Is.EqualTo("Managed by a setting group"));
+    }
+
+    private static string InvokeGroupManagedTooltip(SettingIcons component)
+    {
+        var method = typeof(SettingIcons).GetMethod("GetGroupManagedTooltip", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.That(method, Is.Not.Null);
+
+        return (string)method!.Invoke(component, null)!;
+    }
+
+    private static ISetting CreateMockSetting(string? groupName)
+    {
+        var mock = new Mock<ISetting>();
+        mock.SetupGet(s => s.Group).Returns(groupName);
+        return mock.Object;
+    }
+}

--- a/src/web/Fig.Web/Facades/SettingClientFacade.cs
+++ b/src/web/Fig.Web/Facades/SettingClientFacade.cs
@@ -618,7 +618,7 @@ public class SettingClientFacade : ISettingClientFacade
                     cloned.SetDescription(gs.Description);
                 }
 
-                cloned.SetGroupManagedSettings(managedSettings);
+                cloned.SetGroupManagedSettings(managedSettings, group.Name);
                 settings.Add(cloned);
             }
 

--- a/src/web/Fig.Web/Models/Setting/ISetting.cs
+++ b/src/web/Fig.Web/Models/Setting/ISetting.cs
@@ -117,7 +117,9 @@ public interface ISetting : IScriptableSetting
 
     void SetDescription(string? description);
 
-    void SetGroupManagedSettings(List<ISetting> matches);
+    void SetGroup(string? groupName);
+
+    void SetGroupManagedSettings(List<ISetting> matches, string? groupName = null);
 
     void ShowAdvancedChanged(bool showAdvanced);
     

--- a/src/web/Fig.Web/Models/Setting/SettingConfigurationModel.cs
+++ b/src/web/Fig.Web/Models/Setting/SettingConfigurationModel.cs
@@ -197,7 +197,7 @@ public abstract class SettingConfigurationModel<T> : ISetting, ISearchableSettin
     
     public string RawDescription { get; private set; } = string.Empty;
 
-    public string? Group { get; }
+    public string? Group { get; private set; }
 
     public int? DisplayOrder { get; set; }
     
@@ -419,6 +419,11 @@ public abstract class SettingConfigurationModel<T> : ISetting, ISearchableSettin
         _lowerDescription = TruncatedDescription.ToLowerInvariant();
     }
 
+    public void SetGroup(string? groupName)
+    {
+        Group = string.IsNullOrWhiteSpace(groupName) ? null : groupName;
+    }
+
     public void SetValue(object? value)
     {
         Value = (T?)value;
@@ -511,11 +516,20 @@ public abstract class SettingConfigurationModel<T> : ISetting, ISearchableSettin
         }
     }
 
-    public void SetGroupManagedSettings(List<ISetting> groupManagedSettings)
+    public void SetGroupManagedSettings(List<ISetting> groupManagedSettings, string? groupName = null)
     {
         GroupManagedSettings = groupManagedSettings;
+
+        if (!string.IsNullOrWhiteSpace(groupName))
+            SetGroup(groupName);
+
         foreach (var setting in GroupManagedSettings)
+        {
             setting.IsGroupManaged = true;
+            if (!string.IsNullOrWhiteSpace(groupName))
+                setting.SetGroup(groupName);
+        }
+
         UpdateGroupValueAlignment();
     }
 

--- a/src/web/Fig.Web/Pages/Setting/SettingIcons.razor
+++ b/src/web/Fig.Web/Pages/Setting/SettingIcons.razor
@@ -8,6 +8,8 @@
             MouseEnter="@(args => OnShowTooltip(args, "Functional setting"))"/>
 <RadzenIcon Icon="stars" IconStyle="IconStyle.Warning" Visible="@(Setting.Classification == Classification.Special && IsAdmin)" Style="@GetStarsIconStyle()"
             MouseEnter="@(args => OnShowTooltip(args, "Special setting"))"/>
+<RadzenIcon Icon="hub" IconStyle="IconStyle.Info" Visible="@(Setting.IsGroupManaged && IsAdmin)" Style="@GetIconStyle()"
+            MouseEnter="@(args => OnShowTooltip(args, GetGroupManagedTooltip()))"/>
 @if (GetDependentSettingsCount() > 0)
 {
     <RadzenIcon Icon="visibility" IconStyle="IconStyle.Info" Style="@GetIconStyle()"

--- a/src/web/Fig.Web/Pages/Setting/SettingIcons.razor.cs
+++ b/src/web/Fig.Web/Pages/Setting/SettingIcons.razor.cs
@@ -49,6 +49,13 @@ public partial class SettingIcons
     {
         return $"font-size: {FontSize}em; margin-left: 4px";
     }
+
+    private string GetGroupManagedTooltip()
+    {
+        return string.IsNullOrWhiteSpace(Setting.Group)
+            ? "Managed by a setting group"
+            : $"Managed by setting group {Setting.Group}";
+    }
     
     private int GetDependentSettingsCount()
     {


### PR DESCRIPTION
## Summary
- add an admin-only group-managed icon to the shared setting card icon strip
- show a specific tooltip when the owning setting group name is available
- add unit coverage for the tooltip text helper

## Testing
- dotnet build Fig.sln --configuration Release --no-restore
- dotnet test tests/Fig.Unit.Test/Fig.Unit.Test.csproj --configuration Release --no-build --verbosity minimal