### PR TITLE
Fix problem where FigIgnore attribute did not git ignored when evaluating if a class was suitable for a data grid

### DIFF
--- a/src/client/Fig.Client/DefaultValue/DataGridValueConverter.cs
+++ b/src/client/Fig.Client/DefaultValue/DataGridValueConverter.cs
@@ -76,7 +76,9 @@ internal static class DataGridValueConverter
     {
         var result = new Dictionary<string, object?>();
         var properties = item.GetType().GetProperties(BindingFlags.Instance | BindingFlags.Public);
-        foreach (var property in properties.Where(a => columnNames == null || columnNames.Contains(a.Name)))
+        foreach (var property in properties.Where(a =>
+                     a.IsIncludedDataGridProperty() &&
+                     (columnNames == null || columnNames.Contains(a.Name))))
         {
             var value = property.GetValue(item, null);
             if (property.PropertyType.IsEnum())

--- a/src/client/Fig.Client/SettingDefinitionFactory.cs
+++ b/src/client/Fig.Client/SettingDefinitionFactory.cs
@@ -743,13 +743,8 @@ internal class SettingDefinitionFactory : ISettingDefinitionFactory
         {
             foreach (var property in genericType!.GetProperties(
                              BindingFlags.Public | BindingFlags.Instance)
-                                       .Where(p => p.GetGetMethod() != null &&
-                                                              p.GetSetMethod() != null))
+                                       .Where(p => p.IsIncludedDataGridProperty()))
             {
-                var ignore = GetIsIgnore(property);
-                if (ignore)
-                    continue;
-                
                 DataGridColumnDataContract column;
                 if (property.PropertyType.IsEnum())
                 {
@@ -828,14 +823,6 @@ internal class SettingDefinitionFactory : ISettingDefinitionFactory
             .FirstOrDefault(a => a is ReadOnlyAttribute) as ReadOnlyAttribute;
 
         return readOnlyAttribute != null;
-    }
-    
-    private bool GetIsIgnore(PropertyInfo property)
-    {
-        var ignoreAttribute = property.GetCustomAttributes(true)
-            .FirstOrDefault(a => a is FigIgnoreAttribute) as FigIgnoreAttribute;
-
-        return ignoreAttribute != null;
     }
     
     private (string? Regex, string? Explanation) GetValidation(PropertyInfo property)

--- a/src/common/Fig.Contracts/ExtensionMethods/TypeExtensionMethods.cs
+++ b/src/common/Fig.Contracts/ExtensionMethods/TypeExtensionMethods.cs
@@ -2,7 +2,9 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text.RegularExpressions;
+using Fig.Client.Abstractions.Attributes;
 
 namespace Fig.Contracts.ExtensionMethods
 {
@@ -59,6 +61,7 @@ namespace Fig.Contracts.ExtensionMethods
                     "System.Nullable`1[[System.TimeSpan, System.Private.CoreLib,  Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]",
                     Contracts.FigPropertyType.TimeSpan
                 }
+
             };
 
         public static FigPropertyType FigPropertyType(this Type? type)
@@ -107,8 +110,8 @@ namespace Fig.Contracts.ExtensionMethods
                     if (arguments[0] == typeof(Dictionary<string, object>)) // Could be this for imports
                         return true;
                     
-                    var properties = arguments[0].GetProperties();
-                    if (properties.All(property =>
+                    var properties = arguments[0].GetIncludedDataGridProperties().ToList();
+                    if (properties.Any() && properties.All(property =>
                             property.PropertyType.FigPropertyType() != Contracts.FigPropertyType.Unsupported ||
                             property.PropertyType.IsEnum()))
                     {
@@ -139,6 +142,19 @@ namespace Fig.Contracts.ExtensionMethods
         public static bool IsEnumerableType(this Type type)
         {
             return typeof(IEnumerable).IsAssignableFrom(type) && type != typeof(string);
+        }
+
+        public static IEnumerable<PropertyInfo> GetIncludedDataGridProperties(this Type type)
+        {
+            return type.GetProperties(BindingFlags.Instance | BindingFlags.Public)
+                .Where(IsIncludedDataGridProperty);
+        }
+
+        public static bool IsIncludedDataGridProperty(this PropertyInfo property)
+        {
+            return property.GetGetMethod() != null &&
+                   property.GetSetMethod() != null &&
+                   !Attribute.IsDefined(property, typeof(FigIgnoreAttribute), true);
         }
     }
 }

--- a/src/tests/Fig.Integration.Test/Client/TypeExtensionMethodsTest.cs
+++ b/src/tests/Fig.Integration.Test/Client/TypeExtensionMethodsTest.cs
@@ -7,6 +7,7 @@ using NUnit.Framework;
 namespace Fig.Integration.Test.Client;
 
 [TestFixture]
+[NonParallelizable]
 public class TypeExtensionMethodsTest
 {
     [Test]

--- a/src/tests/Fig.Integration.Test/Client/TypeExtensionMethodsTest.cs
+++ b/src/tests/Fig.Integration.Test/Client/TypeExtensionMethodsTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Fig.Client.Abstractions.Attributes;
 using Fig.Contracts.ExtensionMethods;
 using NUnit.Framework;
 
@@ -46,6 +47,9 @@ public class TypeExtensionMethodsTest
     [TestCase(typeof(SomeClass), false)]
     [TestCase(typeof(Animals), false)]
     [TestCase(typeof(List<SomeClass>), true)]
+    [TestCase(typeof(List<SomeClassWithIgnoredUnsupportedProperty>), true)]
+    [TestCase(typeof(List<SomeClassWithReadOnlyUnsupportedProperty>), true)]
+    [TestCase(typeof(List<SomeClassWithOnlyIgnoredUnsupportedProperty>), false)]
     [TestCase(typeof(Dictionary<string, SomeClass>), false)]
     [TestCase(typeof(KeyValuePair<string, SomeClass>), false)]
     public void ShallSupportDataGridTypes(Type type, bool isSupported)
@@ -57,6 +61,32 @@ public class TypeExtensionMethodsTest
     public class SomeClass
     {
         public string? Sample { get; set; }
+    }
+
+    public class SomeClassWithIgnoredUnsupportedProperty
+    {
+        public string? Sample { get; set; }
+
+        [FigIgnore]
+        public UnsupportedClass Ignored { get; set; } = new();
+    }
+
+    public class SomeClassWithReadOnlyUnsupportedProperty
+    {
+        public string? Sample { get; set; }
+
+        public UnsupportedClass ReadOnlyUnsupported { get; } = new();
+    }
+
+    public class SomeClassWithOnlyIgnoredUnsupportedProperty
+    {
+        [FigIgnore]
+        public UnsupportedClass Ignored { get; set; } = new();
+    }
+
+    public class UnsupportedClass
+    {
+        public string? Value { get; set; }
     }
 
     public enum Animals

--- a/src/tests/Fig.Unit.Test/Client/SettingUpdaterTests.cs
+++ b/src/tests/Fig.Unit.Test/Client/SettingUpdaterTests.cs
@@ -51,6 +51,7 @@ public class SettingUpdaterTests
         Assert.That(dataGrid.Value![0]["Name"], Is.EqualTo("First"));
         Assert.That(dataGrid.Value[0]["Count"], Is.EqualTo(1));
         Assert.That(dataGrid.Value[0]["Pet"], Is.EqualTo("Dog"));
+        Assert.That(dataGrid.Value[0], Does.Not.ContainKey(nameof(UpdaterRow.IgnoredThing)));
     }
 
     [Test]
@@ -178,6 +179,14 @@ public class SettingUpdaterTests
         public int Count { get; set; }
 
         public UpdaterPet Pet { get; set; }
+
+        [FigIgnore]
+        public UpdaterIgnoredThing IgnoredThing { get; set; } = new();
+    }
+
+    private sealed class UpdaterIgnoredThing
+    {
+        public string Value { get; set; } = "ignored";
     }
 
     private enum UpdaterPet

--- a/src/tests/Fig.Unit.Test/Client/UnsupportedTypeValidationTests.cs
+++ b/src/tests/Fig.Unit.Test/Client/UnsupportedTypeValidationTests.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Fig.Client;
 using Fig.Client.Abstractions.Attributes;
 using Fig.Client.Description;
 using Fig.Client.DefaultValue;
+using Fig.Contracts.Settings;
 using Moq;
 using NUnit.Framework;
 
@@ -119,6 +121,35 @@ namespace Fig.Unit.Test.Client
             
             Assert.That(ex!.Message, Does.Contain("NullableFloatSetting"));
             Assert.That(ex.Message, Does.Contain("not supported"));
+        }
+
+        [Test]
+        public void CreateDataContract_WithIgnoredUnsupportedPropertyInListRow_ShouldRegisterAsDataGrid()
+        {
+            var settings = new TestSettingsWithIgnoredUnsupportedListRow();
+
+            var dataContract = settings.CreateDataContract("TestClient");
+            var rowsSetting = dataContract.Settings.Single(a => a.Name == nameof(TestSettingsWithIgnoredUnsupportedListRow.Rows));
+            var defaultValue = (DataGridSettingDataContract)rowsSetting.DefaultValue!;
+
+            Assert.That(rowsSetting.DataGridDefinition, Is.Not.Null);
+            Assert.That(rowsSetting.JsonSchema, Is.Null);
+            Assert.That(rowsSetting.DataGridDefinition!.Columns.Select(a => a.Name), Is.EqualTo(new[] { "Name" }));
+            Assert.That(defaultValue.Value, Has.Count.EqualTo(1));
+            Assert.That(defaultValue.Value![0], Does.ContainKey("Name"));
+            Assert.That(defaultValue.Value[0], Does.Not.ContainKey(nameof(IgnoredUnsupportedRow.Ignored)));
+        }
+
+        [Test]
+        public void CreateDataContract_WithOnlyIgnoredUnsupportedPropertiesInListRow_ShouldRegisterAsJson()
+        {
+            var settings = new TestSettingsWithOnlyIgnoredUnsupportedListRow();
+
+            var dataContract = settings.CreateDataContract("TestClient");
+            var rowsSetting = dataContract.Settings.Single(a => a.Name == nameof(TestSettingsWithOnlyIgnoredUnsupportedListRow.Rows));
+
+            Assert.That(rowsSetting.DataGridDefinition, Is.Null);
+            Assert.That(rowsSetting.JsonSchema, Is.Not.Null);
         }
     }
 
@@ -240,5 +271,66 @@ namespace Fig.Unit.Test.Client
         {
             return Array.Empty<string>();
         }
+    }
+
+    public class TestSettingsWithIgnoredUnsupportedListRow : SettingsBase
+    {
+        public override string ClientDescription => "Test client with ignored unsupported list row";
+
+        [Setting("Rows setting", defaultValueMethodName: nameof(GetRows))]
+        public List<IgnoredUnsupportedRow> Rows { get; set; } = [];
+
+        public override IEnumerable<string> GetValidationErrors()
+        {
+            return Array.Empty<string>();
+        }
+
+        public static List<IgnoredUnsupportedRow> GetRows()
+        {
+            return
+            [
+                new() { Name = "First" }
+            ];
+        }
+    }
+
+    public class TestSettingsWithOnlyIgnoredUnsupportedListRow : SettingsBase
+    {
+        public override string ClientDescription => "Test client with only ignored unsupported list row";
+
+        [Setting("Rows setting", defaultValueMethodName: nameof(GetRows))]
+        public List<OnlyIgnoredUnsupportedRow> Rows { get; set; } = [];
+
+        public override IEnumerable<string> GetValidationErrors()
+        {
+            return Array.Empty<string>();
+        }
+
+        public static List<OnlyIgnoredUnsupportedRow> GetRows()
+        {
+            return
+            [
+                new()
+            ];
+        }
+    }
+
+    public class IgnoredUnsupportedRow
+    {
+        public string Name { get; set; } = "Name";
+
+        [FigIgnore]
+        public UnsupportedRowValue Ignored { get; set; } = new();
+    }
+
+    public class OnlyIgnoredUnsupportedRow
+    {
+        [FigIgnore]
+        public UnsupportedRowValue Ignored { get; set; } = new();
+    }
+
+    public class UnsupportedRowValue
+    {
+        public string Value { get; set; } = "ignored";
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support excluding DataGrid properties via a ignore attribute so unwanted fields no longer appear in grid columns or row data.

* **Refactor**
  * Unified and simplified DataGrid property filtering to ensure column generation and value conversion use the same inclusion rules.

* **Tests**
  * Added and updated integration and unit tests to cover ignored/read-only property scenarios and list-row behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mzbrau/fig/pull/285)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->