### PR TITLE
Fix problem where data grids were not marked as dirty when set by dis…

### DIFF
--- a/src/client/Fig.Client.Testing/Fig.Client.Testing.csproj
+++ b/src/client/Fig.Client.Testing/Fig.Client.Testing.csproj
@@ -27,7 +27,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Jint" Version="4.9.1" />
+        <PackageReference Include="Jint" Version="4.9.0" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/client/Fig.Client.Testing/Scripts/TestDataGridSetting.cs
+++ b/src/client/Fig.Client.Testing/Scripts/TestDataGridSetting.cs
@@ -8,7 +8,7 @@ namespace Fig.Client.Testing.Scripts;
 /// <summary>
 /// A test data grid setting implementation for testing display scripts
 /// </summary>
-public class TestDataGridSetting : TestSetting, IDataGridSettingModel
+public class TestDataGridSetting : TestSetting, IDataGridSettingModel, IDataGridDirtyEvaluationSettingModel
 {
     public TestDataGridSetting(string name, List<Dictionary<string, IDataGridValueModel>>? initialValue = null)
         : base(name, typeof(List<Dictionary<string, IDataGridValueModel>>), initialValue)
@@ -61,6 +61,10 @@ public class TestDataGridSetting : TestSetting, IDataGridSettingModel
         {
             IsValid = true;
         }
+    }
+
+    public void EvaluateDirty()
+    {
     }
 
     public override object? GetValue(bool formatAsT = false) => Value;

--- a/src/common/Fig.Common.NetStandard/Scripting/IDataGridDirtyEvaluationSettingModel.cs
+++ b/src/common/Fig.Common.NetStandard/Scripting/IDataGridDirtyEvaluationSettingModel.cs
@@ -1,0 +1,6 @@
+namespace Fig.Common.NetStandard.Scripting;
+
+public interface IDataGridDirtyEvaluationSettingModel
+{
+    void EvaluateDirty();
+}

--- a/src/common/Fig.Common.NetStandard/Scripting/SettingWrapper.cs
+++ b/src/common/Fig.Common.NetStandard/Scripting/SettingWrapper.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Dynamic;
 using System.Linq;
+using Newtonsoft.Json;
 
 namespace Fig.Common.NetStandard.Scripting;
 
@@ -13,6 +14,7 @@ public class SettingWrapper
     private List<object>? _dataGridIsReadOnly;
     private List<object>? _dataGridValidationErrors;
     private List<object>? _dataGridEditorLineCount;
+    private string? _dataGridValueSnapshot;
 
     public SettingWrapper(IScriptableSetting setting)
     {
@@ -259,6 +261,7 @@ public class SettingWrapper
             if (_setting is IDataGridSettingModel)
             {
                 _dataGridValue = ConvertToObjectList(_setting.GetValue(true) as List<Dictionary<string, IDataGridValueModel?>>, model => model.ReadOnlyValue);
+                _dataGridValueSnapshot = _dataGridValue is null ? null : JsonConvert.SerializeObject(_dataGridValue);
                 return _dataGridValue?.ToArray();
             }
             
@@ -281,6 +284,8 @@ public class SettingWrapper
                     setting.Value![index][property.Key].SetValue(typedValue ?? string.Empty);
                 });
 
+                EvaluateDataGridDirty();
+
                 return;
             }
             
@@ -293,7 +298,10 @@ public class SettingWrapper
 
     public void ApplyChangesToDataGrid()
     {
-        if (_dataGridValue is not null)
+        var dataGridValueChanged = _dataGridValue is not null &&
+                                   _dataGridValueSnapshot != JsonConvert.SerializeObject(_dataGridValue);
+
+        if (dataGridValueChanged)
             Value = _dataGridValue;
 
         if (_dataGridValidValues is not null)
@@ -307,6 +315,9 @@ public class SettingWrapper
 
         if (_dataGridEditorLineCount is not null)
             EditorLineCount = _dataGridEditorLineCount;
+
+        if (dataGridValueChanged)
+            EvaluateDataGridDirty();
     }
     
     private List<dynamic>? ConvertToObjectList(List<Dictionary<string, IDataGridValueModel?>>? sourceCollection, Func<IDataGridValueModel, object?> getValue)
@@ -381,5 +392,11 @@ public class SettingWrapper
                 applyUpdate(property!, dataGridSetting, columns, i);
             }
         }
+    }
+
+    private void EvaluateDataGridDirty()
+    {
+        if (_setting is IDataGridDirtyEvaluationSettingModel dataGridSetting)
+            dataGridSetting.EvaluateDirty();
     }
 }

--- a/src/tests/Fig.Unit.Test/Web/ScriptRunnerTests.cs
+++ b/src/tests/Fig.Unit.Test/Web/ScriptRunnerTests.cs
@@ -236,6 +236,44 @@ public class ScriptRunnerTests
     }
 
     [Test]
+    public void ShallMarkDataGridDirtyWhenScriptUpdatesValue()
+    {
+        var client = CreateSettingClientModel();
+
+        _runner.RunScript("eleven.Value[0].Name = 'todd';", new ScriptableClientAdapter(client));
+
+        var dataGrid = client.Settings.Single(a => a.Name == "eleven");
+        Assert.That(dataGrid.IsDirty, Is.True);
+        Assert.That(client.DirtySettingCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void ShallMarkDataGridDirtyWhenScriptSetsValue()
+    {
+        var client = CreateSettingClientModel();
+
+        _runner.RunScript(
+            "eleven.Value = [{ Name: 'todd', Age: 30, Pet: 'cat' }, { Name: 'john', Age: 25, Pet: 'dog' }];",
+            new ScriptableClientAdapter(client));
+
+        var dataGrid = client.Settings.Single(a => a.Name == "eleven");
+        Assert.That(dataGrid.IsDirty, Is.True);
+        Assert.That(client.DirtySettingCount, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void ShallNotMarkDataGridDirtyWhenScriptOnlyReadsValue()
+    {
+        var client = CreateSettingClientModel();
+
+        _runner.RunScript("log(eleven.Value[0].Name);", new ScriptableClientAdapter(client));
+
+        var dataGrid = client.Settings.Single(a => a.Name == "eleven");
+        Assert.That(dataGrid.IsDirty, Is.False);
+        Assert.That(client.DirtySettingCount, Is.EqualTo(0));
+    }
+
+    [Test]
     public void ShallUpdateDataGridValidValues()
     {
         _runner.RunScript("eleven.ValidValues[0].Pet = [\"Spider\", \"Snake\", \"Parrot\", \"Horse\"];", _model);
@@ -439,6 +477,11 @@ item.Pet = values;
 
     private IScriptableClient CreateModel()
     {
+        return new ScriptableClientAdapter(CreateSettingClientModel());
+    }
+
+    private SettingClientConfigurationModel CreateSettingClientModel()
+    {
         var presentation = new SettingPresentation(false);
         var model = new SettingClientConfigurationModel("test", "test", null, true, Mock.Of<IScriptRunner>());
         model.Settings = new List<ISetting>()
@@ -520,7 +563,7 @@ item.Pet = values;
                 presentation),
         };
 
-        return new ScriptableClientAdapter(model);
+        return model;
     }
 
     private ScriptRunner CreateRunner()

--- a/src/web/Fig.Web/Fig.Web.csproj
+++ b/src/web/Fig.Web/Fig.Web.csproj
@@ -12,7 +12,7 @@
     <ItemGroup>
         <PackageReference Include="BCrypt.Net-Next" Version="4.2.0" />
         <PackageReference Include="Humanizer.Core" Version="3.0.10" />
-        <PackageReference Include="Jint" Version="4.9.1" />
+        <PackageReference Include="Jint" Version="4.9.0" />
         <PackageReference Include="Markdig" Version="1.2.0" />
         <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.8" />
         <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.8" PrivateAssets="all" />

--- a/src/web/Fig.Web/Models/Setting/ConfigurationModels/DataGrid/DataGridSettingConfigurationModel.cs
+++ b/src/web/Fig.Web/Models/Setting/ConfigurationModels/DataGrid/DataGridSettingConfigurationModel.cs
@@ -12,7 +12,7 @@ using Newtonsoft.Json;
 
 namespace Fig.Web.Models.Setting.ConfigurationModels.DataGrid;
 
-public class DataGridSettingConfigurationModel : SettingConfigurationModel<List<Dictionary<string, IDataGridValueModel>>>, IDataGridSettingModel
+public class DataGridSettingConfigurationModel : SettingConfigurationModel<List<Dictionary<string, IDataGridValueModel>>>, IDataGridSettingModel, IDataGridDirtyEvaluationSettingModel
 {
     private const string SecretDiffMask = "******";
     private const string SecretDiffChangedMask = "****** (changed)";


### PR DESCRIPTION
…play scripts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Data-grid settings now expose an explicit dirty-evaluation capability to allow manual/automatic re-evaluation of changed values.

* **Bug Fixes**
  * Improved data-grid change detection using snapshot comparison so modifications made by scripts correctly mark settings as dirty.

* **Tests**
  * Added tests verifying dirty-state detection when scripts update, set, or only read data-grid values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mzbrau/fig/pull/286)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->