### PR TITLE
Add keycloak support

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,0 +1,1 @@
+settings.local.json

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -137,6 +137,7 @@ docker-compose.yml                 # Container orchestration
 - **Port conflicts**: Default ports are 7281 (API HTTPS), 5260 (API HTTP), 7148 (Web HTTPS), 5217 (Web HTTP)
 - **Package restore timeout**: Allow full 10+ minutes, network-dependent operation
 - **Integration test failures**: Often database-related, ensure clean state between runs
+- **Local integration test crashes**: On this current machine, the integration test suite often crashes due to memory pressure. Prefer targeted integration test classes or filtered runs locally, and treat full-suite local crashes as environment-sensitive unless a specific failing test is isolated.
 
 ## Security Notes
 

--- a/.github/workflows/dotnet_build.yml
+++ b/.github/workflows/dotnet_build.yml
@@ -100,6 +100,9 @@ jobs:
         name: build-outputs
         path: src
 
+    - name: Restore
+      run: dotnet restore ./src
+
     - name: Run Unit Tests
       working-directory: src/tests/Fig.Unit.Test
       run: dotnet test --configuration Release --no-build --no-restore --verbosity detailed --collect:"XPlat Code Coverage" --logger "trx;LogFileName=unit-test-results.trx" --results-directory ./TestResults --settings ../../test.runsettings --blame-hang-timeout 20m Fig.Unit.Test.csproj
@@ -144,6 +147,9 @@ jobs:
       with:
         name: build-outputs
         path: src
+
+    - name: Restore
+      run: dotnet restore ./src
 
     - name: Run Integration Tests
       working-directory: src/tests/Fig.Integration.Test

--- a/README.md
+++ b/README.md
@@ -126,6 +126,18 @@ Examples can be found [here](https://github.com/mzbrau/fig/tree/main/examples).
 
 There is also a quick start repository [here](https://github.com/mzbrau/fig-quick-start).
 
+## Authentication Modes
+
+Fig supports two API/web authentication modes:
+
+- `FigManaged` (default): users authenticate directly against Fig (`/users/authenticate`).
+- `Keycloak`: users authenticate through Keycloak (OIDC/JWT). Fig user-management endpoints are not available in this mode.
+
+For full setup, claim mapping, endpoint behavior, and troubleshooting, see:
+
+- [Security Features](./doc/fig-documentation/docs/security.md)
+- [User Management](./doc/fig-documentation/docs/features/3-user-management.md)
+
 ## Fig NuGet Packages
 
 Fig provides several NuGet packages to support different integration scenarios and environments:

--- a/doc/fig-documentation/docs/features/3-user-management.md
+++ b/doc/fig-documentation/docs/features/3-user-management.md
@@ -38,3 +38,13 @@ Wherever Fig asks for a new password, it now shows richer [zxcvbn](https://githu
 
 ![manage account](./img/manage-account.png)
 *Users are able to manage their own accounts*
+
+## Keycloak Mode
+
+When Fig is configured to use Keycloak authentication mode, user identities are managed externally and Fig user management is disabled.
+
+- `POST /users/authenticate` is unavailable.
+- User-management endpoints (`/users`, `/users/register`, `/users/{id}`) are unavailable.
+- In the web UI, user-management actions are suppressed in Keycloak mode.
+
+For full setup details, claim mapping requirements, and mode troubleshooting, see [Security Features](../security.md#keycloak-authentication-mode).

--- a/doc/fig-documentation/docs/features/38-reports.md
+++ b/doc/fig-documentation/docs/features/38-reports.md
@@ -98,6 +98,14 @@ When **Fig Assistant** is enabled and configured under Configuration:
 
 AI-assisted generation can take longer than a normal report.
 
+## Keycloak authentication mode
+
+When Fig runs with `Authentication.Mode=Keycloak`, Fig’s user directory is not available:
+
+- User parameters (for example **User Activity**) use a free-text username field instead of a Fig user dropdown.
+- **Access & Privilege** is derived from login events; privilege fields show `N/A (Keycloak)`.
+- **Fig Platform Self-Report** reports users as `External (Keycloak)`.
+
 ## Output format
 
 Version 1 supports **HTML only**. Additional formats (PDF, Excel, CSV) are reserved for future versions; the API already accepts a `format` field defaulting to `Html`.

--- a/doc/fig-documentation/docs/security.md
+++ b/doc/fig-documentation/docs/security.md
@@ -103,6 +103,163 @@ Rate limiting is configured in the `ApiSettings` section of your configuration:
 
 When rate limits are exceeded, clients receive an HTTP 429 (Too Many Requests) response with a descriptive error message.
 
+## Keycloak Authentication Mode
+
+Fig supports running authentication in either `FigManaged` mode or `Keycloak` mode. In `Keycloak` mode, the API validates JWT bearer tokens using OIDC discovery and JWKS from the configured authority.
+
+### API configuration
+
+Configure `ApiSettings.Authentication`:
+
+Development (local Keycloak over HTTP):
+
+```json
+{
+  "ApiSettings": {
+    "Authentication": {
+      "Mode": "Keycloak",
+      "Keycloak": {
+        "Authority": "http://localhost:8080/realms/fig",
+        "Audience": "fig-api",
+        "RequireHttpsMetadata": false,
+        "UsernameClaim": "preferred_username",
+        "FirstNameClaim": "given_name",
+        "LastNameClaim": "family_name",
+        "NameClaim": "name",
+        "RoleClaimPaths": [
+          "groups",
+          "realm_access.roles",
+          "resource_access.fig.roles"
+        ],
+        "RoleMappings": {
+          "Administrator": [ "Administrator", "/fig/Administrator" ],
+          "User": [ "User", "/fig/User" ],
+          "ReadOnly": [ "ReadOnly", "/fig/ReadOnly" ],
+          "LookupService": [ "LookupService", "/fig/LookupService" ]
+        },
+        "AllowedClassificationsClaim": "fig_allowed_classifications",
+        "ClientFilterClaim": "fig_client_filter",
+        "AdminRoleName": "Administrator"
+      }
+    }
+  }
+}
+```
+
+Production:
+
+```json
+{
+  "ApiSettings": {
+    "Authentication": {
+      "Mode": "Keycloak",
+      "Keycloak": {
+        "Authority": "https://keycloak.example.com/realms/fig",
+        "Audience": "fig-api",
+        "RequireHttpsMetadata": true,
+        "UsernameClaim": "preferred_username"
+      }
+    }
+  }
+}
+```
+
+### Web configuration
+
+Configure `WebSettings.Authentication`:
+
+Development (local Keycloak over HTTP):
+
+```json
+{
+  "WebSettings": {
+    "Authentication": {
+      "Mode": "Keycloak",
+      "Keycloak": {
+        "Authority": "http://localhost:8080/realms/fig",
+        "ClientId": "fig-web",
+        "Scopes": "openid profile email",
+        "ApiScope": "fig-api",
+        "ResponseType": "code",
+        "PostLogoutRedirectUri": "https://localhost:7148/",
+        "AccountManagementUrl": "http://localhost:8080/realms/fig/account",
+        "UsernameClaim": "preferred_username",
+        "FirstNameClaim": "given_name",
+        "LastNameClaim": "family_name",
+        "NameClaim": "name",
+        "RoleClaimPaths": [
+          "groups",
+          "realm_access.roles",
+          "resource_access.fig.roles"
+        ],
+        "RoleMappings": {
+          "Administrator": [ "Administrator", "/fig/Administrator" ],
+          "User": [ "User", "/fig/User" ],
+          "ReadOnly": [ "ReadOnly", "/fig/ReadOnly" ],
+          "LookupService": [ "LookupService", "/fig/LookupService" ]
+        },
+        "AllowedClassificationsClaim": "fig_allowed_classifications",
+        "AdminRoleName": "Administrator"
+      }
+    }
+  }
+}
+```
+
+Production:
+
+```json
+{
+  "WebSettings": {
+    "Authentication": {
+      "Mode": "Keycloak",
+      "Keycloak": {
+        "Authority": "https://keycloak.example.com/realms/fig",
+        "ClientId": "fig-web",
+        "Scopes": "openid profile email",
+        "ApiScope": "fig-api",
+        "ResponseType": "code",
+        "PostLogoutRedirectUri": "https://fig.example.com/",
+        "AccountManagementUrl": "https://keycloak.example.com/realms/fig/account",
+        "UsernameClaim": "preferred_username"
+      }
+    }
+  }
+}
+```
+
+### Claim mapping requirements
+
+- `FigManaged` is the default authentication mode. Keycloak is opt-in and should be enabled for both API and web together.
+- `Audience` is required in API Keycloak mode and must match tokens intended for the Fig API.
+- Keycloak groups are the expected access contract. By default, Fig reads `groups`, `realm_access.roles`, and `resource_access.fig.roles`, then maps those values to Fig roles through `RoleMappings`.
+- Role/group claims must map to Fig roles (`Administrator`, `User`, `ReadOnly`, `LookupService`).
+- `fig_allowed_classifications` should be provided as either a JSON array string or a comma-separated list.
+- `fig_client_filter` must be a valid regular expression.
+
+Fallback behavior:
+
+- If `fig_allowed_classifications` is missing for `Administrator`, Fig grants all classifications.
+- If `fig_allowed_classifications` is missing for non-admin users, access is denied.
+
+### Endpoint behavior in Keycloak mode
+
+- `POST /users/authenticate` returns `404`.
+- Fig user-management endpoints are unavailable (`/users`, `/users/register`, `/users/{id}`).
+- Machine-client endpoints continue to work with `clientSecret`.
+
+### Mode switching and rollback
+
+- To switch to Keycloak mode, set both API and web mode values to `Keycloak`.
+- To roll back, set both API and web mode values to `FigManaged`.
+- Keep API and web modes aligned to avoid login and token propagation mismatches.
+
+### Troubleshooting mode mismatch
+
+- Web is `Keycloak`, API is `FigManaged`: OIDC login succeeds, but API calls fail authorization.
+- Web is `FigManaged`, API is `Keycloak`: local login endpoints are unavailable (`/users/authenticate` returns `404`).
+- Invalid OIDC authority/JWKS/audience causes API token validation failures.
+
 ## Forward Headers
 
 When Fig is deployed behind a reverse proxy or load balancer, the original client IP address and protocol information may be lost. Forward headers configuration allows Fig to trust and process `X-Forwarded-For` and `X-Forwarded-Proto` headers from known proxies.

--- a/doc/fig-documentation/docs/security.md
+++ b/doc/fig-documentation/docs/security.md
@@ -242,6 +242,49 @@ Fallback behavior:
 - If `fig_allowed_classifications` is missing for `Administrator`, Fig grants all classifications.
 - If `fig_allowed_classifications` is missing for non-admin users, access is denied.
 
+### Brokered identity providers (e.g. Entra ID)
+
+Fig always authenticates against Keycloak. External providers such as Microsoft Entra ID are configured in **Keycloak Admin** as identity providers (OIDC/SAML broker). Fig never talks to Entra directly.
+
+To send users straight to a brokered IdP (skipping the Keycloak username/password page), set optional web settings:
+
+```json
+{
+  "WebSettings": {
+    "Authentication": {
+      "Mode": "Keycloak",
+      "Keycloak": {
+        "Authority": "https://keycloak.example.com/realms/fig",
+        "ClientId": "fig-web",
+        "IdentityProviderHint": "entra-id",
+        "EnableIdentityProviderHint": true,
+        "LoginPrompt": "",
+        "PostLogoutLoginPrompt": "select_account"
+      }
+    }
+  }
+}
+```
+
+| Setting | Purpose |
+|---|---|
+| `IdentityProviderHint` | Keycloak IdP alias sent as OIDC `kc_idp_hint` (must match the alias in Keycloak) |
+| `EnableIdentityProviderHint` | Set to `false` to stop sending `kc_idp_hint` without removing the hint value |
+| `LoginPrompt` | Optional OIDC `prompt` on normal logins; leave empty for seamless IdP SSO |
+| `PostLogoutLoginPrompt` | OIDC `prompt` on the first login after logout (default `select_account`) so another account can be chosen |
+
+**Near-seamless Windows / Entra SSO** (open Fig and land logged in with little or no prompt) depends on browser and directory setup outside Fig, for example:
+
+- Microsoft Edge with Enterprise SSO / device Primary Refresh Token
+- Entra Connect Seamless SSO (Kerberos) on domain-joined machines
+- An existing Entra session cookie in that browser
+
+Fig cannot guarantee zero-prompt login. True silent Windows PRT/WAM SSO requires the client to talk directly to Entra; that path is not supported for Blazor WASM through Keycloak.
+
+**Logout and alternate accounts:** after logout, the next login uses `PostLogoutLoginPrompt` (default `select_account`). With `IdentityProviderHint` enabled, account selection happens at the brokered IdP (e.g. another Entra account). To allow Keycloak local users instead, set `EnableIdentityProviderHint` to `false`.
+
+**Turning IdP redirect off:** set `EnableIdentityProviderHint` to `false`, clear `IdentityProviderHint`, or switch both API and web back to `FigManaged`.
+
 ### Endpoint behavior in Keycloak mode
 
 - `POST /users/authenticate` returns `404`.

--- a/doc/fig-documentation/docs/security.md
+++ b/doc/fig-documentation/docs/security.md
@@ -247,6 +247,11 @@ Fallback behavior:
 - `POST /users/authenticate` returns `404`.
 - Fig user-management endpoints are unavailable (`/users`, `/users/register`, `/users/{id}`).
 - Machine-client endpoints continue to work with `clientSecret`.
+- Reports that list Fig-managed users degrade:
+  - **Access & Privilege** is built from login events in the selected range; role/filter/classification fields show `N/A (Keycloak)`.
+  - **Fig Platform Self-Report** shows users as `External (Keycloak)` instead of a Fig database count.
+  - **User Activity** still works; enter the Keycloak username manually (Fig user dropdowns are unavailable).
+- Fig Assistant and other administrator APIs use the live Keycloak access token (refreshed via OIDC), same as other Fig.Web API calls.
 
 ### Mode switching and rollback
 

--- a/doc/fig-documentation/docs/security.md
+++ b/doc/fig-documentation/docs/security.md
@@ -259,6 +259,15 @@ Fallback behavior:
 - To roll back, set both API and web mode values to `FigManaged`.
 - Keep API and web modes aligned to avoid login and token propagation mismatches.
 
+### Aspire AppHost (local development)
+
+- By default, `Fig.AppHost` runs with FigManaged authentication and does **not** start a Keycloak container.
+- Set `"UseKeycloak": true` in `Fig.AppHost` `appsettings.json` (or `UseKeycloak=true` via user secrets / environment) to:
+  - start the local Keycloak container with the sample realm import,
+  - configure the API for Keycloak via environment overrides,
+  - set the web environment to `Keycloak` so Blazor WASM loads `wwwroot/appsettings.Keycloak.json`.
+- Leave `UseKeycloak` as `false` (the default) for the normal FigManaged login flow.
+
 ### Troubleshooting mode mismatch
 
 - Web is `Keycloak`, API is `FigManaged`: OIDC login succeeds, but API calls fail authorization.

--- a/prompts/auth-feature-design.md
+++ b/prompts/auth-feature-design.md
@@ -1,0 +1,405 @@
+# Auth Feature Design: Keycloak Integration with Dual Auth Modes
+
+## 1) Goals and Non-Goals
+
+### Goals
+
+- Introduce Keycloak as an optional identity provider for web-user authentication.
+- Preserve existing Fig-managed authentication/authorization behavior when configured.
+- Enforce that, in Keycloak mode, API user endpoints trust only Keycloak-issued access tokens.
+- Keep existing role-based authorization model (`Administrator`, `User`, `LookupService`, `ReadOnly`).
+- Move user-centric authorization metadata management (`AllowedClassifications`, `ClientFilter`) to Keycloak claims in Keycloak mode.
+- Keep application/client-secret auth flows unchanged (machine clients do **not** use Keycloak).
+- Provide seamless web login redirect flow: unauthenticated users are sent to Keycloak and returned to Fig.
+- Remove/hide Fig user-management UI (`/users`) in Keycloak mode.
+- Add Keycloak to Aspire AppHost for local/dev workflows.
+
+### Non-Goals
+
+- No change to Fig client SDK authentication model for app-to-API interactions.
+- No schema migration required to remove Fig users; Fig user table remains for Fig mode.
+- No mixed token trust for user endpoints in Keycloak mode (Fig JWTs should not be accepted there).
+
+---
+
+## 2) Current State Summary (from code)
+
+### API
+- Custom middleware auth pipeline is used:
+  - `AuthMiddleware` reads `Authorization` bearer token, validates via `ITokenHandler`, resolves `UserDataContract` from DB, stores it in `HttpContext.Items["User"]`.
+  - Custom `[Authorize(...)]` attribute checks role from `HttpContext.Items["User"]`.
+- `UsersController` exposes `/users/authenticate` for local username/password login.
+- Roles and user metadata (`ClientFilter`, `AllowedClassifications`) come from Fig user records.
+- Machine-client endpoints remain `[AllowAnonymous]` and use `clientSecret` headers (e.g., `/clients/{clientName}/settings`, `/statuses/{clientName}`, `/clients` registration).
+
+### Web (Blazor WASM)
+- `AccountService` performs `/users/authenticate`, stores token/user in local storage.
+- `HttpService` attaches bearer token from local storage.
+- Route guarding is done in `AppRouteView` by checking user presence + role markers.
+- Main nav renders `Users` page link for administrators.
+
+### Aspire AppHost
+- AppHost currently wires API, web, and examples.
+- No identity provider resource exists yet.
+
+---
+
+## 3) Target Architecture
+
+Introduce a **dual-mode auth architecture** with explicit mode selection in both API and web:
+
+- `FigManaged` mode (existing behavior)
+- `Keycloak` mode (new behavior)
+
+### 3.1 API Auth Strategy
+Implement a mode-aware user-auth abstraction:
+
+- `IUserAuthenticationModeService` (or equivalent)
+  - `Mode` (`FigManaged` | `Keycloak`)
+  - `TryResolveUser(HttpContext)` returns normalized `UserDataContract`-like principal model
+  - `AuthenticateLocalUser(...)` enabled only in `FigManaged`
+
+- Two implementations:
+  - `FigManagedUserAuthService`
+    - Reuses existing token handler + repository lookup.
+  - `KeycloakUserAuthService`
+    - Validates JWT using Keycloak issuer metadata/JWKS.
+    - Maps claims to normalized user context:
+      - username/display name
+      - role(s)
+      - allowed classifications
+      - client filter regex
+
+Keep machine-client secret auth untouched in services/controllers that already rely on `clientSecret` headers.
+
+### 3.2 Authorization Strategy
+Continue to enforce endpoint-level role rules, but source role from normalized user context for both modes.
+
+Recommended implementation approach:
+- Keep custom `[Authorize(Role...)]` attribute to minimize blast radius.
+- Refactor auth middleware to populate `HttpContext.Items["User"]` from either:
+  - Fig user repository (Fig mode), or
+  - Keycloak claims mapping (Keycloak mode).
+
+This avoids a full rewrite to ASP.NET policy attributes and keeps existing controller annotations intact.
+
+### 3.3 Web Strategy
+Introduce mode-aware authentication in web:
+
+- `IWebAuthenticationModeService`
+  - `Mode` from `WebSettings.Authentication`
+  - `Login`, `Logout`, `GetCurrentUser`, `AcquireAccessToken`
+
+Implementations:
+- `FigManagedWebAuthService` (existing username/password page flow)
+- `KeycloakWebAuthService` (OIDC Authorization Code + PKCE)
+
+`AccountService` becomes facade over mode-specific implementation.
+
+### 3.4 AppHost Strategy
+Add Keycloak resource into Aspire for development and dashboard visibility.
+
+Preferred:
+- Use Aspire-native Keycloak integration package if available for your Aspire version.
+Fallback:
+- Add Keycloak as container resource + env vars + exposed ports + realm import volume.
+
+---
+
+## 4) Configuration Design
+
+## 4.1 Shared Concepts
+Introduce explicit auth mode enum in both API and web settings:
+
+- `AuthMode`: `FigManaged`, `Keycloak`
+
+### 4.2 API Settings (new section)
+Add to `ApiSettings`:
+
+```json
+"Authentication": {
+  "Mode": "FigManaged",
+  "Keycloak": {
+    "Authority": "https://localhost:8443/realms/fig",
+    "Audience": "fig-api",
+    "RequireHttpsMetadata": true,
+    "RoleClaimPath": "realm_access.roles",
+    "RoleClaimType": "role",
+    "AllowedClassificationsClaim": "fig_allowed_classifications",
+    "ClientFilterClaim": "fig_client_filter",
+    "UsernameClaim": "preferred_username",
+    "NameClaim": "name"
+  }
+}
+```
+
+Behavior:
+- `Mode = FigManaged`: current token validation and `/users/authenticate` active.
+- `Mode = Keycloak`: only Keycloak tokens accepted for user-protected endpoints.
+
+### 4.3 Web Settings (new section)
+Add to `WebSettings`:
+
+```json
+"Authentication": {
+  "Mode": "FigManaged",
+  "Keycloak": {
+    "Authority": "https://localhost:8443/realms/fig",
+    "ClientId": "fig-web",
+    "DefaultScopes": ["openid", "profile", "email", "roles"],
+    "ResponseType": "code",
+    "PostLogoutRedirectUri": "/",
+    "ApiScope": "fig-api"
+  }
+}
+```
+
+Behavior:
+- `FigManaged`: existing login page and credential flow.
+- `Keycloak`: automatic OIDC redirect and return.
+
+### 4.4 Startup Validation
+Add startup checks in API and web:
+- If mode is `Keycloak`, required Keycloak config fields must exist.
+- Log clear fatal errors on invalid config.
+- Optional: expose warning endpoint/status when API and web modes mismatch.
+
+---
+
+## 5) Claims and Authorization Mapping
+
+## 5.1 Role Mapping
+Map Keycloak token claims to Fig roles.
+
+Two supported patterns (configurable):
+1. Realm/client roles (e.g., `realm_access.roles`) containing exact Fig role names.
+2. Dedicated claim (e.g., `fig_role`) with one or many roles.
+
+Validation rules:
+- Must map to known enum values only.
+- Unknown roles ignored (or fail, configurable).
+- If no recognized role, deny as unauthorized.
+
+## 5.2 AllowedClassifications Mapping
+Token claim: `fig_allowed_classifications`
+- Value format options:
+  - JSON array string (recommended), or
+  - delimited string (secondary support)
+- Parse into `List<Classification>`.
+- If missing/invalid:
+  - Recommended default: all classifications **only if role is Administrator**, otherwise deny or empty list (see clarifications).
+
+## 5.3 Client Filter Mapping
+Token claim: `fig_client_filter`
+- If missing: default to `.*`.
+- If invalid regex: deny request with clear message and audit event.
+
+## 5.4 User Identity Fields
+Populate normalized user context from claims:
+- `Username`: `preferred_username` fallback to `sub`
+- `FirstName/LastName`: parse from claims if present; optional in Keycloak mode
+- `Role`, `ClientFilter`, `AllowedClassifications` from mapped claims
+
+---
+
+## 6) API Behavior by Mode
+
+## 6.1 FigManaged Mode
+- No behavior change.
+- `/users/authenticate` returns Fig JWT.
+- `/users` CRUD remains available to administrator.
+
+## 6.2 Keycloak Mode
+- User-protected endpoints accept only Keycloak access tokens.
+- `/users/authenticate`: return `404 Not Found` or `400 BadRequest` with explicit message (`Not supported in Keycloak mode`).
+- `/users/register|update|delete|get`: blocked (same as above), because identity lifecycle is external.
+- Existing `[Authorize(Role...)]` semantics remain unchanged via mapped claims.
+- Machine-client endpoints continue unchanged:
+  - `/clients` registration via `clientSecret`
+  - `/clients/{client}/settings` via `clientSecret`
+  - `/statuses/{client}` via `clientSecret`
+
+## 6.3 Auditing and Events
+- Continue event logging with `AuthenticatedUser` semantics.
+- In Keycloak mode, record claim-derived username in event logs.
+
+---
+
+## 7) Web UX Behavior by Mode
+
+## 7.1 FigManaged Mode
+- Keep current `/account/login` form.
+- Keep current local storage user model.
+- Keep `/users` page and admin nav link.
+
+## 7.2 Keycloak Mode
+- Protected routes trigger OIDC challenge automatically.
+- User is redirected to Keycloak login if no valid session.
+- On success, user returns to requested Fig route (`returnUrl` preserved).
+- API calls include Keycloak access token bearer.
+- `Users` nav item and `/users` route are hidden/disabled.
+- `Manage Account` behavior:
+  - Recommended: hide password/identity update controls and show read-only identity info + link to Keycloak account management (if configured).
+
+## 7.3 Logout
+- Keycloak mode logout should:
+  - clear local app state,
+  - trigger OIDC sign-out / end-session endpoint,
+  - return to app base URL.
+
+---
+
+## 8) Aspire / Local Development Design
+
+Add Keycloak to `Fig.AppHost` with:
+- Keycloak container resource
+- Exposed admin and auth ports
+- Realm import mounted from repo (`resources/keycloak/realm-export.json`)
+- Env for admin username/password
+- Dependencies:
+  - API gets `Authentication:Keycloak:Authority`
+  - Web gets `Authentication:Keycloak:*` settings
+
+Also include:
+- A seed realm with:
+  - `fig-api` client (confidential/public depending API design)
+  - `fig-web` public client for SPA + PKCE
+  - roles matching Fig enum
+  - protocol mappers for `fig_allowed_classifications` and `fig_client_filter`
+
+---
+
+## 9) Proposed Implementation Phases
+
+### Phase 1: Config + Mode Infrastructure
+- Add auth mode settings classes (API/web).
+- Add startup validation and mode logging.
+- Add mode abstraction interfaces.
+
+### Phase 2: API Keycloak Validation + Claim Mapping
+- Add JWT bearer validation against Keycloak authority.
+- Implement claim-to-user mapping.
+- Integrate into auth middleware pipeline.
+- Gate `/users/*` local-management endpoints by mode.
+
+### Phase 3: Web OIDC Flow
+- Add Keycloak OIDC auth service.
+- Refactor `AccountService` to mode facade.
+- Route guard updates for challenge and callback handling.
+- Nav/route behavior updates (`Users` page suppression in Keycloak mode).
+
+### Phase 4: AppHost + Dev Realm
+- Add Keycloak resource/container and config wiring.
+- Add realm export/import assets and docs.
+
+### Phase 5: Hardening + Tests
+- Add/adjust integration tests for both modes.
+- Add regression tests for machine-client endpoints.
+- Add role/claim mapping tests and invalid claim cases.
+
+---
+
+## 10) Testing Strategy
+
+## 10.1 API Tests
+- Fig mode regression: all existing auth tests pass unchanged.
+- Keycloak mode:
+  - valid token with each role can access expected endpoints,
+  - missing role claim denied,
+  - bad `ClientFilter` claim denied,
+  - missing/invalid `AllowedClassifications` handling verified,
+  - `/users/authenticate` and user management routes blocked.
+- Machine-client regression:
+  - `/clients` registration by client secret still works,
+  - `/clients/{name}/settings` still works,
+  - `/statuses/{name}` still works.
+
+## 10.2 Web Tests
+- Fig mode login/logout unchanged.
+- Keycloak mode:
+  - first navigation redirects to Keycloak,
+  - callback returns to original route,
+  - API calls include bearer token,
+  - `/users` nav item absent,
+  - unauthorized role cannot access admin pages.
+
+## 10.3 End-to-End
+- AppHost run with Keycloak enabled validates full loop:
+  - web -> keycloak login -> back to web -> API authorized operations.
+
+---
+
+## 11) Backward Compatibility and Rollout
+
+- Default auth mode remains `FigManaged` to avoid breaking existing deployments.
+- Keycloak support is opt-in via config.
+- Existing user data remains intact and reusable if switching back to Fig mode.
+- Add migration/runbook docs:
+  - how to configure Keycloak clients/claims,
+  - how to flip mode safely,
+  - smoke-test checklist.
+
+---
+
+## 12) Risks and Mitigations
+
+- **Risk:** Claim schema drift in Keycloak realm.
+  - **Mitigation:** Configurable claim names/paths + startup self-check endpoint.
+- **Risk:** Mode mismatch between web and API.
+  - **Mitigation:** Startup warning + health/status indicator.
+- **Risk:** Breaking machine-client flows.
+  - **Mitigation:** Explicitly preserve `[AllowAnonymous]` + client-secret tests.
+- **Risk:** Token parsing inconsistencies (array vs string claims).
+  - **Mitigation:** robust parser with strict validation + diagnostics.
+
+---
+
+## 13) Clarification Questions (with recommendations)
+
+1. **Should Keycloak mode support only realm roles, or also client roles?**
+   - **Recommendation:** Support both, configurable claim path, default to realm roles.
+
+Use recommendation.
+
+2. **What is the fallback when `fig_allowed_classifications` is absent?**
+   - **Recommendation:**
+     - `Administrator`: default to all classifications.
+     - non-admin roles: deny access (secure-by-default).
+
+Use recommendation.
+
+3. **Should `/account/manage` remain editable in Keycloak mode?**
+   - **Recommendation:** No. Make it read-only and redirect identity edits to Keycloak account page.
+
+Use recommendation.
+
+4. **How should `/users/authenticate` behave in Keycloak mode?**
+   - **Recommendation:** Return `404` to clearly signal endpoint not available in this mode.
+
+Use recommendation.
+
+5. **Should API accept both Fig JWT and Keycloak JWT during migration windows?**
+   - **Recommendation:** No for steady-state security. If needed, add a short-lived explicit `Dual` migration mode guarded by feature flag and expiry date.
+
+No, it will only accept one or the other but not both at the same time.
+
+1. **Where should `AllowedClassifications` and `ClientFilter` live in Keycloak?**
+   - **Recommendation:** User attributes mapped to token claims via protocol mappers; avoid deriving from groups unless already standardized.
+
+Use recommendation. Ensure that this is well documented.
+
+2. **Do service accounts in Keycloak need API user-role access?**
+   - **Recommendation:** Keep machine clients on existing client-secret flow; do not expand Keycloak scope for them in this phase.
+
+Use recommendation.
+
+---
+
+
+## 14) Recommended Path Forward
+
+- Implement dual-mode with minimal surface change by preserving existing custom authorization attributes and injecting a mode-aware principal resolver.
+- Keep current Fig mode untouched and fully backward-compatible.
+- Add Keycloak OIDC flow to web and Keycloak JWT validation to API under explicit config.
+- Preserve machine-client secret auth exactly as-is.
+- Introduce Keycloak resource in Aspire with preconfigured realm export for fast developer onboarding.

--- a/prompts/auth-feature-implementation-plan.md
+++ b/prompts/auth-feature-implementation-plan.md
@@ -1,0 +1,308 @@
+# Auth Feature Implementation Plan: Keycloak + FigManaged Dual Mode
+
+This plan converts the approved design into an execution-ready sequence for a coding agent, mapped to the current Fig codebase.
+
+## 1) Confirmed Decisions (from design clarifications)
+
+- Support both realm roles and client roles in Keycloak (configurable claim path).
+- In Keycloak mode, if `fig_allowed_classifications` is missing:
+  - `Administrator` => all classifications
+  - non-admin => deny access.
+- `/account/manage` in Keycloak mode is read-only for Fig profile fields and should link out to Keycloak account management if configured.
+- `/users/authenticate` in Keycloak mode returns `404`.
+- API accepts only one user token system at a time (`FigManaged` or `Keycloak`), never both simultaneously.
+- `AllowedClassifications` and `ClientFilter` come from Keycloak user attributes mapped to token claims in Keycloak mode.
+- Machine clients remain on existing `clientSecret` flow (no Keycloak service-account scope in this phase).
+
+## 2) Current Code Anchors (for implementation)
+
+- API startup + DI + middleware: `src/api/Fig.Api/Program.cs`
+- API settings model: `src/api/Fig.Api/ApiSettings.cs`
+- Existing token validation: `src/api/Fig.Api/Authorization/ITokenHandler.cs`, `src/api/Fig.Api/Authorization/TokenHandler.cs`
+- Existing user auth middleware: `src/api/Fig.Api/Middleware/AuthMiddleware.cs`
+- Existing role enforcement: `src/api/Fig.Api/Attributes/AuthorizeAttribute.cs`
+- User endpoints to gate in Keycloak mode: `src/api/Fig.Api/Controllers/UsersController.cs`
+- Existing machine-client endpoints that must stay unchanged:
+  - `src/api/Fig.Api/Controllers/ClientsController.cs`
+  - `src/api/Fig.Api/Controllers/StatusController.cs`
+  - `src/api/Fig.Api/Controllers/LookupTablesController.cs`
+
+- Web startup + DI: `src/web/Fig.Web/Program.cs`
+- Web settings model: `src/web/Fig.Web/WebSettings.cs`
+- Existing web auth service: `src/web/Fig.Web/Services/IAccountService.cs`, `src/web/Fig.Web/Services/AccountService.cs`
+- Existing bearer attachment: `src/web/Fig.Web/Services/HttpService.cs`
+- Existing route guard: `src/web/Fig.Web/Routing/AppRouteView.cs`
+- Login/manage/logout pages:
+  - `src/web/Fig.Web/Pages/Login.razor`
+  - `src/web/Fig.Web/Pages/Login.razor.cs`
+  - `src/web/Fig.Web/Pages/ManageAccount.razor`
+  - `src/web/Fig.Web/Pages/ManageAccount.razor.cs`
+  - `src/web/Fig.Web/Pages/Logout.razor`
+- Users UI + nav entry to suppress in Keycloak mode:
+  - `src/web/Fig.Web/Pages/Users.razor`
+  - `src/web/Fig.Web/Pages/Users.razor.cs`
+  - `src/web/Fig.Web/Shared/MainLayout.razor`
+
+- Aspire host: `src/hosting/Fig.AppHost/Program.cs`
+
+- Existing integration test base/helpers:
+  - `src/tests/Fig.Test.Common/IntegrationTestBase.cs`
+  - `src/tests/Fig.Integration.Test/Api/UserIntegrationTests.cs`
+
+## 3) Execution Order (agent-ready)
+
+### Progress tracker
+
+- [x] Step 0 - Branch hygiene and baseline validation
+- [x] Step 1 - Introduce mode-aware auth configuration models
+- [x] Step 2 - API auth mode abstraction and principal normalization
+- [x] Step 3 - API middleware integration (no endpoint annotation rewrite)
+- [x] Step 4 - API startup wiring for Keycloak mode
+- [x] Step 5 - Gate user lifecycle endpoints in Keycloak mode
+- [x] Step 6 - Web dual-mode auth abstraction
+- [x] Step 7 - Web route, nav, and account UX behavior in Keycloak mode
+- [x] Step 8 - Token propagation in web HTTP client
+- [x] Step 9 - Aspire AppHost Keycloak resource integration
+- [x] Step 10 - Tests for both modes and machine-client regression
+- [x] Step 11 - Documentation and runbook updates
+- [ ] Step 12 - Full validation sequence (must run before merge)
+
+## Step 0 - Branch hygiene and baseline validation
+
+1. Ensure clean working tree and restore/build baseline:
+   - `cd src`
+   - `dotnet restore Fig.sln`
+   - `dotnet build Fig.sln --configuration Release --no-restore`
+2. Run fast baseline tests:
+   - `dotnet test tests/Fig.Unit.Test/Fig.Unit.Test.csproj --configuration Release --no-build --verbosity minimal`
+
+**Exit criteria**
+- Baseline passes before feature changes begin.
+
+---
+
+## Step 1 - Introduce mode-aware auth configuration models
+
+### API
+1. Extend `ApiSettings` with:
+   - `Authentication` object
+   - `Mode` enum/string (`FigManaged`, `Keycloak`)
+   - nested `Keycloak` settings object (`Authority`, `Audience`, `RequireHttpsMetadata`, role + claim mapping fields).
+2. Keep existing `Secret`/`TokenLifeMinutes` unchanged for FigManaged compatibility.
+
+### Web
+3. Extend `WebSettings` with:
+   - `Authentication` object
+   - `Mode` (`FigManaged`, `Keycloak`)
+   - nested Keycloak SPA settings (`Authority`, `ClientId`, scopes, `ResponseType`, `PostLogoutRedirectUri`, `ApiScope`, optional account-management URL).
+
+### Config files
+4. Add new sections to:
+   - `src/api/Fig.Api/appsettings.json`
+   - `src/web/Fig.Web/wwwroot/appsettings.json`
+   using `FigManaged` defaults.
+
+**Exit criteria**
+- App starts in FigManaged with no behavior change.
+- Missing required Keycloak fields cause explicit startup validation errors only when mode=`Keycloak`.
+
+---
+
+## Step 2 - API auth mode abstraction and principal normalization
+
+1. Add shared API auth-mode abstractions (new folder recommended `src/api/Fig.Api/Authorization/UserAuth/`):
+   - `AuthMode` enum
+   - `IUserAuthenticationModeService`
+   - `NormalizedUserContext` (maps to what `AuthorizeAttribute` + services need)
+   - supporting options/validation types.
+2. Implement `FigManagedUserAuthenticationModeService`:
+   - reuses existing `ITokenHandler.Validate(...)`
+   - resolves user via `IUserService.GetById(...)`
+   - preserves existing `HttpContext.Items["User"]` semantics.
+3. Implement `KeycloakUserAuthenticationModeService`:
+   - validates bearer token against Keycloak authority/JWKS
+   - maps username/name/role/classifications/client filter from claims
+   - enforces clarified fallback rules.
+
+**Important**
+- Keep Newtonsoft usage conventions; do not introduce `System.Text.Json` for application contract serialization.
+
+**Exit criteria**
+- A single service can resolve authenticated user context for either mode.
+
+---
+
+## Step 3 - API middleware integration (no endpoint annotation rewrite)
+
+1. Refactor `AuthMiddleware` (`src/api/Fig.Api/Middleware/AuthMiddleware.cs`) to use `IUserAuthenticationModeService`.
+2. Continue setting `HttpContext.Items["User"]` so existing `AuthorizeAttribute` keeps working.
+3. Continue calling `SetAuthenticatedUser(...)` on `IAuthenticatedService` instances.
+4. Ensure unauthenticated requests remain allowed where controller actions use `[AllowAnonymous]`.
+
+**Exit criteria**
+- Existing `[Authorize(Role...)]` behavior is unchanged in FigManaged.
+- Keycloak mode injects claim-derived user context for same authorization path.
+
+---
+
+## Step 4 - API startup wiring for Keycloak mode
+
+1. In `src/api/Fig.Api/Program.cs`:
+   - register auth-mode services and validators.
+   - configure JWT validation dependencies for Keycloak mode.
+   - add startup mode logging (include selected auth mode + critical config values excluding secrets).
+2. Add a startup validator service (new file) that fails fast on invalid Keycloak config.
+
+**Exit criteria**
+- App fails clearly on invalid Keycloak config and starts cleanly on valid config.
+
+---
+
+## Step 5 - Gate user lifecycle endpoints in Keycloak mode
+
+1. Update `src/api/Fig.Api/Controllers/UsersController.cs`:
+   - `POST /users/authenticate` returns `404` in Keycloak mode.
+   - user CRUD endpoints (`register`, `get`, `get/{id}`, `update`, `delete`) return `404` in Keycloak mode.
+2. Preserve full existing behavior in FigManaged mode.
+
+**Exit criteria**
+- User lifecycle is externally managed in Keycloak mode with explicit endpoint unavailability.
+
+---
+
+## Step 6 - Web dual-mode auth abstraction
+
+1. Introduce web-mode abstractions (recommended folder `src/web/Fig.Web/Services/Authentication/`):
+   - `IWebAuthenticationModeService`
+   - `FigManagedWebAuthenticationModeService`
+   - `KeycloakWebAuthenticationModeService`.
+2. Keep existing `IAccountService` as facade contract to minimize blast radius.
+3. Refactor `AccountService` to delegate to selected mode service.
+
+**Key implementation detail**
+- In Keycloak mode, do not use `/users/authenticate`.
+- Access token acquisition must use OIDC Authorization Code + PKCE flow.
+
+**Likely package update**
+- Add `Microsoft.AspNetCore.Components.WebAssembly.Authentication` to `src/web/Fig.Web/Fig.Web.csproj` if not already present.
+
+**Exit criteria**
+- `IAccountService` callers remain intact while auth behavior switches by config mode.
+
+---
+
+## Step 7 - Web route, nav, and account UX behavior in Keycloak mode
+
+1. Update route guard logic in `src/web/Fig.Web/Routing/AppRouteView.cs`:
+   - protected routes trigger OIDC challenge/redirect in Keycloak mode.
+   - preserve return URL handling.
+2. Update login/logout pages:
+   - `Login` page should redirect/challenge in Keycloak mode instead of local form submit flow.
+   - `Logout` should clear local state and invoke OIDC end-session flow.
+3. Update manage account page:
+   - `src/web/Fig.Web/Pages/ManageAccount.razor`
+   - `src/web/Fig.Web/Pages/ManageAccount.razor.cs`
+   - make Fig identity fields read-only in Keycloak mode and optionally show link to Keycloak account management.
+4. Hide/suppress users management in Keycloak mode:
+   - nav link in `src/web/Fig.Web/Shared/MainLayout.razor`
+   - route/page availability for `src/web/Fig.Web/Pages/Users.razor`.
+
+**Exit criteria**
+- Keycloak mode has redirect-based login and no editable Fig user-management UX.
+
+---
+
+## Step 8 - Token propagation in web HTTP client
+
+1. Update `src/web/Fig.Web/Services/HttpService.cs` so bearer token retrieval is mode-aware:
+   - FigManaged: existing local-storage token behavior.
+   - Keycloak: acquire current access token from OIDC auth service and attach to API calls.
+2. Ensure 401 handling remains deterministic and mode-safe.
+
+**Exit criteria**
+- API calls carry the correct token type for active mode.
+
+---
+
+## Step 9 - Aspire AppHost Keycloak resource integration
+
+1. Update `src/hosting/Fig.AppHost/Program.cs` to add Keycloak resource:
+   - Prefer Aspire-native Keycloak resource APIs for current Aspire version.
+   - Fallback to container resource with explicit image/ports/env/volume mount.
+2. Add realm import artifact under repository resources (recommended):
+   - `resources/keycloak/realm-export.json`
+3. Wire env vars/config for API and web Keycloak settings from AppHost.
+
+**Exit criteria**
+- `Fig.AppHost` starts API + web + Keycloak with importable/dev realm.
+
+---
+
+## Step 10 - Tests for both modes and machine-client regression
+
+### Add/Update Integration Tests
+1. Extend test config support (`src/tests/Fig.Test.Common/IntegrationTestBase.cs`) to toggle auth mode and inject test JWT behavior.
+2. Add Keycloak-mode API tests (new test file recommended under `src/tests/Fig.Integration.Test/Api/`):
+   - valid token per role => expected access.
+   - unknown/no role => unauthorized.
+   - invalid `fig_client_filter` regex => denied.
+   - missing/invalid `fig_allowed_classifications` => fallback behavior per clarified rules.
+   - `/users/authenticate` + user management endpoints => `404`.
+3. Preserve existing FigManaged tests (e.g. `UserIntegrationTests`) as regression suite.
+4. Add explicit machine-client regression tests for:
+   - `POST /clients` (`clientSecret`)
+   - `GET /clients/{clientName}/settings` (`clientSecret`)
+   - `PUT /statuses/{clientName}` (`clientSecret`)
+
+### Web behavior tests
+5. If current end-to-end tests are minimal, add focused integration tests for mode-based nav suppression and route handling in web-layer tests where feasible.
+
+**Exit criteria**
+- Both auth modes are covered, and machine-client flows prove unchanged.
+
+---
+
+## Step 11 - Documentation and runbook updates
+
+1. Add/extend docs with Keycloak setup + claim mapping:
+   - where to configure role claim path(s)
+   - how to map `fig_allowed_classifications`
+   - how to map `fig_client_filter`
+   - mode switching and rollback to FigManaged
+2. Document that Keycloak claims should come from user attributes + protocol mappers.
+3. Include troubleshooting for mode mismatch between web and API.
+
+**Suggested doc locations**
+- `README.md` (high-level)
+- `doc/` (detailed setup/runbook)
+
+**Exit criteria**
+- A developer can configure Keycloak mode without reading source code.
+
+---
+
+## Step 12 - Full validation sequence (must run before merge)
+
+1. Build and unit tests:
+   - `cd src`
+   - `dotnet restore Fig.sln`
+   - `dotnet build Fig.sln --configuration Release --no-restore`
+   - `dotnet test tests/Fig.Unit.Test/Fig.Unit.Test.csproj --configuration Release --no-build --verbosity minimal`
+2. Integration tests:
+   - `dotnet test tests/Fig.Integration.Test/Fig.Integration.Test.csproj --configuration Release --no-build --verbosity minimal`
+3. Manual runtime smoke (both modes):
+   - Start API + web in FigManaged mode, verify local login and `/users` admin UX.
+   - Start through AppHost with Keycloak mode, verify redirect login, role-based access, hidden users UI, and machine-client secret flows.
+
+**Exit criteria**
+- No regressions in FigManaged mode.
+- Keycloak mode fully operational and aligned with clarified decisions.
+
+## 4) Delivery slices for PRs (recommended)
+
+- PR 1: config models + API mode abstractions + middleware integration (no web).
+- PR 2: web dual-mode + OIDC flow + UX gating.
+- PR 3: AppHost Keycloak + realm assets + documentation.
+- PR 4: tests/hardening and any bug fixes from validation.
+
+This sequence keeps risk low, enables targeted reviews, and protects existing FigManaged behavior while adding Keycloak support incrementally.

--- a/prompts/auth-feature.md
+++ b/prompts/auth-feature.md
@@ -1,0 +1,35 @@
+# Auth Feature
+
+Currently Fig handles authentication and authorization itself.
+
+Users of the web client will call the UsersController and authenticate towards the api. Other users of the api will do the same.
+Authenticate calls the UserService which verifies the credentials provided against the hashed version of the password stored in the database. It then generates a new auth token for the user, signed by the API's configured secret value.
+
+The user can then use this token for future requests towards the api.
+
+This works well but in some environments a single credential provider is used and Fig cannot work with that currently.
+
+This task involves introducing Keycloak into the solution. Keycloak should be added to the Aspire dashboard and should allow web users to acquire a token which can then be used towards the back end api.
+
+I would still like to retain the ability to use Fig only logins. This would be configured in the Fig.Api and Fig.Web configuration files. If both were configured for Fig managed logins, it would work exactly as it does today.
+
+Otherwise, if Fig is configured for Keycloak logins, then keycloak would be the only trusted token provider allowed to call the api.
+
+The security model should remain the same. Today Fig has the following roles:
+
+- Administrator,
+- User,
+- LookupService,
+- ReadOnly
+
+Each of these roles have different permissions allowing them to call different endpoints within the API. These roles must remain but be configured within Keycloak as claims within the provided token. As a result, the user management and role assignment to users would be managed in Keycloak rather than Fig.
+In addition, users today can also be assigned AllowedClassifications which determine which settings they will see and a Client Filter Regex which can be used to filter which clients they are able to see and update. These would also be managed in Keycloak in the future and just read by the API.
+
+When in Keycloak mode, the Users Razor page would no longer be available to administrators as this detail would no longer be managed in Fig.
+
+The client secret method of authentication used by the applications interacting with Fig will remain unchanged. They will not use Keycloak in any way.
+
+The keycloak feature should be a smooth workflow where the user is automatically directed to Keycloak if they are not already logged in and once logged in, they are automatically directed back to the main Fig page so they can start working.
+
+Based on the existing state of the code and the above plan, produce a detailed design that could be used as the basis for implementing this new feature.
+Please ask any clarification questions required to produce the design and provide recommendations for the best way forward for each of them.

--- a/resources/keycloak/realm-export.json
+++ b/resources/keycloak/realm-export.json
@@ -1,0 +1,218 @@
+{
+  "id": "fig",
+  "realm": "fig",
+  "enabled": true,
+  "displayName": "Fig Development Realm",
+  "sslRequired": "external",
+  "registrationAllowed": false,
+  "resetPasswordAllowed": true,
+  "rememberMe": true,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "roles": {
+    "realm": [
+      {
+        "name": "Administrator"
+      },
+      {
+        "name": "User"
+      },
+      {
+        "name": "LookupService"
+      },
+      {
+        "name": "ReadOnly"
+      }
+    ]
+  },
+  "groups": [
+    {
+      "name": "fig",
+      "path": "/fig",
+      "subGroups": [
+        {
+          "name": "Administrator",
+          "path": "/fig/Administrator"
+        },
+        {
+          "name": "User",
+          "path": "/fig/User"
+        },
+        {
+          "name": "LookupService",
+          "path": "/fig/LookupService"
+        },
+        {
+          "name": "ReadOnly",
+          "path": "/fig/ReadOnly"
+        }
+      ]
+    }
+  ],
+  "clients": [
+    {
+      "clientId": "fig-api",
+      "name": "Fig API",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "bearerOnly": true,
+      "publicClient": false,
+      "standardFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "attributes": {
+        "access.token.lifespan": "300"
+      }
+    },
+    {
+      "clientId": "fig-web",
+      "name": "Fig Web",
+      "enabled": true,
+      "protocol": "openid-connect",
+      "publicClient": true,
+      "standardFlowEnabled": true,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "redirectUris": [
+        "https://localhost:7148/*",
+        "http://localhost:5217/*"
+      ],
+      "webOrigins": [
+        "https://localhost:7148",
+        "http://localhost:5217"
+      ],
+      "attributes": {
+        "pkce.code.challenge.method": "S256"
+      },
+      "protocolMappers": [
+        {
+          "name": "groups",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-group-membership-mapper",
+          "consentRequired": false,
+          "config": {
+            "full.path": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "claim.name": "groups"
+          }
+        },
+        {
+          "name": "fig_allowed_classifications",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "fig_allowed_classifications",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "fig_allowed_classifications",
+            "jsonType.label": "String",
+            "multivalued": "false"
+          }
+        },
+        {
+          "name": "fig_client_filter",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "fig_client_filter",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "fig_client_filter",
+            "jsonType.label": "String",
+            "multivalued": "false"
+          }
+        },
+        {
+          "name": "audience-fig-api",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.client.audience": "fig-api",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "false"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "profile",
+        "email",
+        "roles",
+        "web-origins"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "microprofile-jwt",
+        "offline_access"
+      ]
+    }
+  ],
+  "users": [
+    {
+      "username": "fig-admin",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Fig",
+      "lastName": "Administrator",
+      "email": "fig-admin@fig.local",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "admin",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "Administrator"
+      ],
+      "groups": [
+        "/fig/Administrator"
+      ],
+      "attributes": {
+        "fig_allowed_classifications": [
+          "[\"Technical\",\"Functional\",\"Special\"]"
+        ],
+        "fig_client_filter": [
+          ".*"
+        ]
+      }
+    },
+    {
+      "username": "fig-user",
+      "enabled": true,
+      "emailVerified": true,
+      "firstName": "Fig",
+      "lastName": "User",
+      "email": "fig-user@fig.local",
+      "credentials": [
+        {
+          "type": "password",
+          "value": "user",
+          "temporary": false
+        }
+      ],
+      "realmRoles": [
+        "User"
+      ],
+      "groups": [
+        "/fig/User"
+      ],
+      "attributes": {
+        "fig_allowed_classifications": [
+          "[\"Technical\",\"Functional\"]"
+        ],
+        "fig_client_filter": [
+          "^demo-.*"
+        ]
+      }
+    }
+  ]
+}

--- a/src/api/Fig.Api/ApiSettings.cs
+++ b/src/api/Fig.Api/ApiSettings.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading.RateLimiting;
+using Fig.Contracts.Authentication;
 
 namespace Fig.Api;
 
@@ -31,6 +32,8 @@ public class ApiSettings
     public long TimeMachineCheckIntervalMs { get; set; }
     
     public bool DisableTransactionMiddleware { get; set; }
+
+    public AuthenticationSettings Authentication { get; set; } = new();
 
     public string? ImportFolderPath { get; set; }
 
@@ -127,6 +130,58 @@ public class ApiSettings
 
         return result;
     }
+}
+
+public class AuthenticationSettings
+{
+    public AuthMode Mode { get; set; } = AuthMode.FigManaged;
+
+    public KeycloakAuthenticationSettings Keycloak { get; set; } = new();
+}
+
+public enum AuthMode
+{
+    FigManaged,
+    Keycloak
+}
+
+public class KeycloakAuthenticationSettings
+{
+    private static readonly Dictionary<string, string[]> DefaultRoleMappings = new(StringComparer.OrdinalIgnoreCase)
+    {
+        [Role.Administrator.ToString()] = ["Administrator", "/fig/Administrator"],
+        [Role.User.ToString()] = ["User", "/fig/User"],
+        [Role.ReadOnly.ToString()] = ["ReadOnly", "/fig/ReadOnly"],
+        [Role.LookupService.ToString()] = ["LookupService", "/fig/LookupService"]
+    };
+
+    public string? Authority { get; set; }
+
+    public string? Audience { get; set; }
+
+    public bool RequireHttpsMetadata { get; set; } = true;
+
+    public string UsernameClaim { get; set; } = "preferred_username";
+
+    public string FirstNameClaim { get; set; } = "given_name";
+
+    public string LastNameClaim { get; set; } = "family_name";
+
+    public string NameClaim { get; set; } = "name";
+
+    public List<string> RoleClaimPaths { get; set; } = ["groups", "realm_access.roles", "resource_access.fig.roles"];
+
+    public string RoleClaimPath { get; set; } = "realm_access.roles";
+
+    public string? AdditionalRoleClaimPath { get; set; } = "resource_access.fig.roles";
+
+    public Dictionary<string, string[]> RoleMappings { get; set; } = new(DefaultRoleMappings, StringComparer.OrdinalIgnoreCase);
+
+    public string AllowedClassificationsClaim { get; set; } = "fig_allowed_classifications";
+
+    public string ClientFilterClaim { get; set; } = "fig_client_filter";
+
+    public string AdminRoleName { get; set; } = "Administrator";
 }
 
 public class RateLimitingSettings

--- a/src/api/Fig.Api/Authorization/UserAuth/ApiAuthMode.cs
+++ b/src/api/Fig.Api/Authorization/UserAuth/ApiAuthMode.cs
@@ -1,0 +1,7 @@
+namespace Fig.Api.Authorization.UserAuth;
+
+public enum ApiAuthMode
+{
+    FigManaged,
+    Keycloak
+}

--- a/src/api/Fig.Api/Authorization/UserAuth/AuthenticationSettingsValidator.cs
+++ b/src/api/Fig.Api/Authorization/UserAuth/AuthenticationSettingsValidator.cs
@@ -1,0 +1,46 @@
+using Fig.Contracts.Authentication;
+
+namespace Fig.Api.Authorization.UserAuth;
+
+public static class AuthenticationSettingsValidator
+{
+    public static void Validate(ApiSettings settings)
+    {
+        if (settings.Authentication.Mode != AuthMode.Keycloak)
+            return;
+
+        var keycloak = settings.Authentication.Keycloak;
+
+        if (string.IsNullOrWhiteSpace(keycloak.Authority))
+            throw new InvalidOperationException("ApiSettings:Authentication:Keycloak:Authority must be configured when Mode=Keycloak");
+
+        if ((keycloak.RoleClaimPaths == null || keycloak.RoleClaimPaths.All(string.IsNullOrWhiteSpace)) &&
+            string.IsNullOrWhiteSpace(keycloak.RoleClaimPath) &&
+            string.IsNullOrWhiteSpace(keycloak.AdditionalRoleClaimPath))
+            throw new InvalidOperationException("ApiSettings:Authentication:Keycloak:RoleClaimPaths must be configured when Mode=Keycloak");
+
+        if (string.IsNullOrWhiteSpace(keycloak.AllowedClassificationsClaim))
+            throw new InvalidOperationException("ApiSettings:Authentication:Keycloak:AllowedClassificationsClaim must be configured when Mode=Keycloak");
+
+        if (string.IsNullOrWhiteSpace(keycloak.ClientFilterClaim))
+            throw new InvalidOperationException("ApiSettings:Authentication:Keycloak:ClientFilterClaim must be configured when Mode=Keycloak");
+
+        if (string.IsNullOrWhiteSpace(keycloak.Audience))
+            throw new InvalidOperationException("ApiSettings:Authentication:Keycloak:Audience must be configured when Mode=Keycloak");
+
+        if (string.IsNullOrWhiteSpace(keycloak.AdminRoleName))
+            throw new InvalidOperationException("ApiSettings:Authentication:Keycloak:AdminRoleName must be configured when Mode=Keycloak");
+
+        if (keycloak.RoleMappings == null)
+            throw new InvalidOperationException("ApiSettings:Authentication:Keycloak:RoleMappings must be configured when Mode=Keycloak");
+
+        foreach (var roleName in Enum.GetNames<Role>())
+        {
+            if (!keycloak.RoleMappings.TryGetValue(roleName, out var mappedValues) ||
+                mappedValues == null ||
+                mappedValues.All(string.IsNullOrWhiteSpace))
+                throw new InvalidOperationException(
+                    $"ApiSettings:Authentication:Keycloak:RoleMappings:{roleName} must be configured when Mode=Keycloak");
+        }
+    }
+}

--- a/src/api/Fig.Api/Authorization/UserAuth/FigManagedUserAuthenticationModeService.cs
+++ b/src/api/Fig.Api/Authorization/UserAuth/FigManagedUserAuthenticationModeService.cs
@@ -1,0 +1,39 @@
+using Fig.Api.Services;
+using Fig.Api.Authorization;
+using Fig.Contracts.Authentication;
+
+namespace Fig.Api.Authorization.UserAuth;
+
+public class FigManagedUserAuthenticationModeService : IUserAuthenticationModeService
+{
+    private readonly IUserService _userService;
+    private readonly ITokenHandler _tokenHandler;
+
+    public FigManagedUserAuthenticationModeService(IUserService userService, ITokenHandler tokenHandler)
+    {
+        _userService = userService;
+        _tokenHandler = tokenHandler;
+    }
+
+    public ApiAuthMode Mode => ApiAuthMode.FigManaged;
+
+    public async Task<UserDataContract?> ResolveAuthenticatedUser(HttpContext context)
+    {
+        var authHeader = context.Request.Headers["Authorization"].FirstOrDefault();
+        string? token = null;
+        if (authHeader != null)
+        {
+            token = authHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase)
+                ? authHeader.Substring("Bearer ".Length).Trim()
+                : authHeader;
+        }
+
+        var tokenData = _tokenHandler.Validate(token);
+        if (tokenData == null)
+            return null;
+
+        var user = await _userService.GetById(tokenData.UserId);
+        user.PasswordChangeRequired = tokenData.PasswordChangeRequired;
+        return user;
+    }
+}

--- a/src/api/Fig.Api/Authorization/UserAuth/IUserAuthenticationModeService.cs
+++ b/src/api/Fig.Api/Authorization/UserAuth/IUserAuthenticationModeService.cs
@@ -1,0 +1,10 @@
+using Fig.Contracts.Authentication;
+
+namespace Fig.Api.Authorization.UserAuth;
+
+public interface IUserAuthenticationModeService
+{
+    ApiAuthMode Mode { get; }
+
+    Task<UserDataContract?> ResolveAuthenticatedUser(HttpContext context);
+}

--- a/src/api/Fig.Api/Authorization/UserAuth/KeycloakUserAuthenticationModeService.cs
+++ b/src/api/Fig.Api/Authorization/UserAuth/KeycloakUserAuthenticationModeService.cs
@@ -1,0 +1,404 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Collections.Concurrent;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.RegularExpressions;
+using Fig.Client.Abstractions.Data;
+using Fig.Contracts.Authentication;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Tokens;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Fig.Api.Authorization.UserAuth;
+
+public class KeycloakUserAuthenticationModeService : IUserAuthenticationModeService
+{
+    private readonly ConcurrentDictionary<string, IConfigurationManager<OpenIdConnectConfiguration>> _configurationManagers = new();
+    private readonly IOptionsMonitor<ApiSettings> _apiSettings;
+    private readonly ILogger<KeycloakUserAuthenticationModeService> _logger;
+
+    public KeycloakUserAuthenticationModeService(
+        IOptionsMonitor<ApiSettings> apiSettings,
+        ILogger<KeycloakUserAuthenticationModeService> logger)
+    {
+        _apiSettings = apiSettings;
+        _logger = logger;
+    }
+
+    public ApiAuthMode Mode => ApiAuthMode.Keycloak;
+
+    public async Task<UserDataContract?> ResolveAuthenticatedUser(HttpContext context)
+    {
+        var token = ExtractBearerToken(context);
+        if (string.IsNullOrWhiteSpace(token))
+            return null;
+
+        var keycloakSettings = _apiSettings.CurrentValue.Authentication.Keycloak;
+        var configurationManager = GetConfigurationManager(keycloakSettings);
+        var config = await configurationManager.GetConfigurationAsync(context.RequestAborted);
+        var validationParameters = new TokenValidationParameters
+        {
+            ValidateIssuer = true,
+            ValidIssuers =
+            [
+                config.Issuer,
+                keycloakSettings.Authority?.TrimEnd('/')
+            ],
+            ValidateAudience = true,
+            ValidAudience = keycloakSettings.Audience,
+            ValidateLifetime = true,
+            ValidateIssuerSigningKey = true,
+            IssuerSigningKeys = config.SigningKeys,
+            ClockSkew = TimeSpan.FromMinutes(1)
+        };
+
+        var tokenHandler = new JwtSecurityTokenHandler { MapInboundClaims = false };
+        ClaimsPrincipal principal;
+        JwtSecurityToken jwt;
+
+        try
+        {
+            principal = tokenHandler.ValidateToken(token, validationParameters, out var validatedToken);
+            jwt = (JwtSecurityToken)validatedToken;
+        }
+        catch (SecurityTokenException ex)
+        {
+            _logger.LogWarning(ex, "Keycloak token validation failed");
+            return null;
+        }
+
+        var role = ResolveRole(principal, jwt, keycloakSettings);
+        if (role == null)
+        {
+            _logger.LogWarning("No recognized Fig role found in Keycloak token claims");
+            return null;
+        }
+
+        var classifications = ResolveAllowedClassifications(principal, role.Value, keycloakSettings);
+        if (classifications == null)
+        {
+            _logger.LogWarning("No valid allowed classifications found for non-admin user in Keycloak token");
+            return null;
+        }
+
+        var username = GetStringClaim(principal, keycloakSettings.UsernameClaim)
+                       ?? GetStringClaim(principal, ClaimTypes.Name)
+                       ?? GetStringClaim(principal, "sub");
+
+        if (string.IsNullOrWhiteSpace(username))
+        {
+            _logger.LogWarning("No username claim found in Keycloak token");
+            return null;
+        }
+
+        var firstName = GetStringClaim(principal, keycloakSettings.FirstNameClaim)
+                        ?? GetStringClaim(principal, keycloakSettings.NameClaim)
+                        ?? username;
+        var lastName = GetStringClaim(principal, keycloakSettings.LastNameClaim) ?? string.Empty;
+        var clientFilter = GetStringClaim(principal, keycloakSettings.ClientFilterClaim) ?? ".*";
+        if (!IsValidRegex(clientFilter))
+        {
+            _logger.LogWarning("Invalid client filter regex '{ClientFilter}' in Keycloak token for user {Username}",
+                clientFilter, username);
+            return null;
+        }
+
+        var subject = GetStringClaim(principal, "sub") ?? username;
+
+        return new UserDataContract(
+            CreateDeterministicGuid(subject),
+            username,
+            firstName,
+            lastName,
+            role.Value,
+            clientFilter,
+            classifications);
+    }
+
+    private static string? ExtractBearerToken(HttpContext context)
+    {
+        var authHeader = context.Request.Headers["Authorization"].FirstOrDefault();
+        if (string.IsNullOrWhiteSpace(authHeader))
+            return null;
+
+        if (!authHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        return authHeader["Bearer ".Length..].Trim();
+    }
+
+    private static Role? ResolveRole(
+        ClaimsPrincipal principal,
+        JwtSecurityToken token,
+        KeycloakAuthenticationSettings settings)
+    {
+        var roles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var role in principal.Claims.SelectMany(ExtractRoleValues))
+            roles.Add(role);
+
+        foreach (var role in token.Claims.SelectMany(ExtractRoleValues))
+            roles.Add(role);
+
+        foreach (var claimPath in GetConfiguredRoleClaimPaths(settings))
+        {
+            foreach (var role in GetValuesAtPath(token, claimPath))
+                roles.Add(role);
+        }
+
+        if (ContainsMappedRole(roles, Role.Administrator, settings, settings.AdminRoleName))
+            return Role.Administrator;
+
+        if (ContainsMappedRole(roles, Role.ReadOnly, settings))
+            return Role.ReadOnly;
+
+        if (ContainsMappedRole(roles, Role.LookupService, settings))
+            return Role.LookupService;
+
+        if (ContainsMappedRole(roles, Role.User, settings))
+            return Role.User;
+
+        return null;
+    }
+
+    private static IEnumerable<string> ExtractRoleValues(Claim claim)
+    {
+        if (claim.Type == ClaimTypes.Role || claim.Type == "role")
+            return [claim.Value];
+
+        if (claim.Type == "roles")
+        {
+            var parsed = ParseStringArrayClaim(claim.Value);
+            return parsed.Count > 0 ? parsed : [claim.Value];
+        }
+
+        if (claim.Type == "groups")
+        {
+            var parsed = ParseStringArrayClaim(claim.Value);
+            return parsed.Count > 0 ? parsed : [claim.Value];
+        }
+
+        if (claim.Type == "realm_access")
+            return ParseKeycloakRoleContainer(claim.Value, "roles");
+
+        if (claim.Type == "resource_access")
+            return ParseKeycloakResourceAccessRoles(claim.Value);
+
+        return [];
+    }
+
+    private static List<string> ParseStringArrayClaim(string claimValue)
+    {
+        if (string.IsNullOrWhiteSpace(claimValue) || !claimValue.TrimStart().StartsWith("["))
+            return [];
+
+        try
+        {
+            var token = JToken.Parse(claimValue);
+            return token is JArray array
+                ? array.Values<string?>().Where(a => !string.IsNullOrWhiteSpace(a)).Select(a => a!).ToList()
+                : [];
+        }
+        catch (JsonException)
+        {
+            return [];
+        }
+    }
+
+    private static List<string> ParseKeycloakRoleContainer(string claimValue, string propertyName)
+    {
+        if (string.IsNullOrWhiteSpace(claimValue))
+            return [];
+
+        try
+        {
+            var token = JToken.Parse(claimValue);
+            var roles = token[propertyName] as JArray;
+            return roles?.Values<string?>().Where(a => !string.IsNullOrWhiteSpace(a)).Select(a => a!).ToList() ?? [];
+        }
+        catch (JsonException)
+        {
+            return [];
+        }
+    }
+
+    private static List<string> ParseKeycloakResourceAccessRoles(string claimValue)
+    {
+        if (string.IsNullOrWhiteSpace(claimValue))
+            return [];
+
+        try
+        {
+            var token = JToken.Parse(claimValue) as JObject;
+            if (token == null)
+                return [];
+
+            return token.Properties()
+                .SelectMany(property => (property.Value["roles"] as JArray)?.Values<string?>() ?? [])
+                .Where(role => !string.IsNullOrWhiteSpace(role))
+                .Select(role => role!)
+                .ToList();
+        }
+        catch (JsonException)
+        {
+            return [];
+        }
+    }
+
+    private static List<Classification>? ResolveAllowedClassifications(
+        ClaimsPrincipal principal,
+        Role role,
+        KeycloakAuthenticationSettings settings)
+    {
+        var claimValue = GetStringClaim(principal, settings.AllowedClassificationsClaim);
+        if (string.IsNullOrWhiteSpace(claimValue))
+        {
+            return role == Role.Administrator
+                ? Enum.GetValues(typeof(Classification)).Cast<Classification>().ToList()
+                : null;
+        }
+
+        var classifications = new List<Classification>();
+        IEnumerable<string?> values;
+
+        try
+        {
+            values = claimValue.Trim().StartsWith("[")
+                ? JArray.Parse(claimValue).Values<string>()
+                : claimValue.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        }
+        catch (Newtonsoft.Json.JsonReaderException)
+        {
+            return null;
+        }
+
+        foreach (var value in values)
+        {
+            if (value != null && Enum.TryParse<Classification>(value, true, out var classification))
+                classifications.Add(classification);
+        }
+
+        if (classifications.Count == 0)
+            return null;
+
+        return classifications;
+    }
+
+    private static IEnumerable<string> GetValuesAtPath(JwtSecurityToken token, string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return [];
+
+        try
+        {
+            var jToken = JObject.Parse(token.Payload.SerializeToJson()).SelectToken(path);
+            if (jToken == null)
+                return [];
+
+            return jToken.Type == JTokenType.Array
+                ? jToken.Values<string>().Where(a => !string.IsNullOrWhiteSpace(a))
+                : [jToken.ToString()];
+        }
+        catch (JsonException)
+        {
+            return [];
+        }
+    }
+
+    private static string? GetStringClaim(ClaimsPrincipal principal, string claimType)
+    {
+        return principal.Claims.FirstOrDefault(a => a.Type == claimType)?.Value;
+    }
+
+    private static bool IsValidRegex(string regexPattern)
+    {
+        try
+        {
+            _ = Regex.IsMatch(string.Empty, regexPattern, RegexOptions.None, TimeSpan.FromSeconds(1));
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            return false;
+        }
+    }
+
+    private static Guid CreateDeterministicGuid(string source)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(source));
+        Span<byte> guidBytes = stackalloc byte[16];
+        bytes[..16].CopyTo(guidBytes);
+        return new Guid(guidBytes);
+    }
+
+    private IConfigurationManager<OpenIdConnectConfiguration> GetConfigurationManager(
+        KeycloakAuthenticationSettings keycloakSettings)
+    {
+        var authority = keycloakSettings.Authority?.TrimEnd('/');
+        if (string.IsNullOrWhiteSpace(authority))
+            throw new InvalidOperationException("Keycloak authority is not configured");
+
+        var cacheKey = $"{authority}|{keycloakSettings.RequireHttpsMetadata}";
+        return _configurationManagers.GetOrAdd(cacheKey, _ =>
+        {
+            var metadataAddress = $"{authority}/.well-known/openid-configuration";
+            return new ConfigurationManager<OpenIdConnectConfiguration>(
+                metadataAddress,
+                new OpenIdConnectConfigurationRetriever(),
+                new HttpDocumentRetriever { RequireHttps = keycloakSettings.RequireHttpsMetadata });
+        });
+    }
+
+    private static IEnumerable<string> GetConfiguredRoleClaimPaths(KeycloakAuthenticationSettings settings)
+    {
+        foreach (var path in settings.RoleClaimPaths.Where(a => !string.IsNullOrWhiteSpace(a)))
+            yield return path;
+
+        if (!string.IsNullOrWhiteSpace(settings.RoleClaimPath))
+            yield return settings.RoleClaimPath;
+
+        if (!string.IsNullOrWhiteSpace(settings.AdditionalRoleClaimPath))
+            yield return settings.AdditionalRoleClaimPath;
+    }
+
+    private static bool ContainsMappedRole(
+        HashSet<string> tokenValues,
+        Role role,
+        KeycloakAuthenticationSettings settings,
+        params string[] additionalMappedValues)
+    {
+        var mappedValues = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (settings.RoleMappings.TryGetValue(role.ToString(), out var configuredValues))
+        {
+            foreach (var configuredValue in configuredValues.Where(a => !string.IsNullOrWhiteSpace(a)))
+                mappedValues.Add(configuredValue);
+        }
+
+        foreach (var additionalMappedValue in additionalMappedValues.Where(a => !string.IsNullOrWhiteSpace(a)))
+            mappedValues.Add(additionalMappedValue);
+
+        mappedValues.Add(role.ToString());
+
+        return tokenValues.Any(tokenValue => MatchesAnyMappedRoleValue(tokenValue, mappedValues));
+    }
+
+    private static bool MatchesAnyMappedRoleValue(string tokenValue, HashSet<string> mappedValues)
+    {
+        if (mappedValues.Contains(tokenValue))
+            return true;
+
+        var groupLeaf = tokenValue.Split('/', StringSplitOptions.RemoveEmptyEntries).LastOrDefault();
+        return !string.IsNullOrWhiteSpace(groupLeaf) &&
+               mappedValues.Any(mappedValue =>
+                   !mappedValue.Contains('/', StringComparison.Ordinal) &&
+                   string.Equals(groupLeaf, mappedValue, StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/src/api/Fig.Api/Authorization/UserAuth/KeycloakUserAuthenticationModeService.cs
+++ b/src/api/Fig.Api/Authorization/UserAuth/KeycloakUserAuthenticationModeService.cs
@@ -71,7 +71,7 @@ public class KeycloakUserAuthenticationModeService : IUserAuthenticationModeServ
             return null;
         }
 
-        var role = ResolveRole(principal, jwt, keycloakSettings);
+        var role = ResolveRole(jwt, keycloakSettings);
         if (role == null)
         {
             _logger.LogWarning("No recognized Fig role found in Keycloak token claims");
@@ -131,18 +131,14 @@ public class KeycloakUserAuthenticationModeService : IUserAuthenticationModeServ
         return authHeader["Bearer ".Length..].Trim();
     }
 
-    private static Role? ResolveRole(
-        ClaimsPrincipal principal,
+    /// <summary>
+    /// Resolves the Fig role exclusively from configured claim paths so RoleClaimPaths remain an authorization boundary.
+    /// </summary>
+    internal static Role? ResolveRole(
         JwtSecurityToken token,
         KeycloakAuthenticationSettings settings)
     {
         var roles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-        foreach (var role in principal.Claims.SelectMany(ExtractRoleValues))
-            roles.Add(role);
-
-        foreach (var role in token.Claims.SelectMany(ExtractRoleValues))
-            roles.Add(role);
 
         foreach (var claimPath in GetConfiguredRoleClaimPaths(settings))
         {
@@ -163,90 +159,6 @@ public class KeycloakUserAuthenticationModeService : IUserAuthenticationModeServ
             return Role.User;
 
         return null;
-    }
-
-    private static IEnumerable<string> ExtractRoleValues(Claim claim)
-    {
-        if (claim.Type == ClaimTypes.Role || claim.Type == "role")
-            return [claim.Value];
-
-        if (claim.Type == "roles")
-        {
-            var parsed = ParseStringArrayClaim(claim.Value);
-            return parsed.Count > 0 ? parsed : [claim.Value];
-        }
-
-        if (claim.Type == "groups")
-        {
-            var parsed = ParseStringArrayClaim(claim.Value);
-            return parsed.Count > 0 ? parsed : [claim.Value];
-        }
-
-        if (claim.Type == "realm_access")
-            return ParseKeycloakRoleContainer(claim.Value, "roles");
-
-        if (claim.Type == "resource_access")
-            return ParseKeycloakResourceAccessRoles(claim.Value);
-
-        return [];
-    }
-
-    private static List<string> ParseStringArrayClaim(string claimValue)
-    {
-        if (string.IsNullOrWhiteSpace(claimValue) || !claimValue.TrimStart().StartsWith("["))
-            return [];
-
-        try
-        {
-            var token = JToken.Parse(claimValue);
-            return token is JArray array
-                ? array.Values<string?>().Where(a => !string.IsNullOrWhiteSpace(a)).Select(a => a!).ToList()
-                : [];
-        }
-        catch (JsonException)
-        {
-            return [];
-        }
-    }
-
-    private static List<string> ParseKeycloakRoleContainer(string claimValue, string propertyName)
-    {
-        if (string.IsNullOrWhiteSpace(claimValue))
-            return [];
-
-        try
-        {
-            var token = JToken.Parse(claimValue);
-            var roles = token[propertyName] as JArray;
-            return roles?.Values<string?>().Where(a => !string.IsNullOrWhiteSpace(a)).Select(a => a!).ToList() ?? [];
-        }
-        catch (JsonException)
-        {
-            return [];
-        }
-    }
-
-    private static List<string> ParseKeycloakResourceAccessRoles(string claimValue)
-    {
-        if (string.IsNullOrWhiteSpace(claimValue))
-            return [];
-
-        try
-        {
-            var token = JToken.Parse(claimValue) as JObject;
-            if (token == null)
-                return [];
-
-            return token.Properties()
-                .SelectMany(property => (property.Value["roles"] as JArray)?.Values<string?>() ?? [])
-                .Where(role => !string.IsNullOrWhiteSpace(role))
-                .Select(role => role!)
-                .ToList();
-        }
-        catch (JsonException)
-        {
-            return [];
-        }
     }
 
     private static List<Classification>? ResolveAllowedClassifications(

--- a/src/api/Fig.Api/Authorization/UserAuth/UserAuthenticationModeService.cs
+++ b/src/api/Fig.Api/Authorization/UserAuth/UserAuthenticationModeService.cs
@@ -1,0 +1,33 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Fig.Api.Authorization.UserAuth;
+
+public class UserAuthenticationModeService : IUserAuthenticationModeService
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly IOptionsMonitor<ApiSettings> _apiSettings;
+
+    public UserAuthenticationModeService(
+        IServiceProvider serviceProvider,
+        IOptionsMonitor<ApiSettings> apiSettings)
+    {
+        _serviceProvider = serviceProvider;
+        _apiSettings = apiSettings;
+    }
+
+    public ApiAuthMode Mode => _apiSettings.CurrentValue.Authentication.Mode switch
+    {
+        AuthMode.Keycloak => ApiAuthMode.Keycloak,
+        _ => ApiAuthMode.FigManaged
+    };
+
+    public Task<Fig.Contracts.Authentication.UserDataContract?> ResolveAuthenticatedUser(HttpContext context)
+    {
+        return Mode switch
+        {
+            ApiAuthMode.Keycloak => _serviceProvider.GetRequiredService<KeycloakUserAuthenticationModeService>().ResolveAuthenticatedUser(context),
+            _ => _serviceProvider.GetRequiredService<FigManagedUserAuthenticationModeService>().ResolveAuthenticatedUser(context)
+        };
+    }
+}

--- a/src/api/Fig.Api/Controllers/UsersController.cs
+++ b/src/api/Fig.Api/Controllers/UsersController.cs
@@ -2,6 +2,7 @@ using Fig.Api.Attributes;
 using Fig.Api.Services;
 using Fig.Contracts.Authentication;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 
 namespace Fig.Api.Controllers;
 
@@ -9,18 +10,24 @@ namespace Fig.Api.Controllers;
 [Route("users")]
 public class UsersController : ControllerBase
 {
+    private readonly IOptions<ApiSettings> _apiSettings;
     private readonly IUserService _userService;
 
     public UsersController(
-        IUserService userService)
+        IUserService userService,
+        IOptions<ApiSettings> apiSettings)
     {
         _userService = userService;
+        _apiSettings = apiSettings;
     }
 
     [AllowAnonymous]
     [HttpPost("authenticate")]
     public async Task<IActionResult> Authenticate(AuthenticateRequestDataContract model)
     {
+        if (IsKeycloakMode())
+            return NotFound();
+
         var response = await _userService.Authenticate(model);
         if (response is null)
             return Unauthorized();
@@ -32,6 +39,9 @@ public class UsersController : ControllerBase
     [HttpPost("register")]
     public async Task<IActionResult> Register(RegisterUserRequestDataContract model)
     {
+        if (IsKeycloakMode())
+            return NotFound();
+
         var id = await _userService.Register(model);
         return Ok(id);
     }
@@ -40,6 +50,9 @@ public class UsersController : ControllerBase
     [HttpGet]
     public async Task<IActionResult> GetAll()
     {
+        if (IsKeycloakMode())
+            return NotFound();
+
         var users = await _userService.GetAll();
         return Ok(users);
     }
@@ -48,6 +61,9 @@ public class UsersController : ControllerBase
     [HttpGet("{id}")]
     public async Task<IActionResult> GetById(Guid id)
     {
+        if (IsKeycloakMode())
+            return NotFound();
+
         var user = await _userService.GetById(id);
         return Ok(user);
     }
@@ -56,6 +72,9 @@ public class UsersController : ControllerBase
     [HttpPut("{id}")]
     public async Task<IActionResult> Update(Guid id, UpdateUserRequestDataContract model)
     {
+        if (IsKeycloakMode())
+            return NotFound();
+
         await _userService.Update(id, model);
         return Ok();
     }
@@ -64,7 +83,15 @@ public class UsersController : ControllerBase
     [HttpDelete("{id}")]
     public async Task<IActionResult> Delete(Guid id)
     {
+        if (IsKeycloakMode())
+            return NotFound();
+
         await _userService.Delete(id);
         return Ok();
+    }
+
+    private bool IsKeycloakMode()
+    {
+        return _apiSettings.Value.Authentication.Mode == AuthMode.Keycloak;
     }
 }

--- a/src/api/Fig.Api/Middleware/AuthMiddleware.cs
+++ b/src/api/Fig.Api/Middleware/AuthMiddleware.cs
@@ -1,6 +1,6 @@
-using Fig.Api.Authorization;
 using Fig.Api.Controllers;
 using Fig.Contracts.Authentication;
+using Fig.Api.Authorization.UserAuth;
 using Fig.Api.Exceptions;
 using Fig.Api.Services;
 using Microsoft.AspNetCore.Mvc.Controllers;
@@ -17,27 +17,14 @@ public class AuthMiddleware
     }
 
     public async Task Invoke(HttpContext context,
-        IUserService userService,
         IEnumerable<IAuthenticatedService> authenticatedServices,
-        ITokenHandler tokenHandler)
+        IUserAuthenticationModeService userAuthenticationModeService)
     {
         try
         {
-            var authHeader = context.Request.Headers["Authorization"].FirstOrDefault();
-            string? token = null;
-            if (authHeader != null)
+            var user = await userAuthenticationModeService.ResolveAuthenticatedUser(context);
+            if (user != null)
             {
-                token = authHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase)
-                    ? authHeader.Substring("Bearer ".Length).Trim()
-                    : authHeader;
-            }
-            var tokenData = tokenHandler.Validate(token);
-            if (tokenData != null)
-            {
-                // attach user to context on successful jwt validation
-                var user = await userService.GetById(tokenData.UserId);
-                user.PasswordChangeRequired = tokenData.PasswordChangeRequired;
-
                 context.Items["User"] = user;
                 foreach (var service in authenticatedServices)
                     service.SetAuthenticatedUser(user);

--- a/src/api/Fig.Api/Program.cs
+++ b/src/api/Fig.Api/Program.cs
@@ -2,6 +2,7 @@ using Fig.Api;
 using Fig.Api.ApiStatus;
 using Fig.Api.Assistant;
 using Fig.Api.Authorization;
+using Fig.Api.Authorization.UserAuth;
 using Fig.Api.Converters;
 using Fig.Api.Datalayer;
 using Fig.Api.DataImport;
@@ -56,9 +57,25 @@ builder.Services.Configure<ApiSettings>(configuration.GetSection("ApiSettings"))
 var environment = builder.Environment.EnvironmentName ?? "Development";
 
 var apiSettings = configuration.GetSection("ApiSettings");
+var apiSettingsObject = apiSettings.Get<ApiSettings>() ?? new ApiSettings { DbConnectionString = string.Empty };
+
+AuthenticationSettingsValidator.Validate(apiSettingsObject);
 
 var logger = CreateLogger(builder);
 builder.Host.UseSerilog(logger);
+
+if (apiSettingsObject.Authentication.Mode == AuthMode.Keycloak)
+{
+    logger.Information(
+        "Configured authentication mode: {AuthMode}. Keycloak Authority: {KeycloakAuthority}. Keycloak Audience: {KeycloakAudience}",
+        apiSettingsObject.Authentication.Mode,
+        apiSettingsObject.Authentication.Keycloak.Authority,
+        apiSettingsObject.Authentication.Keycloak.Audience);
+}
+else
+{
+    logger.Information("Configured authentication mode: {AuthMode}", apiSettingsObject.Authentication.Mode);
+}
 
 builder.AddServiceDefaults(ApiActivitySource.Name, WebClientActivitySource.Name);
 
@@ -98,6 +115,9 @@ builder.Services.AddSingleton<ISessionFactory>(s => s.GetService<IFigSessionFact
 builder.Services.AddScoped<ISession>(s => s.GetService<ISessionFactory>()!.OpenSession());
 builder.Services.AddScoped<IEventLogFactory, EventLogFactory>();
 builder.Services.AddScoped<ITokenHandler, TokenHandler>();
+builder.Services.AddScoped<FigManagedUserAuthenticationModeService>();
+builder.Services.AddSingleton<KeycloakUserAuthenticationModeService>();
+builder.Services.AddScoped<IUserAuthenticationModeService, UserAuthenticationModeService>();
 builder.Services.AddTransient<IFileImporter, FileImporter>();
 builder.Services.AddSingleton<IFileWatcherFactory, FileWatcherFactory>();
 builder.Services.AddTransient<IFileMonitor, FileMonitor>();
@@ -241,8 +261,7 @@ builder.Services.AddScoped<IAuthenticatedService>(a => a.GetService<IReleaseHigh
 builder.Services.AddScoped<IAuthenticatedService>(a => a.GetService<IReportExecutionService>()!);
 
 // Add rate limiting services
-var apiSettingsObject = configuration.GetSection("ApiSettings").Get<ApiSettings>();
-var rateLimitingConfig = apiSettingsObject?.RateLimiting ?? new RateLimitingSettings();
+var rateLimitingConfig = apiSettingsObject.RateLimiting ?? new RateLimitingSettings();
 if (rateLimitingConfig.GlobalPolicy.Enabled)
 {
     builder.Services.AddRateLimiter(options =>

--- a/src/api/Fig.Api/Reports/Implementations/AccessPrivilegeReport.cs
+++ b/src/api/Fig.Api/Reports/Implementations/AccessPrivilegeReport.cs
@@ -3,6 +3,7 @@ using Fig.Api.Reports.Rendering.Components;
 using Fig.Api.Reports.Rendering.Views;
 using Fig.Common.Constants;
 using Fig.Datalayer.BusinessEntities;
+using Microsoft.Extensions.Options;
 
 namespace Fig.Api.Reports.Implementations;
 
@@ -35,6 +36,8 @@ public class AccessPrivilegeRow
 
 public class AccessPrivilegeReport : ReportBase<AccessPrivilegeParameters, AccessPrivilegeReportModel>
 {
+    private const string KeycloakNotApplicable = "N/A (Keycloak)";
+
     private static readonly string[] LoginEventTypes =
     [
         EventMessage.Login,
@@ -43,11 +46,16 @@ public class AccessPrivilegeReport : ReportBase<AccessPrivilegeParameters, Acces
 
     private readonly IUserRepository _userRepository;
     private readonly IEventLogRepository _eventLogRepository;
+    private readonly AuthMode _authMode;
 
-    public AccessPrivilegeReport(IUserRepository userRepository, IEventLogRepository eventLogRepository)
+    public AccessPrivilegeReport(
+        IUserRepository userRepository,
+        IEventLogRepository eventLogRepository,
+        IOptions<ApiSettings> apiSettings)
     {
         _userRepository = userRepository;
         _eventLogRepository = eventLogRepository;
+        _authMode = apiSettings.Value.Authentication.Mode;
     }
 
     public override string Id => "access-privilege";
@@ -61,38 +69,71 @@ public class AccessPrivilegeReport : ReportBase<AccessPrivilegeParameters, Acces
     public override async Task<object> ExecuteAsync(AccessPrivilegeParameters parameters, CancellationToken cancellationToken = default)
     {
         var (from, to) = ReportDateRange.Validate(parameters.From, parameters.To);
-        var users = (await _userRepository.GetAllUsers())
-            .OrderBy(u => u.Username, StringComparer.OrdinalIgnoreCase)
-            .ToList();
         var loginEvents = await _eventLogRepository.GetEventsByTypes(from, to, LoginEventTypes, RequireAuthenticatedUser());
 
-        var rows = users.Select(user =>
+        List<AccessPrivilegeRow> rows;
+        if (_authMode == AuthMode.Keycloak)
         {
-            var userEvents = loginEvents
-                .Where(e => string.Equals(e.AuthenticatedUser, user.Username, StringComparison.OrdinalIgnoreCase))
+            rows = loginEvents
+                .Where(e => !string.IsNullOrWhiteSpace(e.AuthenticatedUser))
+                .GroupBy(e => e.AuthenticatedUser!, StringComparer.OrdinalIgnoreCase)
+                .OrderBy(g => g.Key, StringComparer.OrdinalIgnoreCase)
+                .Select(g =>
+                {
+                    var logins = g.Where(e => e.EventType == EventMessage.Login).ToList();
+                    var fails = g.Where(e => e.EventType == EventMessage.LoginFailed).ToList();
+                    return new AccessPrivilegeRow
+                    {
+                        Username = g.Key,
+                        Role = KeycloakNotApplicable,
+                        ClientFilter = KeycloakNotApplicable,
+                        Classifications = KeycloakNotApplicable,
+                        PasswordChangeRequired = KeycloakNotApplicable,
+                        LoginCount = logins.Count,
+                        FailCount = fails.Count,
+                        LastLogin = logins.Count == 0 ? null : logins.Max(l => l.Timestamp)
+                    };
+                })
                 .ToList();
-            var logins = userEvents.Where(e => e.EventType == EventMessage.Login).ToList();
-            var fails = userEvents.Where(e => e.EventType == EventMessage.LoginFailed).ToList();
+        }
+        else
+        {
+            var users = (await _userRepository.GetAllUsers())
+                .OrderBy(u => u.Username, StringComparer.OrdinalIgnoreCase)
+                .ToList();
 
-            return new AccessPrivilegeRow
+            rows = users.Select(user =>
             {
-                Username = user.Username,
-                Role = user.Role.ToString(),
-                ClientFilter = user.ClientFilter,
-                Classifications = FormatClassifications(user),
-                PasswordChangeRequired = user.PasswordChangeRequired ? "Yes" : "No",
-                LoginCount = logins.Count,
-                FailCount = fails.Count,
-                LastLogin = logins.Count == 0 ? null : logins.Max(l => l.Timestamp)
-            };
-        }).ToList();
+                var userEvents = loginEvents
+                    .Where(e => string.Equals(e.AuthenticatedUser, user.Username, StringComparison.OrdinalIgnoreCase))
+                    .ToList();
+                var logins = userEvents.Where(e => e.EventType == EventMessage.Login).ToList();
+                var fails = userEvents.Where(e => e.EventType == EventMessage.LoginFailed).ToList();
+
+                return new AccessPrivilegeRow
+                {
+                    Username = user.Username,
+                    Role = user.Role.ToString(),
+                    ClientFilter = user.ClientFilter,
+                    Classifications = FormatClassifications(user),
+                    PasswordChangeRequired = user.PasswordChangeRequired ? "Yes" : "No",
+                    LoginCount = logins.Count,
+                    FailCount = fails.Count,
+                    LastLogin = logins.Count == 0 ? null : logins.Max(l => l.Timestamp)
+                };
+            }).ToList();
+        }
 
         return new AccessPrivilegeReportModel
         {
             Summary =
             [
-                new SummaryCardItem("Users", users.Count.ToString()),
-                new SummaryCardItem("Password Change Required", rows.Count(r => r.PasswordChangeRequired == "Yes").ToString()),
+                new SummaryCardItem("Users", rows.Count.ToString()),
+                new SummaryCardItem(
+                    "Password Change Required",
+                    _authMode == AuthMode.Keycloak
+                        ? KeycloakNotApplicable
+                        : rows.Count(r => r.PasswordChangeRequired == "Yes").ToString()),
                 new SummaryCardItem("Logins In Range", rows.Sum(r => r.LoginCount).ToString()),
                 new SummaryCardItem("Failed Logins In Range", rows.Sum(r => r.FailCount).ToString())
             ],

--- a/src/api/Fig.Api/Reports/Implementations/FigPlatformReport.cs
+++ b/src/api/Fig.Api/Reports/Implementations/FigPlatformReport.cs
@@ -2,6 +2,7 @@ using Fig.Api.Datalayer.Repositories;
 using Fig.Api.Reports.Rendering.Components;
 using Fig.Api.Reports.Rendering.Views;
 using Fig.Datalayer.BusinessEntities;
+using Microsoft.Extensions.Options;
 
 namespace Fig.Api.Reports.Implementations;
 
@@ -45,6 +46,7 @@ public class FigPlatformReport : ReportBase<FigPlatformParameters, FigPlatformRe
     private readonly IUserRepository _userRepository;
     private readonly IWebHookRepository _webHookRepository;
     private readonly ISettingGroupRepository _settingGroupRepository;
+    private readonly AuthMode _authMode;
 
     public FigPlatformReport(
         IApiStatusRepository apiStatusRepository,
@@ -53,7 +55,8 @@ public class FigPlatformReport : ReportBase<FigPlatformParameters, FigPlatformRe
         ISettingClientRepository settingClientRepository,
         IUserRepository userRepository,
         IWebHookRepository webHookRepository,
-        ISettingGroupRepository settingGroupRepository)
+        ISettingGroupRepository settingGroupRepository,
+        IOptions<ApiSettings> apiSettings)
     {
         _apiStatusRepository = apiStatusRepository;
         _configurationRepository = configurationRepository;
@@ -62,6 +65,7 @@ public class FigPlatformReport : ReportBase<FigPlatformParameters, FigPlatformRe
         _userRepository = userRepository;
         _webHookRepository = webHookRepository;
         _settingGroupRepository = settingGroupRepository;
+        _authMode = apiSettings.Value.Authentication.Mode;
     }
 
     public override string Id => "fig-platform";
@@ -77,9 +81,12 @@ public class FigPlatformReport : ReportBase<FigPlatformParameters, FigPlatformRe
         var configuration = await _configurationRepository.GetConfiguration();
         var eventLogCount = await _eventLogRepository.GetEventLogCount();
         var clients = await _settingClientRepository.GetAllClients(RequireAuthenticatedUser());
-        var users = await _userRepository.GetAllUsers();
         var webhooks = await _webHookRepository.GetWebHooks();
         var groups = await _settingGroupRepository.GetAllGroups();
+
+        var usersSummary = _authMode == AuthMode.Keycloak
+            ? "External (Keycloak)"
+            : (await _userRepository.GetAllUsers()).Count.ToString();
 
         return new FigPlatformReportModel
         {
@@ -87,7 +94,7 @@ public class FigPlatformReport : ReportBase<FigPlatformParameters, FigPlatformRe
             [
                 new SummaryCardItem("Active API Nodes", apiNodes.Count.ToString()),
                 new SummaryCardItem("Clients", clients.Count.ToString()),
-                new SummaryCardItem("Users", users.Count.ToString()),
+                new SummaryCardItem("Users", usersSummary),
                 new SummaryCardItem("Webhooks", webhooks.Count.ToString()),
                 new SummaryCardItem("Setting Groups", groups.Count.ToString()),
                 new SummaryCardItem("Event Log Rows", eventLogCount.ToString("N0"))

--- a/src/api/Fig.Api/Services/ImportExportService.cs
+++ b/src/api/Fig.Api/Services/ImportExportService.cs
@@ -11,6 +11,7 @@ using Fig.Contracts.ExtensionMethods;
 using Fig.Contracts.ImportExport;
 using Fig.Datalayer.BusinessEntities;
 using Fig.Datalayer.BusinessEntities.SettingValues;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace Fig.Api.Services;
@@ -230,6 +231,18 @@ public class ImportExportService : AuthenticatedService, IImportExportService
             };
         }
         catch (CryptographicException e)
+        {
+            const string message = "Unable to decrypt existing client data. The server encryption key may have changed since this client was registered.";
+            _logger.LogError(e, "Value only import failed during client retrieval due to decryption error");
+            await _eventLogRepository.Add(_eventLogFactory.DataImportFailed(data.ImportType, importMode, AuthenticatedUser, message));
+            return new ImportResultDataContract
+            {
+                ImportType = data.ImportType,
+                ErrorMessage = message,
+                RequiresDecryptionKey = true
+            };
+        }
+        catch (JsonSerializationException e) when (e.InnerException is CryptographicException or FormatException)
         {
             const string message = "Unable to decrypt existing client data. The server encryption key may have changed since this client was registered.";
             _logger.LogError(e, "Value only import failed during client retrieval due to decryption error");

--- a/src/api/Fig.Api/appsettings.json
+++ b/src/api/Fig.Api/appsettings.json
@@ -5,6 +5,44 @@
     "TokenLifeMinutes": 10080,
     "PreviousSecret": "",
     "SecretsDpapiEncrypted": false,
+    "Authentication": {
+      "Mode": "FigManaged",
+      "Keycloak": {
+        "Authority": "",
+        "Audience": "",
+        "RequireHttpsMetadata": true,
+        "UsernameClaim": "preferred_username",
+        "FirstNameClaim": "given_name",
+        "LastNameClaim": "family_name",
+        "NameClaim": "name",
+        "RoleClaimPaths": [
+          "groups",
+          "realm_access.roles",
+          "resource_access.fig.roles"
+        ],
+        "RoleMappings": {
+          "Administrator": [
+            "Administrator",
+            "/fig/Administrator"
+          ],
+          "User": [
+            "User",
+            "/fig/User"
+          ],
+          "ReadOnly": [
+            "ReadOnly",
+            "/fig/ReadOnly"
+          ],
+          "LookupService": [
+            "LookupService",
+            "/fig/LookupService"
+          ]
+        },
+        "AllowedClassificationsClaim": "fig_allowed_classifications",
+        "ClientFilterClaim": "fig_client_filter",
+        "AdminRoleName": "Administrator"
+      }
+    },
     "WebClientAddresses": [
       "https://localhost:7148",
       "http://localhost:7148",

--- a/src/hosting/Fig.AppHost/Fig.AppHost.csproj
+++ b/src/hosting/Fig.AppHost/Fig.AppHost.csproj
@@ -14,6 +14,7 @@
 
     <ItemGroup>
         <PackageReference Include="Aspire.Hosting.AppHost" Version="13.4.6" />
+        <PackageReference Include="Aspire.Hosting.Keycloak" Version="13.1.1-preview.1.26105.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/hosting/Fig.AppHost/Program.cs
+++ b/src/hosting/Fig.AppHost/Program.cs
@@ -2,11 +2,41 @@ using Projects;
 
 var builder = DistributedApplication.CreateBuilder(args);
 
-builder.AddProject<Fig_Api>("fig-api")
-    .WithHttpsEndpoint(7281, name: "fig-api-https");
+const int keycloakPort = 8085;
+var keycloakHostUrl = $"http://localhost:{keycloakPort}";
+var realmImportPath = Path.GetFullPath(Path.Combine(
+    builder.Environment.ContentRootPath,
+    "..",
+    "..",
+    "..",
+    "resources",
+    "keycloak",
+    "realm-export.json"));
+
+var keycloak = builder.AddKeycloak("keycloak", keycloakPort)
+    .WithRealmImport(realmImportPath)
+    .WithLifetime(ContainerLifetime.Persistent);
+
+var figApi = builder.AddProject<Fig_Api>("fig-api")
+    .WithHttpsEndpoint(7281, name: "fig-api-https")
+    .WithEnvironment("ApiSettings__Authentication__Mode", "Keycloak")
+    .WithEnvironment("ApiSettings__Authentication__Keycloak__Authority", $"{keycloakHostUrl}/realms/fig")
+    .WithEnvironment("ApiSettings__Authentication__Keycloak__Audience", "fig-api")
+    .WithEnvironment("ApiSettings__Authentication__Keycloak__RequireHttpsMetadata", "false")
+    .WaitFor(keycloak);
 
 builder.AddProject<Fig_Web>("fig-web")
-    .WithHttpsEndpoint(7148, name: "fig-web-https");
+    .WithHttpsEndpoint(7148, name: "fig-web-https")
+    .WithEnvironment("WebSettings__Authentication__Mode", "Keycloak")
+    .WithEnvironment("WebSettings__Authentication__Keycloak__Authority", $"{keycloakHostUrl}/realms/fig")
+    .WithEnvironment("WebSettings__Authentication__Keycloak__ClientId", "fig-web")
+    .WithEnvironment("WebSettings__Authentication__Keycloak__Scopes", "openid profile email roles")
+    .WithEnvironment("WebSettings__Authentication__Keycloak__ApiScope", "")
+    .WithEnvironment("WebSettings__Authentication__Keycloak__ResponseType", "code")
+    .WithEnvironment("WebSettings__Authentication__Keycloak__PostLogoutRedirectUri", "https://localhost:7148/")
+    .WithEnvironment("WebSettings__Authentication__Keycloak__AccountManagementUrl", $"{keycloakHostUrl}/realms/fig/account/")
+    .WaitFor(keycloak)
+    .WaitFor(figApi);
 
 builder.AddProject<Fig_Examples_AspNetApi>("aspnetapi-example")
     .WithEnvironment("FIG_API_URI", "https://localhost:7281")

--- a/src/hosting/Fig.AppHost/Program.cs
+++ b/src/hosting/Fig.AppHost/Program.cs
@@ -2,41 +2,55 @@ using Projects;
 
 var builder = DistributedApplication.CreateBuilder(args);
 
+var useKeycloak = bool.TryParse(builder.Configuration["UseKeycloak"], out var parsedUseKeycloak) &&
+                  parsedUseKeycloak;
+
+IResourceBuilder<IResource>? keycloak = null;
 const int keycloakPort = 8085;
 var keycloakHostUrl = $"http://localhost:{keycloakPort}";
-var realmImportPath = Path.GetFullPath(Path.Combine(
-    builder.Environment.ContentRootPath,
-    "..",
-    "..",
-    "..",
-    "resources",
-    "keycloak",
-    "realm-export.json"));
 
-var keycloak = builder.AddKeycloak("keycloak", keycloakPort)
-    .WithRealmImport(realmImportPath)
-    .WithLifetime(ContainerLifetime.Persistent);
+if (useKeycloak)
+{
+    var realmImportPath = Path.GetFullPath(Path.Combine(
+        builder.Environment.ContentRootPath,
+        "..",
+        "..",
+        "..",
+        "resources",
+        "keycloak",
+        "realm-export.json"));
+
+    keycloak = builder.AddKeycloak("keycloak", keycloakPort)
+        .WithRealmImport(realmImportPath)
+        .WithLifetime(ContainerLifetime.Persistent);
+}
 
 var figApi = builder.AddProject<Fig_Api>("fig-api")
-    .WithHttpsEndpoint(7281, name: "fig-api-https")
-    .WithEnvironment("ApiSettings__Authentication__Mode", "Keycloak")
-    .WithEnvironment("ApiSettings__Authentication__Keycloak__Authority", $"{keycloakHostUrl}/realms/fig")
-    .WithEnvironment("ApiSettings__Authentication__Keycloak__Audience", "fig-api")
-    .WithEnvironment("ApiSettings__Authentication__Keycloak__RequireHttpsMetadata", "false")
-    .WaitFor(keycloak);
+    .WithHttpsEndpoint(7281, name: "fig-api-https");
 
-builder.AddProject<Fig_Web>("fig-web")
+if (useKeycloak)
+{
+    figApi = figApi
+        .WithEnvironment("ApiSettings__Authentication__Mode", "Keycloak")
+        .WithEnvironment("ApiSettings__Authentication__Keycloak__Authority", $"{keycloakHostUrl}/realms/fig")
+        .WithEnvironment("ApiSettings__Authentication__Keycloak__Audience", "fig-api")
+        .WithEnvironment("ApiSettings__Authentication__Keycloak__RequireHttpsMetadata", "false")
+        .WaitFor(keycloak!);
+}
+
+var figWeb = builder.AddProject<Fig_Web>("fig-web")
     .WithHttpsEndpoint(7148, name: "fig-web-https")
-    .WithEnvironment("WebSettings__Authentication__Mode", "Keycloak")
-    .WithEnvironment("WebSettings__Authentication__Keycloak__Authority", $"{keycloakHostUrl}/realms/fig")
-    .WithEnvironment("WebSettings__Authentication__Keycloak__ClientId", "fig-web")
-    .WithEnvironment("WebSettings__Authentication__Keycloak__Scopes", "openid profile email roles")
-    .WithEnvironment("WebSettings__Authentication__Keycloak__ApiScope", "")
-    .WithEnvironment("WebSettings__Authentication__Keycloak__ResponseType", "code")
-    .WithEnvironment("WebSettings__Authentication__Keycloak__PostLogoutRedirectUri", "https://localhost:7148/")
-    .WithEnvironment("WebSettings__Authentication__Keycloak__AccountManagementUrl", $"{keycloakHostUrl}/realms/fig/account/")
-    .WaitFor(keycloak)
     .WaitFor(figApi);
+
+if (useKeycloak)
+{
+    // Blazor WASM loads wwwroot/appsettings.{Environment}.json in the browser;
+    // process WebSettings__* env vars do not reach that config.
+    figWeb = figWeb
+        .WithEnvironment("ASPNETCORE_ENVIRONMENT", "Keycloak")
+        .WithEnvironment("DOTNET_ENVIRONMENT", "Keycloak")
+        .WaitFor(keycloak!);
+}
 
 builder.AddProject<Fig_Examples_AspNetApi>("aspnetapi-example")
     .WithEnvironment("FIG_API_URI", "https://localhost:7281")

--- a/src/hosting/Fig.AppHost/appsettings.json
+++ b/src/hosting/Fig.AppHost/appsettings.json
@@ -1,4 +1,5 @@
 {
+  "UseKeycloak": false,
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/src/tests/Fig.Integration.Test/Api/KeycloakAuthenticationIntegrationTests.cs
+++ b/src/tests/Fig.Integration.Test/Api/KeycloakAuthenticationIntegrationTests.cs
@@ -1,0 +1,113 @@
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+using Fig.Contracts.Authentication;
+using Fig.Test.Common;
+using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace Fig.Integration.Test.Api;
+
+public class KeycloakAuthenticationIntegrationTests : IntegrationTestBase
+{
+    [Test]
+    public async Task ShallReturnNotFoundForAuthenticateEndpointInKeycloakMode()
+    {
+        EnableKeycloakModeForTests();
+
+        var authContract = new AuthenticateRequestDataContract("any-user", "any-password");
+        var json = JsonConvert.SerializeObject(authContract);
+        using var content = new StringContent(json, Encoding.UTF8, "application/json");
+        using var httpClient = GetHttpClient();
+
+        var response = await httpClient.PostAsync("/users/authenticate", content);
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
+    }
+
+    [Test]
+    public async Task ShallReturnNotFoundForUsersEndpointWithValidAdminKeycloakToken()
+    {
+        EnableKeycloakModeForTests();
+        var token = CreateKeycloakToken(Role.Administrator);
+
+        using var response = await ApiClient.GetRaw("/users", token);
+        var responseBody = await response.Content.ReadAsStringAsync();
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.NotFound), responseBody);
+    }
+
+    [Test]
+    public async Task ShallRejectTokenWithNoMappedRole()
+    {
+        EnableKeycloakModeForTests();
+        var token = CreateKeycloakToken(null);
+
+        using var response = await ApiClient.GetRaw("/clients", token);
+        var responseBody = await response.Content.ReadAsStringAsync();
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized), responseBody);
+    }
+
+    [Test]
+    public async Task ShallRejectNonAdminTokenWithMissingAllowedClassifications()
+    {
+        EnableKeycloakModeForTests();
+        var token = CreateKeycloakToken(Role.User, includeAllowedClassificationsClaim: false);
+
+        using var response = await ApiClient.GetRaw("/clients", token);
+        var responseBody = await response.Content.ReadAsStringAsync();
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized), responseBody);
+    }
+
+    [Test]
+    public async Task ShallAllowAdminTokenWithMissingAllowedClassifications()
+    {
+        EnableKeycloakModeForTests();
+        var token = CreateKeycloakToken(Role.Administrator, includeAllowedClassificationsClaim: false);
+
+        using var response = await ApiClient.GetRaw("/clients", token);
+        var responseBody = await response.Content.ReadAsStringAsync();
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), responseBody);
+    }
+
+    [Test]
+    public async Task ShallAllowTokenWithConfiguredKeycloakGroup()
+    {
+        EnableKeycloakModeForTests();
+        var token = CreateKeycloakToken(Role.Administrator, includeRoleClaims: false);
+
+        using var response = await ApiClient.GetRaw("/clients", token);
+        var responseBody = await response.Content.ReadAsStringAsync();
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK), responseBody);
+    }
+
+    [Test]
+    public async Task ShallRejectTokenWithWrongAudience()
+    {
+        EnableKeycloakModeForTests();
+        var token = CreateKeycloakToken(Role.Administrator, audience: "other-api");
+
+        using var response = await ApiClient.GetRaw("/clients", token);
+        var responseBody = await response.Content.ReadAsStringAsync();
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized), responseBody);
+    }
+
+    [Test]
+    public async Task ShallRejectTokenWithInvalidClientFilterRegex()
+    {
+        EnableKeycloakModeForTests();
+        var token = CreateKeycloakToken(Role.Administrator, clientFilter: "[");
+
+        using var response = await ApiClient.GetRaw("/clients", token);
+        var responseBody = await response.Content.ReadAsStringAsync();
+
+        Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized), responseBody);
+    }
+}

--- a/src/tests/Fig.Integration.Test/Api/MachineClientRegressionTests.cs
+++ b/src/tests/Fig.Integration.Test/Api/MachineClientRegressionTests.cs
@@ -1,0 +1,54 @@
+using System.Net;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Fig.Client.Abstractions.Data;
+using Fig.Contracts.Authentication;
+using Fig.Test.Common;
+using Fig.Test.Common.TestSettings;
+using NUnit.Framework;
+
+namespace Fig.Integration.Test.Api;
+
+public class MachineClientRegressionTests : IntegrationTestBase
+{
+    [Test]
+    public async Task ShallRegisterClientWithClientSecretInKeycloakMode()
+    {
+        EnableKeycloakModeForTests();
+        var clientSecret = GetNewSecret();
+
+        var settings = await RegisterSettings<ThreeSettings>(clientSecret);
+        var adminToken = CreateKeycloakToken(Role.Administrator);
+        var clients = (await GetAllClients(tokenOverride: adminToken)).ToList();
+
+        Assert.That(clients.Any(a => a.Name == settings.ClientName), Is.True);
+    }
+
+    [Test]
+    public async Task ShallGetClientSettingsWithClientSecretInKeycloakMode()
+    {
+        EnableKeycloakModeForTests();
+        var clientSecret = GetNewSecret();
+
+        var settings = await RegisterSettings<ThreeSettings>(clientSecret);
+        var settingValues = await GetSettingsForClient(settings.ClientName, clientSecret);
+
+        Assert.That(settingValues.Count, Is.GreaterThan(0));
+    }
+
+    [Test]
+    public async Task ShallUpdateStatusWithClientSecretInKeycloakMode()
+    {
+        EnableKeycloakModeForTests();
+        var clientSecret = GetNewSecret();
+
+        var settings = await RegisterSettings<ThreeSettings>(clientSecret);
+        var statusRequest = CreateStatusRequest(DateTime.UtcNow, DateTime.UtcNow, 1000, liveReload: true);
+
+        var status = await GetStatus(settings.ClientName, clientSecret, statusRequest);
+
+        Assert.That(status, Is.Not.Null);
+        Assert.That(status.PollIntervalMs, Is.Not.Null);
+    }
+}

--- a/src/tests/Fig.Integration.Test/Api/SchedulingTests.cs
+++ b/src/tests/Fig.Integration.Test/Api/SchedulingTests.cs
@@ -407,13 +407,13 @@ public class SchedulingTests : IntegrationTestBase
         Assert.That(await GetCurrentSettingValue(), Is.EqualTo(originalValue));
 
         await WaitForCondition(
-            () => Task.FromResult(settings.CurrentValue.AStringSetting == newValue),
+            async () => await GetCurrentSettingValue() == newValue,
             TimeSpan.FromSeconds(5),
-            () => $"New value ({newValue}) should have been applied but had {settings.CurrentValue.AStringSetting} instead");
+            () => $"New value ({newValue}) should have been applied");
 
-        var appliedSettings = await GetSettingsForClient(settings.CurrentValue.ClientName, secret);
+        var appliedSettings = await GetSettingsForClient(clientName, secret);
         Assert.That(
-            appliedSettings.First(a => a.Name == nameof(settings.CurrentValue.AStringSetting)).Value?.GetValue(),
+            appliedSettings.First(a => a.Name == nameof(settings.AStringSetting)).Value?.GetValue(),
             Is.EqualTo(newValue));
 
         await WaitForCondition(async () =>
@@ -423,14 +423,20 @@ public class SchedulingTests : IntegrationTestBase
         }, TimeSpan.FromSeconds(5));
 
         await WaitForCondition(
-            () => Task.FromResult(settings.CurrentValue.AStringSetting == originalValue),
+            async () => await GetCurrentSettingValue() == originalValue,
             TimeSpan.FromSeconds(6),
-            () => $"Original value ({originalValue}) should have been reverted but had {settings.CurrentValue.AStringSetting} instead");
+            () => $"Original value ({originalValue}) should have been reverted");
 
-        var revertedSettings = await GetSettingsForClient(settings.CurrentValue.ClientName, secret);
+        var revertedSettings = await GetSettingsForClient(clientName, secret);
         Assert.That(
-            revertedSettings.First(a => a.Name == nameof(settings.CurrentValue.AStringSetting)).Value?.GetValue(),
+            revertedSettings.First(a => a.Name == nameof(settings.AStringSetting)).Value?.GetValue(),
             Is.EqualTo(originalValue));
+
+        async Task<string?> GetCurrentSettingValue()
+        {
+            var currentSettings = await GetSettingsForClient(clientName, secret);
+            return currentSettings.First(a => a.Name == nameof(settings.AStringSetting)).Value!.GetValue()?.ToString();
+        }
     }
 
     [Test]

--- a/src/tests/Fig.Integration.Test/Api/SchedulingTests.cs
+++ b/src/tests/Fig.Integration.Test/Api/SchedulingTests.cs
@@ -366,6 +366,7 @@ public class SchedulingTests : IntegrationTestBase
     }
     
     [Test]
+    [NonParallelizable]
     public async Task ShallScheduleChangesWithRevertAndDelayedApply()
     {
         SetSchedulingCheckIntervalMs(50);
@@ -373,13 +374,14 @@ public class SchedulingTests : IntegrationTestBase
 
         // Arrange
         var secret = GetNewSecret();
-        var (settings, _) = InitializeConfigurationProvider<ThreeSettings>(secret);
+        var clientName = $"ThreeSettings-{Guid.NewGuid():N}";
+        var settings = await RegisterSettings<ThreeSettings>(secret, nameOverride: clientName);
         const string newValue = "Temporary scheduled value";
-        var originalValue = settings.CurrentValue.AStringSetting;
+        var originalValue = settings.AStringSetting;
         
         var settingsToUpdate = new List<SettingDataContract>
         {
-            new(nameof(settings.CurrentValue.AStringSetting), new StringSettingDataContract(newValue))
+            new(nameof(settings.AStringSetting), new StringSettingDataContract(newValue))
         };
 
         // Capture timestamps immediately before the API call so slow CI setup
@@ -390,7 +392,7 @@ public class SchedulingTests : IntegrationTestBase
         var revertAt = applyAt.AddSeconds(2);
 
         // Act - Schedule a change with revert
-        var result = await SetSettings(settings.CurrentValue.ClientName, settingsToUpdate, applyAt: applyAt, revertAt: revertAt);
+        var result = await SetSettings(clientName, settingsToUpdate, applyAt: applyAt, revertAt: revertAt);
         
         // Assert - Verify the change and revert were scheduled
         Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.OK));
@@ -401,8 +403,8 @@ public class SchedulingTests : IntegrationTestBase
         var applyChange = scheduledChanges.Changes.First();
         Assert.That(applyChange.ExecuteAtUtc, Is.EqualTo(applyAt).Within(1).Seconds);
         
-        Assert.That(applyChange.ClientName, Is.EqualTo(settings.CurrentValue.ClientName));
-        Assert.That(settings.CurrentValue.AStringSetting, Is.EqualTo(originalValue));
+        Assert.That(applyChange.ClientName, Is.EqualTo(clientName));
+        Assert.That(await GetCurrentSettingValue(), Is.EqualTo(originalValue));
 
         await WaitForCondition(
             () => Task.FromResult(settings.CurrentValue.AStringSetting == newValue),

--- a/src/tests/Fig.Integration.Test/Api/ValueOnlyImportExportTests.cs
+++ b/src/tests/Fig.Integration.Test/Api/ValueOnlyImportExportTests.cs
@@ -1130,12 +1130,16 @@ public class ValueOnlyImportExportTests : IntegrationTestBase
     [Test]
     public async Task ShallReturnRequiresDecryptionKeyForValueOnlyImportWithDifferentSecret()
     {
-        await RegisterSettings<SecretSettings>();
+        var secret = GetNewSecret();
+        await RegisterSettings<SecretSettings>(secret);
 
         var export = await ExportValueOnlyData();
 
+        await DeleteAllClients();
+
         await WithRotatedServerSecret(async () =>
         {
+            await RegisterSettings<SecretSettings>(secret);
             var result = await ImportValueOnlyData(export);
 
             Assert.That(result.RequiresDecryptionKey, Is.True);
@@ -1146,12 +1150,16 @@ public class ValueOnlyImportExportTests : IntegrationTestBase
     [Test]
     public async Task ShallReturnRequiresDecryptionKeyForValueOnlyImportWithWrongCustomDecryptionKey()
     {
-        await RegisterSettings<SecretSettings>();
+        var secret = GetNewSecret();
+        await RegisterSettings<SecretSettings>(secret);
 
         var export = await ExportValueOnlyData();
 
+        await DeleteAllClients();
+
         await WithRotatedServerSecret(async () =>
         {
+            await RegisterSettings<SecretSettings>(secret);
             export.DecryptionKey = Guid.NewGuid().ToString("N");
             var result = await ImportValueOnlyData(export);
 

--- a/src/tests/Fig.Test.Common/IntegrationTestBase.cs
+++ b/src/tests/Fig.Test.Common/IntegrationTestBase.cs
@@ -1,5 +1,8 @@
 using System.Net;
 using System.Reflection;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Security.Cryptography;
 using System.Text;
 using Fig.Api;
 using Fig.Api.Secrets;
@@ -31,12 +34,17 @@ using Fig.Datalayer.BusinessEntities;
 using Fig.Test.Common.TestSettings;
 using Fig.WebHooks.TestClient;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
 using Moq;
 using Newtonsoft.Json;
 using NHibernate;
@@ -53,6 +61,10 @@ public abstract class IntegrationTestBase
 
     private WebApplicationFactory<ApiSettings> _app = null!;
     private WebApplicationFactory<FigWebHookAuthMiddleware> _webHookTestApp = null!;
+    private WebApplication? _keycloakTestAuthority;
+    private RSA? _keycloakRsa;
+    private RsaSecurityKey? _keycloakSigningKey;
+    private string _keycloakAuthority = string.Empty;
     protected ApiClient ApiClient = null!;
     protected HttpClient WebHookClient = null!;
     private string _dbFile = string.Empty;
@@ -140,6 +152,14 @@ public abstract class IntegrationTestBase
         
         _app.Dispose();
         _webHookTestApp.Dispose();
+
+        if (_keycloakTestAuthority is not null)
+        {
+            _keycloakTestAuthority.StopAsync().GetAwaiter().GetResult();
+            _keycloakTestAuthority.DisposeAsync().GetAwaiter().GetResult();
+        }
+
+        _keycloakRsa?.Dispose();
         
         // Give SQLite a moment to release file locks
         Thread.Sleep(100);
@@ -176,6 +196,21 @@ public abstract class IntegrationTestBase
     [SetUp]
     public virtual async Task Setup()
     {
+        Settings.Authentication.Mode = AuthMode.FigManaged;
+        Settings.Authentication.Keycloak.Authority = null;
+        Settings.Authentication.Keycloak.Audience = null;
+        Settings.Authentication.Keycloak.RequireHttpsMetadata = true;
+        Settings.DisableTransactionMiddleware = false;
+
+        var currentOptions = _app.Services.GetRequiredService<IOptions<ApiSettings>>().Value;
+        currentOptions.Authentication.Mode = AuthMode.FigManaged;
+        currentOptions.Authentication.Keycloak.Authority = null;
+        currentOptions.Authentication.Keycloak.Audience = null;
+        currentOptions.Authentication.Keycloak.RequireHttpsMetadata = true;
+        currentOptions.DisableTransactionMiddleware = false;
+
+        ConfigReloader.Reload(Settings);
+
         await ApiClient.Authenticate();
         _originalServerSecret = Settings.Secret;
         _originalPreviousServerSecret = Settings.PreviousSecret;
@@ -201,6 +236,16 @@ public abstract class IntegrationTestBase
         Settings.PreviousSecret = _originalPreviousServerSecret;
         Settings.SchedulingCheckIntervalMs = 547;
         Settings.TimeMachineCheckIntervalMs = 1002;
+        Settings.Authentication.Mode = AuthMode.FigManaged;
+        Settings.Authentication.Keycloak.Authority = null;
+        Settings.Authentication.Keycloak.Audience = null;
+        Settings.Authentication.Keycloak.RequireHttpsMetadata = true;
+
+        var currentOptions = _app.Services.GetRequiredService<IOptions<ApiSettings>>().Value;
+        currentOptions.Authentication.Mode = AuthMode.FigManaged;
+        currentOptions.Authentication.Keycloak.Authority = null;
+        currentOptions.Authentication.Keycloak.Audience = null;
+        currentOptions.Authentication.Keycloak.RequireHttpsMetadata = true;
         ConfigReloader.Reload(Settings);
 
         await ResetDatabaseStateAsync();
@@ -257,6 +302,119 @@ public abstract class IntegrationTestBase
     protected async Task<AuthenticateResponseDataContract?> TryLogin(string username, string password)
     {
         return await ApiClient.TryLogin(username, password);
+    }
+
+    protected void EnableKeycloakModeForTests()
+    {
+        EnsureFakeKeycloakAuthorityStarted();
+
+        ConfigureForKeycloak(Settings);
+
+        var currentOptions = _app.Services.GetRequiredService<IOptions<ApiSettings>>().Value;
+        ConfigureForKeycloak(currentOptions);
+
+        ConfigReloader.Reload(Settings);
+    }
+
+    private void EnsureFakeKeycloakAuthorityStarted()
+    {
+        if (_keycloakTestAuthority is not null)
+            return;
+
+        StartFakeKeycloakAuthority().GetAwaiter().GetResult();
+    }
+
+    private void ConfigureForKeycloak(ApiSettings target)
+    {
+        target.Authentication.Mode = AuthMode.Keycloak;
+        target.Authentication.Keycloak.Authority = _keycloakAuthority;
+        target.Authentication.Keycloak.Audience = "fig-api";
+        target.Authentication.Keycloak.RequireHttpsMetadata = false;
+        target.Authentication.Keycloak.UsernameClaim = "preferred_username";
+        target.Authentication.Keycloak.FirstNameClaim = "given_name";
+        target.Authentication.Keycloak.LastNameClaim = "family_name";
+        target.Authentication.Keycloak.NameClaim = "name";
+        target.Authentication.Keycloak.RoleClaimPaths = ["groups", "realm_access.roles", "resource_access.fig.roles"];
+        target.Authentication.Keycloak.RoleMappings = new Dictionary<string, string[]>
+        {
+            [Role.Administrator.ToString()] = [Role.Administrator.ToString(), $"/fig/{Role.Administrator}"],
+            [Role.User.ToString()] = [Role.User.ToString(), $"/fig/{Role.User}"],
+            [Role.ReadOnly.ToString()] = [Role.ReadOnly.ToString(), $"/fig/{Role.ReadOnly}"],
+            [Role.LookupService.ToString()] = [Role.LookupService.ToString(), $"/fig/{Role.LookupService}"]
+        };
+        target.Authentication.Keycloak.AllowedClassificationsClaim = "fig_allowed_classifications";
+        target.Authentication.Keycloak.ClientFilterClaim = "fig_client_filter";
+        target.Authentication.Keycloak.AdminRoleName = Role.Administrator.ToString();
+    }
+
+    protected string CreateKeycloakToken(
+        Role? role,
+        bool includeAllowedClassificationsClaim = true,
+        string? clientFilter = ".*",
+        string? username = null,
+        string? allowedClassificationsClaimValue = null,
+        string audience = "fig-api",
+        bool includeRoleClaims = true,
+        bool includeGroupClaim = true)
+    {
+        EnsureFakeKeycloakAuthorityStarted();
+
+        if (_keycloakSigningKey is null)
+            throw new ApplicationException("Keycloak signing key was not initialized for tests");
+
+        var userName = username ?? $"{role?.ToString().ToLowerInvariant() ?? "unknown"}-user";
+        var signingCredentials = new SigningCredentials(_keycloakSigningKey, SecurityAlgorithms.RsaSha256);
+        var now = DateTime.UtcNow;
+
+        var payload = new JwtPayload
+        {
+            { "iss", _keycloakAuthority },
+            { "aud", audience },
+            { "sub", Guid.NewGuid().ToString("N") },
+            { "preferred_username", userName },
+            { "given_name", "Test" },
+            { "family_name", "User" },
+            { "name", "Test User" },
+            { "iat", new DateTimeOffset(now).ToUnixTimeSeconds() },
+            { "nbf", new DateTimeOffset(now.AddMinutes(-1)).ToUnixTimeSeconds() },
+            { "exp", new DateTimeOffset(now.AddMinutes(30)).ToUnixTimeSeconds() }
+        };
+
+        if (role is not null)
+        {
+            if (includeGroupClaim)
+                payload["groups"] = new[] { $"/fig/{role}" };
+
+            if (includeRoleClaims)
+            {
+                payload["realm_access"] = new Dictionary<string, object>
+                {
+                    { "roles", new[] { role.ToString() } }
+                };
+
+                payload["resource_access"] = new Dictionary<string, object>
+                {
+                    {
+                        "fig", new Dictionary<string, object>
+                        {
+                            { "roles", new[] { role.ToString() } }
+                        }
+                    }
+                };
+            }
+        }
+
+        if (includeAllowedClassificationsClaim)
+        {
+            payload["fig_allowed_classifications"] =
+                allowedClassificationsClaimValue ?? "[\"Technical\",\"Functional\",\"Special\"]";
+        }
+
+        if (clientFilter is not null)
+            payload["fig_client_filter"] = clientFilter;
+
+        var token = new JwtSecurityToken(new JwtHeader(signingCredentials), payload);
+        return $"Bearer {new JwtSecurityTokenHandler().WriteToken(token)}";
     }
 
     protected async Task<List<SettingDataContract>> GetSettingsForClient(string clientName,
@@ -1600,5 +1758,67 @@ public abstract class IntegrationTestBase
     protected IServiceScope GetServiceScope()
     {
         return _app.Services.CreateScope();
+    }
+
+    private async Task StartFakeKeycloakAuthority()
+    {
+        _keycloakRsa = RSA.Create(2048);
+        _keycloakSigningKey = new RsaSecurityKey(_keycloakRsa)
+        {
+            KeyId = Guid.NewGuid().ToString("N")
+        };
+
+        var webBuilder = WebApplication.CreateBuilder();
+        webBuilder.WebHost.ConfigureKestrel(options => options.Listen(IPAddress.Loopback, 0));
+        var app = webBuilder.Build();
+
+        app.MapGet("/realms/fig/.well-known/openid-configuration", async context =>
+        {
+            var openIdConfiguration = JsonConvert.SerializeObject(new
+            {
+                issuer = _keycloakAuthority,
+                jwks_uri = $"{_keycloakAuthority}/protocol/openid-connect/certs",
+                authorization_endpoint = $"{_keycloakAuthority}/protocol/openid-connect/auth",
+                token_endpoint = $"{_keycloakAuthority}/protocol/openid-connect/token"
+            });
+
+            context.Response.ContentType = "application/json";
+            await context.Response.WriteAsync(openIdConfiguration);
+        });
+
+        app.MapGet("/realms/fig/protocol/openid-connect/certs", async context =>
+        {
+            var jwk = JsonWebKeyConverter.ConvertFromRSASecurityKey(_keycloakSigningKey);
+            jwk.Alg = SecurityAlgorithms.RsaSha256;
+            jwk.Use = "sig";
+            var keySet = new
+            {
+                keys = new[]
+                {
+                    new
+                    {
+                        kty = jwk.Kty,
+                        use = jwk.Use,
+                        key_ops = jwk.KeyOps,
+                        alg = jwk.Alg,
+                        kid = jwk.Kid,
+                        n = jwk.N,
+                        e = jwk.E
+                    }
+                }
+            };
+
+            context.Response.ContentType = "application/json";
+            await context.Response.WriteAsync(JsonConvert.SerializeObject(keySet));
+        });
+
+        await app.StartAsync();
+
+        var addresses = app.Services.GetRequiredService<IServer>().Features.Get<IServerAddressesFeature>()?.Addresses;
+        var address = addresses?.FirstOrDefault(a => a.StartsWith("http://", StringComparison.OrdinalIgnoreCase))
+                      ?? throw new ApplicationException("Unable to resolve fake keycloak authority address for tests");
+
+        _keycloakAuthority = $"{address.TrimEnd('/')}/realms/fig";
+        _keycloakTestAuthority = app;
     }
 }

--- a/src/tests/Fig.Unit.Test/Api/AuthMiddlewareTests.cs
+++ b/src/tests/Fig.Unit.Test/Api/AuthMiddlewareTests.cs
@@ -1,5 +1,5 @@
 using System.Reflection;
-using Fig.Api.Authorization;
+using Fig.Api.Authorization.UserAuth;
 using Fig.Api.Controllers;
 using Fig.Api.Middleware;
 using Fig.Api.Services;
@@ -14,9 +14,8 @@ namespace Fig.Unit.Test.Api;
 [TestFixture]
 public class AuthMiddlewareTests
 {
-    private Mock<IUserService> _userService = null!;
     private Mock<IAuthenticatedService> _authenticatedService = null!;
-    private Mock<ITokenHandler> _tokenHandler = null!;
+    private Mock<IUserAuthenticationModeService> _userAuthenticationModeService = null!;
     private UserDataContract _user = null!;
     private AuthMiddleware _sut = null!;
     private bool _nextCalled;
@@ -35,12 +34,14 @@ public class AuthMiddlewareTests
             [],
             false);
 
-        _userService = new Mock<IUserService>();
-        _userService.Setup(x => x.GetById(_user.Id)).ReturnsAsync(_user);
-
         _authenticatedService = new Mock<IAuthenticatedService>();
-        _tokenHandler = new Mock<ITokenHandler>();
-        _tokenHandler.Setup(x => x.Validate("token")).Returns(new ValidatedTokenData(_user.Id, true));
+        _userAuthenticationModeService = new Mock<IUserAuthenticationModeService>();
+        _userAuthenticationModeService.Setup(x => x.ResolveAuthenticatedUser(It.IsAny<HttpContext>()))
+            .ReturnsAsync(() =>
+            {
+                _user.PasswordChangeRequired = true;
+                return _user;
+            });
 
         _sut = new AuthMiddleware(_ =>
         {
@@ -59,7 +60,7 @@ public class AuthMiddlewareTests
             nameof(UsersController.Update),
             _user.Id);
 
-        await _sut.Invoke(context, _userService.Object, [_authenticatedService.Object], _tokenHandler.Object);
+        await _sut.Invoke(context, [_authenticatedService.Object], _userAuthenticationModeService.Object);
 
         Assert.That(_nextCalled, Is.True);
         _authenticatedService.Verify(x => x.SetAuthenticatedUser(It.Is<UserDataContract>(user =>
@@ -77,7 +78,7 @@ public class AuthMiddlewareTests
             _user.Id);
 
         var exception = Assert.ThrowsAsync<UnauthorizedAccessException>(async () =>
-            await _sut.Invoke(context, _userService.Object, [_authenticatedService.Object], _tokenHandler.Object));
+            await _sut.Invoke(context, [_authenticatedService.Object], _userAuthenticationModeService.Object));
 
         Assert.That(exception!.Message, Does.Contain("Password change is required"));
         Assert.That(_nextCalled, Is.False);
@@ -95,7 +96,7 @@ public class AuthMiddlewareTests
             otherUserId);
 
         var exception = Assert.ThrowsAsync<UnauthorizedAccessException>(async () =>
-            await _sut.Invoke(context, _userService.Object, [_authenticatedService.Object], _tokenHandler.Object));
+            await _sut.Invoke(context, [_authenticatedService.Object], _userAuthenticationModeService.Object));
 
         Assert.That(exception!.Message, Does.Contain("Password change is required"));
         Assert.That(_nextCalled, Is.False);

--- a/src/tests/Fig.Unit.Test/Api/AuthenticationSettingsValidatorTests.cs
+++ b/src/tests/Fig.Unit.Test/Api/AuthenticationSettingsValidatorTests.cs
@@ -1,0 +1,89 @@
+using Fig.Api;
+using Fig.Api.Authorization.UserAuth;
+using Fig.Contracts.Authentication;
+using NUnit.Framework;
+
+namespace Fig.Unit.Test.Api;
+
+[TestFixture]
+public class AuthenticationSettingsValidatorTests
+{
+    [Test]
+    public void Validate_ShouldAllowDefaultFigManagedModeWithoutKeycloakSettings()
+    {
+        var settings = new ApiSettings
+        {
+            DbConnectionString = "Data Source=:memory:",
+            Secret = "secret",
+            Authentication = new AuthenticationSettings()
+        };
+
+        Assert.DoesNotThrow(() => AuthenticationSettingsValidator.Validate(settings));
+    }
+
+    [Test]
+    public void Validate_ShouldRequireAudienceInKeycloakMode()
+    {
+        var settings = CreateKeycloakSettings();
+        settings.Authentication.Keycloak.Audience = "";
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            AuthenticationSettingsValidator.Validate(settings));
+
+        Assert.That(exception!.Message, Does.Contain("Audience"));
+    }
+
+    [Test]
+    public void Validate_ShouldRequireRoleMappingsInKeycloakMode()
+    {
+        var settings = CreateKeycloakSettings();
+        settings.Authentication.Keycloak.RoleMappings.Remove(Role.User.ToString());
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            AuthenticationSettingsValidator.Validate(settings));
+
+        Assert.That(exception!.Message, Does.Contain("RoleMappings:User"));
+    }
+
+    [Test]
+    public void Validate_ShouldRequireNonNullRoleMappingValuesInKeycloakMode()
+    {
+        var settings = CreateKeycloakSettings();
+        settings.Authentication.Keycloak.RoleMappings[Role.User.ToString()] = null!;
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            AuthenticationSettingsValidator.Validate(settings));
+
+        Assert.That(exception!.Message, Does.Contain("RoleMappings:User"));
+    }
+
+    [Test]
+    public void Validate_ShouldAllowCompleteKeycloakSettings()
+    {
+        var settings = CreateKeycloakSettings();
+
+        Assert.DoesNotThrow(() => AuthenticationSettingsValidator.Validate(settings));
+    }
+
+    private static ApiSettings CreateKeycloakSettings()
+    {
+        return new ApiSettings
+        {
+            DbConnectionString = "Data Source=:memory:",
+            Secret = "secret",
+            Authentication = new AuthenticationSettings
+            {
+                Mode = AuthMode.Keycloak,
+                Keycloak = new KeycloakAuthenticationSettings
+                {
+                    Authority = "https://keycloak.example.com/realms/fig",
+                    Audience = "fig-api",
+                    RoleClaimPaths = ["groups"],
+                    AllowedClassificationsClaim = "fig_allowed_classifications",
+                    ClientFilterClaim = "fig_client_filter",
+                    AdminRoleName = Role.Administrator.ToString()
+                }
+            }
+        };
+    }
+}

--- a/src/tests/Fig.Unit.Test/Api/KeycloakRoleResolutionTests.cs
+++ b/src/tests/Fig.Unit.Test/Api/KeycloakRoleResolutionTests.cs
@@ -1,0 +1,112 @@
+using System.IdentityModel.Tokens.Jwt;
+using Fig.Api;
+using Fig.Api.Authorization.UserAuth;
+using Fig.Contracts.Authentication;
+using NUnit.Framework;
+
+namespace Fig.Unit.Test.Api;
+
+[TestFixture]
+public class KeycloakRoleResolutionTests
+{
+    [Test]
+    public void ResolveRole_ShouldGrantRoleFromConfiguredResourceAccessPath()
+    {
+        var settings = CreateSettings(roleClaimPaths: ["resource_access.fig.roles"]);
+        var token = CreateToken(payload =>
+        {
+            payload["resource_access"] = new Dictionary<string, object>
+            {
+                ["fig"] = new Dictionary<string, object>
+                {
+                    ["roles"] = new[] { Role.User.ToString() }
+                }
+            };
+        });
+
+        var role = KeycloakUserAuthenticationModeService.ResolveRole(token, settings);
+
+        Assert.That(role, Is.EqualTo(Role.User));
+    }
+
+    [Test]
+    public void ResolveRole_ShouldGrantRoleFromConfiguredGroupsPath()
+    {
+        var settings = CreateSettings(roleClaimPaths: ["groups"]);
+        var token = CreateToken(payload =>
+        {
+            payload["groups"] = new[] { $"/fig/{Role.Administrator}" };
+        });
+
+        var role = KeycloakUserAuthenticationModeService.ResolveRole(token, settings);
+
+        Assert.That(role, Is.EqualTo(Role.Administrator));
+    }
+
+    [Test]
+    public void ResolveRole_ShouldIgnoreAdministratorOnUnconfiguredResourceAccessClient()
+    {
+        var settings = CreateSettings(roleClaimPaths: ["resource_access.fig.roles"]);
+        var token = CreateToken(payload =>
+        {
+            payload["resource_access"] = new Dictionary<string, object>
+            {
+                ["other-client"] = new Dictionary<string, object>
+                {
+                    ["roles"] = new[] { Role.Administrator.ToString() }
+                },
+                ["fig"] = new Dictionary<string, object>
+                {
+                    ["roles"] = new[] { Role.User.ToString() }
+                }
+            };
+        });
+
+        var role = KeycloakUserAuthenticationModeService.ResolveRole(token, settings);
+
+        Assert.That(role, Is.EqualTo(Role.User));
+    }
+
+    [Test]
+    public void ResolveRole_ShouldReturnNullWhenOnlyUnconfiguredResourceAccessClientHasRole()
+    {
+        var settings = CreateSettings(roleClaimPaths: ["resource_access.fig.roles"]);
+        var token = CreateToken(payload =>
+        {
+            payload["resource_access"] = new Dictionary<string, object>
+            {
+                ["other-client"] = new Dictionary<string, object>
+                {
+                    ["roles"] = new[] { Role.Administrator.ToString() }
+                }
+            };
+            payload["groups"] = new[] { $"/fig/{Role.Administrator}" };
+            payload["realm_access"] = new Dictionary<string, object>
+            {
+                ["roles"] = new[] { Role.Administrator.ToString() }
+            };
+        });
+
+        var role = KeycloakUserAuthenticationModeService.ResolveRole(token, settings);
+
+        Assert.That(role, Is.Null);
+    }
+
+    private static KeycloakAuthenticationSettings CreateSettings(List<string> roleClaimPaths)
+    {
+        return new KeycloakAuthenticationSettings
+        {
+            RoleClaimPaths = roleClaimPaths,
+            // Clear legacy paths so tests assert RoleClaimPaths alone as the boundary.
+            RoleClaimPath = string.Empty,
+            AdditionalRoleClaimPath = null
+        };
+    }
+
+    private static JwtSecurityToken CreateToken(Action<JwtPayload> configurePayload)
+    {
+        var payload = new JwtPayload();
+        configurePayload(payload);
+        return new JwtSecurityToken(new JwtHeader(), payload);
+    }
+}

--- a/src/tests/Fig.Unit.Test/Api/Reports/ClientAndUserReportExecuteTests.cs
+++ b/src/tests/Fig.Unit.Test/Api/Reports/ClientAndUserReportExecuteTests.cs
@@ -1,3 +1,4 @@
+using Fig.Api;
 using Fig.Api.Datalayer.Repositories;
 using Fig.Api.Reports;
 using Fig.Api.Reports.Implementations;
@@ -7,6 +8,7 @@ using Fig.Common.Constants;
 using Fig.Contracts.Authentication;
 using Fig.Datalayer.BusinessEntities;
 using Fig.Datalayer.BusinessEntities.SettingValues;
+using Microsoft.Extensions.Options;
 using Moq;
 using NUnit.Framework;
 
@@ -109,7 +111,10 @@ public class ClientAndUserReportExecuteTests
                 null))
             .ReturnsAsync(loginEvents);
 
-        var report = new AccessPrivilegeReport(userRepo.Object, eventLog.Object);
+        var report = new AccessPrivilegeReport(
+            userRepo.Object,
+            eventLog.Object,
+            Options.Create(new ApiSettings { DbConnectionString = "test" }));
         ReportTestFixtures.Authenticate(report);
 
         var model = (AccessPrivilegeReportModel)await report.ExecuteAsync(new AccessPrivilegeParameters
@@ -156,7 +161,10 @@ public class ClientAndUserReportExecuteTests
                 null))
             .ReturnsAsync(new List<EventLogBusinessEntity>());
 
-        var report = new AccessPrivilegeReport(userRepo.Object, eventLog.Object);
+        var report = new AccessPrivilegeReport(
+            userRepo.Object,
+            eventLog.Object,
+            Options.Create(new ApiSettings { DbConnectionString = "test" }));
         ReportTestFixtures.Authenticate(report);
 
         var model = (AccessPrivilegeReportModel)await report.ExecuteAsync(new AccessPrivilegeParameters

--- a/src/tests/Fig.Unit.Test/Api/Reports/OperationsReportExecuteTests.cs
+++ b/src/tests/Fig.Unit.Test/Api/Reports/OperationsReportExecuteTests.cs
@@ -1,3 +1,4 @@
+using Fig.Api;
 using Fig.Api.Datalayer.Repositories;
 using Fig.Api.Reports.Implementations;
 using Fig.Api.Reports.Rendering.Components;
@@ -10,6 +11,7 @@ using Fig.Contracts.SettingGroups;
 using Fig.Contracts.Settings;
 using Fig.Contracts.WebHook;
 using Fig.Datalayer.BusinessEntities;
+using Microsoft.Extensions.Options;
 using Moq;
 using Newtonsoft.Json;
 using NUnit.Framework;
@@ -568,7 +570,8 @@ public class OperationsReportExecuteTests
             clientRepo.Object,
             userRepo.Object,
             webhookRepo.Object,
-            groupRepo.Object);
+            groupRepo.Object,
+            Options.Create(new ApiSettings { DbConnectionString = "test" }));
         ReportTestFixtures.Authenticate(report);
 
         var model = (FigPlatformReportModel)await report.ExecuteAsync(new FigPlatformParameters());

--- a/src/tests/Fig.Unit.Test/Web/AccountServiceTests.cs
+++ b/src/tests/Fig.Unit.Test/Web/AccountServiceTests.cs
@@ -6,6 +6,7 @@ using Fig.Web.Events;
 using Fig.Web.Models.Authentication;
 using Fig.Web.Notifications;
 using Fig.Web.Services;
+using Fig.Web.Services.Authentication;
 using Microsoft.AspNetCore.Components;
 using Moq;
 using NUnit.Framework;
@@ -23,7 +24,7 @@ public class AccountServiceTests
     private Mock<INotificationHistoryService> _notificationHistoryService = null!;
     private TestNavigationManager _navigationManager = null!;
     private NotificationService _notificationService = null!;
-    private AccountService _sut = null!;
+    private FigManagedWebAuthenticationModeService _sut = null!;
 
     [SetUp]
     public void SetUp()
@@ -36,7 +37,7 @@ public class AccountServiceTests
         _navigationManager = new TestNavigationManager();
         _notificationService = new NotificationService();
 
-        _sut = new AccountService(
+        _sut = new FigManagedWebAuthenticationModeService(
             _httpService.Object,
             _navigationManager,
             _localStorageService.Object,
@@ -115,7 +116,7 @@ public class AccountServiceTests
             []);
         var convertedUser = CreateAuthenticatedUser(response.Id, response.Token, false);
 
-        _httpService.Setup(a => a.Post<AuthenticateResponseDataContract>("/users/authenticate", It.IsAny<object>()))
+        _httpService.Setup(a => a.Post<AuthenticateResponseDataContract>("/users/authenticate", It.IsAny<AuthenticateRequestDataContract>()))
             .ReturnsAsync(response);
         _userConverter.Setup(a => a.Convert(response)).Returns(convertedUser);
         _notificationService.Notify(NotificationSeverity.Success, "Old", "Toast", 1000);

--- a/src/tests/Fig.Unit.Test/Web/HttpServiceTests.cs
+++ b/src/tests/Fig.Unit.Test/Web/HttpServiceTests.cs
@@ -5,12 +5,11 @@ using Fig.Common.NetStandard.Json;
 using Fig.Contracts.Json;
 using Fig.Contracts.SettingDefinitions;
 using Fig.Contracts.Settings;
-using Fig.Web;
 using Fig.Web.Models.Authentication;
 using Fig.Web.Notifications;
 using Fig.Web.Services;
+using Fig.Web.Services.Authentication;
 using Microsoft.AspNetCore.Components;
-using Microsoft.Extensions.Options;
 using Moq;
 using Newtonsoft.Json;
 using NUnit.Framework;
@@ -56,11 +55,14 @@ public class HttpServiceTests
         _sut = new HttpService(
             _httpClientFactory.Object,
             _navigationManager,
-            _localStorageService.Object,
+            CreateAccessTokenProvider(),
             _notificationService,
-            _notificationFactory.Object,
-            Options.Create(new WebSettings()),
-            Mock.Of<IServiceProvider>());
+            _notificationFactory.Object);
+    }
+
+    private IFigApiAccessTokenProvider CreateAccessTokenProvider()
+    {
+        return new TestFigApiAccessTokenProvider(_localStorageService.Object);
     }
 
     [Test]
@@ -297,5 +299,22 @@ public class HttpServiceTests
     private sealed class SimpleNamedDto
     {
         public string Name { get; set; } = string.Empty;
+    }
+
+    private sealed class TestFigApiAccessTokenProvider : IFigApiAccessTokenProvider
+    {
+        private readonly ILocalStorageService _localStorageService;
+
+        public TestFigApiAccessTokenProvider(ILocalStorageService localStorageService)
+        {
+            _localStorageService = localStorageService;
+        }
+
+        public async Task<string?> GetAccessTokenAsync()
+        {
+            var user = await _localStorageService.GetItem<AuthenticatedUserModel>(
+                WebAuthenticationConstants.AuthenticatedUserStorageKey);
+            return string.IsNullOrWhiteSpace(user?.Token) ? null : user.Token;
+        }
     }
 }

--- a/src/tests/Fig.Unit.Test/Web/HttpServiceTests.cs
+++ b/src/tests/Fig.Unit.Test/Web/HttpServiceTests.cs
@@ -5,10 +5,12 @@ using Fig.Common.NetStandard.Json;
 using Fig.Contracts.Json;
 using Fig.Contracts.SettingDefinitions;
 using Fig.Contracts.Settings;
+using Fig.Web;
 using Fig.Web.Models.Authentication;
 using Fig.Web.Notifications;
 using Fig.Web.Services;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Options;
 using Moq;
 using Newtonsoft.Json;
 using NUnit.Framework;
@@ -56,7 +58,9 @@ public class HttpServiceTests
             _navigationManager,
             _localStorageService.Object,
             _notificationService,
-            _notificationFactory.Object);
+            _notificationFactory.Object,
+            Options.Create(new WebSettings()),
+            Mock.Of<IServiceProvider>());
     }
 
     [Test]

--- a/src/tests/Fig.Unit.Test/Web/KeycloakWebRoleResolutionTests.cs
+++ b/src/tests/Fig.Unit.Test/Web/KeycloakWebRoleResolutionTests.cs
@@ -1,0 +1,77 @@
+using System.Security.Claims;
+using Fig.Contracts.Authentication;
+using Fig.Web;
+using Fig.Web.Services.Authentication;
+using NUnit.Framework;
+
+namespace Fig.Unit.Test.Web;
+
+[TestFixture]
+public class KeycloakWebRoleResolutionTests
+{
+    [Test]
+    public void ResolveRole_ShouldGrantRoleFromConfiguredResourceAccessPath()
+    {
+        var settings = CreateSettings(roleClaimPaths: ["resource_access.fig.roles"]);
+        var principal = CreatePrincipal(
+            ("resource_access", """{"fig":{"roles":["User"]}}"""));
+
+        var role = KeycloakWebAuthenticationModeService.ResolveRole(principal, settings);
+
+        Assert.That(role, Is.EqualTo(Role.User));
+    }
+
+    [Test]
+    public void ResolveRole_ShouldGrantRoleFromConfiguredGroupsPath()
+    {
+        var settings = CreateSettings(roleClaimPaths: ["groups"]);
+        var principal = CreatePrincipal(
+            ("groups", """["/fig/Administrator"]"""));
+
+        var role = KeycloakWebAuthenticationModeService.ResolveRole(principal, settings);
+
+        Assert.That(role, Is.EqualTo(Role.Administrator));
+    }
+
+    [Test]
+    public void ResolveRole_ShouldIgnoreAdministratorOnUnconfiguredResourceAccessClient()
+    {
+        var settings = CreateSettings(roleClaimPaths: ["resource_access.fig.roles"]);
+        var principal = CreatePrincipal(
+            ("resource_access", """{"other-client":{"roles":["Administrator"]},"fig":{"roles":["User"]}}"""));
+
+        var role = KeycloakWebAuthenticationModeService.ResolveRole(principal, settings);
+
+        Assert.That(role, Is.EqualTo(Role.User));
+    }
+
+    [Test]
+    public void ResolveRole_ShouldReturnNullWhenOnlyUnconfiguredResourceAccessClientHasRole()
+    {
+        var settings = CreateSettings(roleClaimPaths: ["resource_access.fig.roles"]);
+        var principal = CreatePrincipal(
+            ("resource_access", """{"other-client":{"roles":["Administrator"]}}"""),
+            ("groups", """["/fig/Administrator"]"""),
+            ("realm_access", """{"roles":["Administrator"]}"""));
+
+        var role = KeycloakWebAuthenticationModeService.ResolveRole(principal, settings);
+
+        Assert.That(role, Is.Null);
+    }
+
+    private static WebKeycloakAuthenticationSettings CreateSettings(List<string> roleClaimPaths)
+    {
+        return new WebKeycloakAuthenticationSettings
+        {
+            RoleClaimPaths = roleClaimPaths
+        };
+    }
+
+    private static ClaimsPrincipal CreatePrincipal(params (string Type, string Value)[] claims)
+    {
+        var identity = new ClaimsIdentity(
+            claims.Select(claim => new Claim(claim.Type, claim.Value)),
+            authenticationType: "Test");
+        return new ClaimsPrincipal(identity);
+    }
+}

--- a/src/tests/Fig.Unit.Test/Web/OidcProviderOptionsConfiguratorTests.cs
+++ b/src/tests/Fig.Unit.Test/Web/OidcProviderOptionsConfiguratorTests.cs
@@ -1,0 +1,81 @@
+using Fig.Web;
+using Fig.Web.Services.Authentication;
+using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
+using NUnit.Framework;
+
+namespace Fig.Unit.Test.Web;
+
+[TestFixture]
+public class OidcProviderOptionsConfiguratorTests
+{
+    [Test]
+    public void Apply_ShouldNotAddHintOrPrompt_WhenDefaults()
+    {
+        var options = new OidcProviderOptions();
+        var settings = new WebKeycloakAuthenticationSettings();
+
+        OidcProviderOptionsConfigurator.Apply(options, settings);
+
+        Assert.That(options.AdditionalProviderParameters.ContainsKey("kc_idp_hint"), Is.False);
+        Assert.That(options.AdditionalProviderParameters.ContainsKey("prompt"), Is.False);
+    }
+
+    [Test]
+    public void Apply_ShouldAddKcIdpHint_WhenEnabledAndHintConfigured()
+    {
+        var options = new OidcProviderOptions();
+        var settings = new WebKeycloakAuthenticationSettings
+        {
+            EnableIdentityProviderHint = true,
+            IdentityProviderHint = " entra-id "
+        };
+
+        OidcProviderOptionsConfigurator.Apply(options, settings);
+
+        Assert.That(options.AdditionalProviderParameters["kc_idp_hint"], Is.EqualTo("entra-id"));
+    }
+
+    [Test]
+    public void Apply_ShouldNotAddKcIdpHint_WhenDisabled()
+    {
+        var options = new OidcProviderOptions();
+        var settings = new WebKeycloakAuthenticationSettings
+        {
+            EnableIdentityProviderHint = false,
+            IdentityProviderHint = "entra-id"
+        };
+
+        OidcProviderOptionsConfigurator.Apply(options, settings);
+
+        Assert.That(options.AdditionalProviderParameters.ContainsKey("kc_idp_hint"), Is.False);
+    }
+
+    [Test]
+    public void Apply_ShouldNotAddKcIdpHint_WhenHintWhitespace()
+    {
+        var options = new OidcProviderOptions();
+        var settings = new WebKeycloakAuthenticationSettings
+        {
+            EnableIdentityProviderHint = true,
+            IdentityProviderHint = "   "
+        };
+
+        OidcProviderOptionsConfigurator.Apply(options, settings);
+
+        Assert.That(options.AdditionalProviderParameters.ContainsKey("kc_idp_hint"), Is.False);
+    }
+
+    [Test]
+    public void Apply_ShouldAddPrompt_WhenLoginPromptConfigured()
+    {
+        var options = new OidcProviderOptions();
+        var settings = new WebKeycloakAuthenticationSettings
+        {
+            LoginPrompt = " login "
+        };
+
+        OidcProviderOptionsConfigurator.Apply(options, settings);
+
+        Assert.That(options.AdditionalProviderParameters["prompt"], Is.EqualTo("login"));
+    }
+}

--- a/src/tests/Fig.Unit.Test/Web/WebAuthenticationSettingsValidatorTests.cs
+++ b/src/tests/Fig.Unit.Test/Web/WebAuthenticationSettingsValidatorTests.cs
@@ -1,0 +1,81 @@
+using Fig.Contracts.Authentication;
+using Fig.Web;
+using Fig.Web.Services.Authentication;
+using NUnit.Framework;
+
+namespace Fig.Unit.Test.Web;
+
+[TestFixture]
+public class WebAuthenticationSettingsValidatorTests
+{
+    [Test]
+    public void Validate_ShouldAllowDefaultFigManagedModeWithoutKeycloakSettings()
+    {
+        var settings = new WebSettings();
+
+        Assert.DoesNotThrow(() => WebAuthenticationSettingsValidator.Validate(settings));
+    }
+
+    [Test]
+    public void Validate_ShouldRequireClientIdInKeycloakMode()
+    {
+        var settings = CreateKeycloakSettings();
+        settings.Authentication.Keycloak.ClientId = "";
+
+        var exception = Assert.Throws<ApplicationException>(() =>
+            WebAuthenticationSettingsValidator.Validate(settings));
+
+        Assert.That(exception!.Message, Does.Contain("ClientId"));
+    }
+
+    [Test]
+    public void Validate_ShouldRequireRoleMappingsInKeycloakMode()
+    {
+        var settings = CreateKeycloakSettings();
+        settings.Authentication.Keycloak.RoleMappings.Remove(Role.User.ToString());
+
+        var exception = Assert.Throws<ApplicationException>(() =>
+            WebAuthenticationSettingsValidator.Validate(settings));
+
+        Assert.That(exception!.Message, Does.Contain("RoleMappings:User"));
+    }
+
+    [Test]
+    public void Validate_ShouldRequireNonNullRoleMappingValuesInKeycloakMode()
+    {
+        var settings = CreateKeycloakSettings();
+        settings.Authentication.Keycloak.RoleMappings[Role.User.ToString()] = null!;
+
+        var exception = Assert.Throws<ApplicationException>(() =>
+            WebAuthenticationSettingsValidator.Validate(settings));
+
+        Assert.That(exception!.Message, Does.Contain("RoleMappings:User"));
+    }
+
+    [Test]
+    public void Validate_ShouldAllowCompleteKeycloakSettings()
+    {
+        var settings = CreateKeycloakSettings();
+
+        Assert.DoesNotThrow(() => WebAuthenticationSettingsValidator.Validate(settings));
+    }
+
+    private static WebSettings CreateKeycloakSettings()
+    {
+        return new WebSettings
+        {
+            Authentication = new WebAuthenticationSettings
+            {
+                Mode = WebAuthMode.Keycloak,
+                Keycloak = new WebKeycloakAuthenticationSettings
+                {
+                    Authority = "https://keycloak.example.com/realms/fig",
+                    ClientId = "fig-web",
+                    RoleClaimPaths = ["groups"],
+                    AllowedClassificationsClaim = "fig_allowed_classifications",
+                    AdminRoleName = Role.Administrator.ToString()
+                }
+            }
+        };
+    }
+}

--- a/src/tests/Fig.Unit.Test/Web/WebAuthenticationSettingsValidatorTests.cs
+++ b/src/tests/Fig.Unit.Test/Web/WebAuthenticationSettingsValidatorTests.cs
@@ -60,6 +60,28 @@ public class WebAuthenticationSettingsValidatorTests
         Assert.DoesNotThrow(() => WebAuthenticationSettingsValidator.Validate(settings));
     }
 
+    [Test]
+    public void Validate_ShouldAllowIdentityProviderHintSettingsWithoutThrowing()
+    {
+        var settings = CreateKeycloakSettings();
+        settings.Authentication.Keycloak.IdentityProviderHint = "entra-id";
+        settings.Authentication.Keycloak.EnableIdentityProviderHint = true;
+        settings.Authentication.Keycloak.LoginPrompt = "login";
+        settings.Authentication.Keycloak.PostLogoutLoginPrompt = "select_account";
+
+        Assert.DoesNotThrow(() => WebAuthenticationSettingsValidator.Validate(settings));
+    }
+
+    [Test]
+    public void Validate_ShouldAllowWhitespaceIdentityProviderHintWithoutThrowing()
+    {
+        var settings = CreateKeycloakSettings();
+        settings.Authentication.Keycloak.EnableIdentityProviderHint = true;
+        settings.Authentication.Keycloak.IdentityProviderHint = "  ";
+
+        Assert.DoesNotThrow(() => WebAuthenticationSettingsValidator.Validate(settings));
+    }
+
     private static WebSettings CreateKeycloakSettings()
     {
         return new WebSettings

--- a/src/web/Fig.Web/App.razor
+++ b/src/web/Fig.Web/App.razor
@@ -1,14 +1,17 @@
 ﻿@using Fig.Web.Shared
+@using Microsoft.AspNetCore.Components.Authorization
 @inject NavigationManager NavigationManager
 
-<Router AppAssembly="@typeof(App).Assembly">
-    <Found Context="routeData">
-        <Fig.Web.Routing.AppRouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
-    </Found>
-    <NotFound>
-        @{
-            // redirect to home page if not found
-            NavigationManager.NavigateTo("");
-        }
-    </NotFound>
-</Router>
+<CascadingAuthenticationState>
+    <Router AppAssembly="@typeof(App).Assembly">
+        <Found Context="routeData">
+            <Fig.Web.Routing.AppRouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
+        </Found>
+        <NotFound>
+            @{
+                // redirect to home page if not found
+                NavigationManager.NavigateTo("");
+            }
+        </NotFound>
+    </Router>
+</CascadingAuthenticationState>

--- a/src/web/Fig.Web/Fig.Web.csproj
+++ b/src/web/Fig.Web/Fig.Web.csproj
@@ -38,6 +38,10 @@
     </ItemGroup>
 
     <ItemGroup>
+        <InternalsVisibleTo Include="Fig.Unit.Test" />
+    </ItemGroup>
+
+    <ItemGroup>
       <Content Update="wwwroot\appsettings.json">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </Content>

--- a/src/web/Fig.Web/Fig.Web.csproj
+++ b/src/web/Fig.Web/Fig.Web.csproj
@@ -15,6 +15,7 @@
         <PackageReference Include="Jint" Version="4.14.0" />
         <PackageReference Include="Markdig" Version="1.3.2" />
         <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.10" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="10.0.10" />
         <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.10" PrivateAssets="all" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
         <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.10" />

--- a/src/web/Fig.Web/Pages/Authentication.razor
+++ b/src/web/Fig.Web/Pages/Authentication.razor
@@ -1,0 +1,9 @@
+@page "/authentication/{action}"
+@using Microsoft.AspNetCore.Components.WebAssembly.Authentication
+
+<RemoteAuthenticatorView Action="@Action" />
+
+@code {
+    [Parameter]
+    public string? Action { get; set; }
+}

--- a/src/web/Fig.Web/Pages/Login.razor
+++ b/src/web/Fig.Web/Pages/Login.razor
@@ -7,32 +7,41 @@
     <img class="logo" src="images/fig_logo_only_500x500.png" alt="Logo" />
     <h3 class="white-text">Login to Fig</h3>
     <p>@Settings.Value.Environment</p>
-    @if (!string.IsNullOrEmpty(_errorMessage))
+    @if (IsKeycloakMode)
     {
-        <div class="login-error-banner">
-            <span class="error-icon">⚠</span>
-            <span>@_errorMessage</span>
-        </div>
+        <RadzenCard class="login-card" Style="min-width: 300px">
+            <p class="white-text">Redirecting to Keycloak...</p>
+        </RadzenCard>
     }
-    <RadzenCard class="login-card" Style="min-width: 300px">
-        <RadzenTemplateForm TItem="LoginModel" Data=@_loginModel>
-            <div class="form-group">
-                <label for="username" class="white-text">Username</label>
-                <RadzenTextBox AutoComplete="true" Name="Username" @bind-Value=@_loginModel.Username Style="width: 100%"/>
-                <RadzenRequiredValidator Component="Username" Text="Username is required" class="validator" />
+    else
+    {
+        @if (!string.IsNullOrEmpty(_errorMessage))
+        {
+            <div class="login-error-banner">
+                <span class="error-icon">⚠</span>
+                <span>@_errorMessage</span>
             </div>
-            <div class="form-group">
-                <label for="password" class="white-text">Password</label>
-                <RadzenPassword AutoComplete="true" Name="Password" @bind-Value=@_loginModel.Password Style="width: 100%" />
-                <RadzenRequiredValidator Component="Password" Text="Password is required" class="validator" />
-            </div>
-            <div class="form-group">
-                <RadzenButton ButtonStyle="ButtonStyle.Primary" ButtonType="ButtonType.Submit" data-test-id="LoginButton"
-                              Text="Login" Click=@(OnLogin) IsBusy="_loading" BusyText="Logging in..." class="login-button"
-                              Style="width: 100%"/>
-            </div>
-        </RadzenTemplateForm>
-    </RadzenCard>
+        }
+        <RadzenCard class="login-card" Style="min-width: 300px">
+            <RadzenTemplateForm TItem="LoginModel" Data=@_loginModel>
+                <div class="form-group">
+                    <label for="username" class="white-text">Username</label>
+                    <RadzenTextBox AutoComplete="true" Name="Username" @bind-Value=@_loginModel.Username Style="width: 100%"/>
+                    <RadzenRequiredValidator Component="Username" Text="Username is required" class="validator" />
+                </div>
+                <div class="form-group">
+                    <label for="password" class="white-text">Password</label>
+                    <RadzenPassword AutoComplete="true" Name="Password" @bind-Value=@_loginModel.Password Style="width: 100%" />
+                    <RadzenRequiredValidator Component="Password" Text="Password is required" class="validator" />
+                </div>
+                <div class="form-group">
+                    <RadzenButton ButtonStyle="ButtonStyle.Primary" ButtonType="ButtonType.Submit" data-test-id="LoginButton"
+                                  Text="Login" Click=@(OnLogin) IsBusy="_loading" BusyText="Logging in..." class="login-button"
+                                  Style="width: 100%"/>
+                </div>
+            </RadzenTemplateForm>
+        </RadzenCard>
+    }
 </div>
 
 <div class="footer">

--- a/src/web/Fig.Web/Pages/Login.razor.cs
+++ b/src/web/Fig.Web/Pages/Login.razor.cs
@@ -13,6 +13,8 @@ public partial class Login
     private string _webVersion = "Unknown";
     private string? _errorMessage;
 
+    private bool IsKeycloakMode => AccountService.AuthenticationMode == WebAuthMode.Keycloak;
+
     [Inject] 
     private IAccountService AccountService { get; set; } = null!;
 
@@ -25,6 +27,12 @@ public partial class Login
     protected override async Task OnInitializedAsync()
     {
         _webVersion = $"v{VersionHelper.GetVersion()}";
+
+        if (IsKeycloakMode)
+        {
+            await AccountService.Login(new LoginModel());
+            return;
+        }
         
         // If user is already authenticated and account service is initialized, redirect to the return URL or home
         if (AccountService.IsInitialized && AccountService.AuthenticatedUser != null)
@@ -39,6 +47,12 @@ public partial class Login
     
     private async Task OnLogin()
     {
+        if (IsKeycloakMode)
+        {
+            await AccountService.Login(_loginModel);
+            return;
+        }
+
         if (!_loginModel.IsValid())
             return;
         

--- a/src/web/Fig.Web/Pages/ManageAccount.razor
+++ b/src/web/Fig.Web/Pages/ManageAccount.razor
@@ -1,4 +1,4 @@
-@page "/account/Manage"
+@page "/account/manage"
 @using Fig.Web.Models.Authentication
 @using Fig.Web.Attributes
 @attribute [Manage]
@@ -39,7 +39,7 @@
                                 <RadzenLabel Text="First Name" />
                             </div>
                             <div class="col-md-8">
-                                <RadzenTextBox @bind-Value="authenticatedUser.FirstName" style="width: 100%;" Name="FirstName" />
+                                <RadzenTextBox @bind-Value="authenticatedUser.FirstName" style="width: 100%;" Name="FirstName" ReadOnly="@IsKeycloakMode" />
                             </div>
                         </div>
                         <div class="row">
@@ -47,7 +47,7 @@
                                 <RadzenLabel Text="Last Name" />
                             </div>
                             <div class="col-md-8">
-                                <RadzenTextBox @bind-Value="authenticatedUser.LastName" style="width: 100%;" Name="LastName" />
+                                <RadzenTextBox @bind-Value="authenticatedUser.LastName" style="width: 100%;" Name="LastName" ReadOnly="@IsKeycloakMode" />
                             </div>
                         </div>
                         <div class="row">
@@ -65,17 +65,29 @@
                                 }
                             </div>
                         </div>
-                        <div class="row">
-                            <div class="col-md-6 align-items-end d-flex">
-                                <RadzenButton Text="Update Password" Click="ShowPasswordRow"></RadzenButton>
+                        @if (!IsKeycloakMode)
+                        {
+                            <div class="row">
+                                <div class="col-md-6 align-items-end d-flex">
+                                    <RadzenButton Text="Update Password" Click="ShowPasswordRow"></RadzenButton>
+                                </div>
                             </div>
-                        </div>
+                        }
+                        else if (!string.IsNullOrWhiteSpace(AccountManagementUrl))
+                        {
+                            <div class="row">
+                                <div class="col-md-12">
+                                    <p>Account details are managed in Keycloak.</p>
+                                    <RadzenButton Text="Manage Account in Keycloak" Click="OpenKeycloakAccountManagement" ButtonType="ButtonType.Button" Icon="open_in_new" />
+                                </div>
+                            </div>
+                        }
                     </div>
 
                     <div class="row @(authenticatedUser.PasswordChangeRequired ? "" : "collapse")">
                         <p style="color: orange">PASSWORD CHANGE REQUIRED</p>
                     </div>
-                    <div class="row @(_showPasswordRow ? "" : "collapse")">
+                    <div class="row @(_showPasswordRow && !IsKeycloakMode ? "" : "collapse")">
                         <div class="col-md-4 align-items-center d-flex">
                             <RadzenLabel Text="New Password" />
                         </div>
@@ -97,10 +109,12 @@
                             }
                         </div>
                     </div>
-                    <div class="col-md-12 d-flex align-items-end justify-content-end" style="margin-top: 16px;">
-                        <RadzenButton ButtonType="ButtonType.Submit" Icon="save" Text="Save" />
-                    </div>
-
+                    @if (!IsKeycloakMode)
+                    {
+                        <div class="col-md-12 d-flex align-items-end justify-content-end" style="margin-top: 16px;">
+                            <RadzenButton ButtonType="ButtonType.Submit" Icon="save" Text="Save" />
+                        </div>
+                    }
                 </RadzenFieldset>
             </div>
         </div>

--- a/src/web/Fig.Web/Pages/ManageAccount.razor.cs
+++ b/src/web/Fig.Web/Pages/ManageAccount.razor.cs
@@ -4,6 +4,7 @@ using Fig.Web.Models.Authentication;
 using Fig.Web.Notifications;
 using Fig.Web.Services;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Options;
 using Radzen;
 
 namespace Fig.Web.Pages;
@@ -18,10 +19,20 @@ public partial class ManageAccount
 
     [Inject]
     private INotificationFactory NotificationFactory { get; set; } = null!;
+
+    [Inject]
+    private IOptions<WebSettings> WebSettings { get; set; } = null!;
+
+    [Inject]
+    private NavigationManager NavigationManager { get; set; } = null!;
     
     private bool _showPasswordRow;
     private string _password = string.Empty;
     private bool _passwordValid;
+
+    private bool IsKeycloakMode => AccountService.AuthenticationMode == WebAuthMode.Keycloak;
+
+    private string? AccountManagementUrl => WebSettings.Value.Authentication.Keycloak.AccountManagementUrl;
     
     private List<Classification> AllClassifications { get; } = Enum.GetValues(typeof(Classification))
         .Cast<Classification>()
@@ -41,6 +52,13 @@ public partial class ManageAccount
 
     private async Task Submit(AuthenticatedUserModel user)
     {
+        if (IsKeycloakMode)
+        {
+            NotificationService.Notify(NotificationFactory.Info("Managed by Keycloak",
+                "Profile updates are managed by Keycloak in this mode."));
+            return;
+        }
+
         if (AccountService.AuthenticatedUser?.PasswordChangeRequired == true && !_passwordValid)
         {
             NotificationService.Notify(NotificationFactory.Failure(
@@ -78,7 +96,7 @@ public partial class ManageAccount
                 NotificationService.Notify(NotificationFactory.Failure("User Update Failed", ex.Message));
             }
         }
-            
+
     }
 
     private void OnValidPassword(string password)
@@ -104,5 +122,16 @@ public partial class ManageAccount
         _passwordValid = false;
         _password = password;
         StateHasChanged();
+    }
+
+    private void OpenKeycloakAccountManagement()
+    {
+        if (string.IsNullOrWhiteSpace(AccountManagementUrl))
+            return;
+
+        var targetUrl = AccountManagementUrl.EndsWith('/')
+            ? AccountManagementUrl
+            : $"{AccountManagementUrl}/";
+        NavigationManager.NavigateTo(targetUrl, forceLoad: true);
     }
 }

--- a/src/web/Fig.Web/Pages/Reports.razor
+++ b/src/web/Fig.Web/Pages/Reports.razor
@@ -58,14 +58,24 @@
 
                                 @if (parameter.LookupKind == ReportParameterLookupKind.Users)
                                 {
-                                    <RadzenDropDown TValue="string"
-                                                    Data="@_usernames"
-                                                    Value="@GetString(parameter.Name)"
-                                                    ValueChanged="@(v => SetString(parameter.Name, v))"
-                                                    AllowClear="@(!parameter.Required)"
-                                                    AllowFiltering="true"
-                                                    Class="w-100"
-                                                    Placeholder="Select user" />
+                                    @if (_useFreeTextUsername)
+                                    {
+                                        <RadzenTextBox Value="@GetString(parameter.Name)"
+                                                       ValueChanged="@(v => SetString(parameter.Name, v))"
+                                                       Class="w-100"
+                                                       Placeholder="Enter username" />
+                                    }
+                                    else
+                                    {
+                                        <RadzenDropDown TValue="string"
+                                                        Data="@_usernames"
+                                                        Value="@GetString(parameter.Name)"
+                                                        ValueChanged="@(v => SetString(parameter.Name, v))"
+                                                        AllowClear="@(!parameter.Required)"
+                                                        AllowFiltering="true"
+                                                        Class="w-100"
+                                                        Placeholder="Select user" />
+                                    }
                                 }
                                 else if (parameter.LookupKind == ReportParameterLookupKind.Clients)
                                 {

--- a/src/web/Fig.Web/Pages/Reports.razor.cs
+++ b/src/web/Fig.Web/Pages/Reports.razor.cs
@@ -4,6 +4,7 @@ using Fig.Web.Facades;
 using Fig.Web.Models.Reports;
 using Fig.Web.Models.Setting;
 using Fig.Web.Notifications;
+using Fig.Web.Services;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;
 using Radzen;
@@ -22,9 +23,11 @@ public partial class Reports
     private List<ClientOption> _clientOptions = new();
     private List<GroupOption> _groupOptions = new();
     private List<string> _settingNames = new();
+    private bool _useFreeTextUsername;
 
     [Inject] private IReportsFacade ReportsFacade { get; set; } = null!;
     [Inject] private IUsersFacade UsersFacade { get; set; } = null!;
+    [Inject] private IAccountService AccountService { get; set; } = null!;
     [Inject] private ISettingClientFacade SettingClientFacade { get; set; } = null!;
     [Inject] private IGroupsFacade GroupsFacade { get; set; } = null!;
     [Inject] private IJSRuntime JavascriptRuntime { get; set; } = null!;
@@ -40,17 +43,22 @@ public partial class Reports
     protected override async Task OnInitializedAsync()
     {
         await ReportsFacade.LoadReports();
-        await UsersFacade.LoadAllUsers();
+
+        _useFreeTextUsername = AccountService.AuthenticationMode == WebAuthMode.Keycloak;
+        if (!_useFreeTextUsername)
+        {
+            await UsersFacade.LoadAllUsers();
+            _usernames = UsersFacade.UserCollection
+                .Select(u => u.Username)
+                .Where(u => !string.IsNullOrWhiteSpace(u))
+                .Cast<string>()
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(u => u)
+                .ToList();
+        }
+
         if (!SettingClientFacade.SettingClients.Any())
             await SettingClientFacade.LoadAllClients(initializeScripts: false);
-
-        _usernames = UsersFacade.UserCollection
-            .Select(u => u.Username)
-            .Where(u => !string.IsNullOrWhiteSpace(u))
-            .Cast<string>()
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .OrderBy(u => u)
-            .ToList();
 
         var groups = await GroupsFacade.GetAllGroups();
         _groupNames = groups

--- a/src/web/Fig.Web/Pages/Users.razor.cs
+++ b/src/web/Fig.Web/Pages/Users.razor.cs
@@ -41,8 +41,17 @@ public partial class Users
     [Inject]
     private IAccountService AccountService { get; set; } = null!;
 
+    [Inject]
+    private NavigationManager NavigationManager { get; set; } = null!;
+
     protected override async Task OnInitializedAsync()
     {
+        if (AccountService.AuthenticationMode == WebAuthMode.Keycloak)
+        {
+            NavigationManager.NavigateTo("/");
+            return;
+        }
+
         await UsersFacade.LoadAllUsers();
         await base.OnInitializedAsync();
     }

--- a/src/web/Fig.Web/Program.cs
+++ b/src/web/Fig.Web/Program.cs
@@ -76,6 +76,7 @@ async Task BuildApplication(WebAssemblyHostBuilder builder)
     builder.Services.AddScoped<FigManagedWebAuthenticationModeService>();
     builder.Services.AddScoped<KeycloakWebAuthenticationModeService>();
     builder.Services.AddScoped<IWebAuthenticationModeService, WebAuthenticationModeService>();
+    builder.Services.AddScoped<IFigApiAccessTokenProvider, FigApiAccessTokenProvider>();
     builder.Services.AddScoped<IAccountService, AccountService>();
     builder.Services.AddScoped<IHttpService, HttpService>();
     builder.Services.AddScoped<IAssistantContextService, AssistantContextService>();

--- a/src/web/Fig.Web/Program.cs
+++ b/src/web/Fig.Web/Program.cs
@@ -57,6 +57,8 @@ async Task BuildApplication(WebAssemblyHostBuilder builder)
 
             if (!string.IsNullOrWhiteSpace(webSettings.Authentication.Keycloak.PostLogoutRedirectUri))
                 options.ProviderOptions.PostLogoutRedirectUri = webSettings.Authentication.Keycloak.PostLogoutRedirectUri;
+
+            OidcProviderOptionsConfigurator.Apply(options.ProviderOptions, webSettings.Authentication.Keycloak);
         });
     }
 

--- a/src/web/Fig.Web/Program.cs
+++ b/src/web/Fig.Web/Program.cs
@@ -15,6 +15,7 @@ using Fig.Web.Scripting;
 using Fig.Web.Services;
 using Fig.Web.Services.Assistant;
 using Fig.Web.Services.Authentication;
+using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
@@ -60,6 +61,12 @@ async Task BuildApplication(WebAssemblyHostBuilder builder)
 
             OidcProviderOptionsConfigurator.Apply(options.ProviderOptions, webSettings.Authentication.Keycloak);
         });
+
+        builder.Services.AddScoped<KeycloakWebAuthenticationModeService>();
+    }
+    else
+    {
+        builder.Services.AddScoped<AuthenticationStateProvider, FigManagedAuthenticationStateProvider>();
     }
 
     builder.Services.AddHttpClient(HttpClientNames.FigApi, c =>
@@ -76,7 +83,6 @@ async Task BuildApplication(WebAssemblyHostBuilder builder)
     builder.Services.AddRadzenComponents();
     
     builder.Services.AddScoped<FigManagedWebAuthenticationModeService>();
-    builder.Services.AddScoped<KeycloakWebAuthenticationModeService>();
     builder.Services.AddScoped<IWebAuthenticationModeService, WebAuthenticationModeService>();
     builder.Services.AddScoped<IFigApiAccessTokenProvider, FigApiAccessTokenProvider>();
     builder.Services.AddScoped<IAccountService, AccountService>();

--- a/src/web/Fig.Web/Program.cs
+++ b/src/web/Fig.Web/Program.cs
@@ -14,8 +14,10 @@ using Fig.Web.ReleaseHighlights;
 using Fig.Web.Scripting;
 using Fig.Web.Services;
 using Fig.Web.Services.Assistant;
+using Fig.Web.Services.Authentication;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
 using Radzen;
 using Toolbelt.Blazor.Extensions.DependencyInjection;
 
@@ -30,10 +32,33 @@ async Task BuildApplication(WebAssemblyHostBuilder builder)
     builder.RootComponents.Add<HeadOutlet>("head::after");
 
     builder.Services.Configure<WebSettings>(config);
-    var figUri = config.Get<WebSettings>()?.ApiUri;
+    var webSettings = config.Get<WebSettings>() ?? new WebSettings();
+    var figUri = webSettings.ApiUri;
+
+    WebAuthenticationSettingsValidator.Validate(webSettings);
 
     if (string.IsNullOrEmpty(figUri))
         throw new ApplicationException("ApiUri must be configured");
+
+    if (webSettings.Authentication.Mode == WebAuthMode.Keycloak)
+    {
+        builder.Services.AddOidcAuthentication(options =>
+        {
+            options.ProviderOptions.Authority = webSettings.Authentication.Keycloak.Authority;
+            options.ProviderOptions.ClientId = webSettings.Authentication.Keycloak.ClientId;
+            options.ProviderOptions.ResponseType = webSettings.Authentication.Keycloak.ResponseType;
+
+            options.ProviderOptions.DefaultScopes.Clear();
+            foreach (var scope in webSettings.Authentication.Keycloak.Scopes.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+                options.ProviderOptions.DefaultScopes.Add(scope);
+
+            if (!string.IsNullOrWhiteSpace(webSettings.Authentication.Keycloak.ApiScope))
+                options.ProviderOptions.DefaultScopes.Add(webSettings.Authentication.Keycloak.ApiScope);
+
+            if (!string.IsNullOrWhiteSpace(webSettings.Authentication.Keycloak.PostLogoutRedirectUri))
+                options.ProviderOptions.PostLogoutRedirectUri = webSettings.Authentication.Keycloak.PostLogoutRedirectUri;
+        });
+    }
 
     builder.Services.AddHttpClient(HttpClientNames.FigApi, c =>
     {
@@ -48,6 +73,9 @@ async Task BuildApplication(WebAssemblyHostBuilder builder)
     
     builder.Services.AddRadzenComponents();
     
+    builder.Services.AddScoped<FigManagedWebAuthenticationModeService>();
+    builder.Services.AddScoped<KeycloakWebAuthenticationModeService>();
+    builder.Services.AddScoped<IWebAuthenticationModeService, WebAuthenticationModeService>();
     builder.Services.AddScoped<IAccountService, AccountService>();
     builder.Services.AddScoped<IHttpService, HttpService>();
     builder.Services.AddScoped<IAssistantContextService, AssistantContextService>();

--- a/src/web/Fig.Web/Routing/AppRouteView.cs
+++ b/src/web/Fig.Web/Routing/AppRouteView.cs
@@ -33,14 +33,18 @@ public class AppRouteView : RouteView
         if (authorize && AccountService?.AuthenticatedUser == null && NavigationManager != null)
         {
             var returnUrl = WebUtility.UrlEncode(new Uri(NavigationManager.Uri).PathAndQuery);
-            NavigationManager.NavigateTo($"account/login?returnUrl={returnUrl}");
+            if (AccountService?.AuthenticationMode == WebAuthMode.Keycloak)
+                NavigationManager.NavigateTo($"authentication/login?returnUrl={returnUrl}");
+            else
+                NavigationManager.NavigateTo($"account/login?returnUrl={returnUrl}");
+
             return;
         }
         
         // Check for password change requirement (except on manage page)
         if (!isManagePage && AccountService?.AuthenticatedUser?.PasswordChangeRequired == true && NavigationManager != null)
         {
-            NavigationManager.NavigateTo("account/Manage");
+            NavigationManager.NavigateTo("/account/manage");
             return;
         }
         

--- a/src/web/Fig.Web/Routing/AppRouteView.cs
+++ b/src/web/Fig.Web/Routing/AppRouteView.cs
@@ -33,11 +33,8 @@ public class AppRouteView : RouteView
         if (authorize && AccountService?.AuthenticatedUser == null && NavigationManager != null)
         {
             var returnUrl = WebUtility.UrlEncode(new Uri(NavigationManager.Uri).PathAndQuery);
-            if (AccountService?.AuthenticationMode == WebAuthMode.Keycloak)
-                NavigationManager.NavigateTo($"authentication/login?returnUrl={returnUrl}");
-            else
-                NavigationManager.NavigateTo($"account/login?returnUrl={returnUrl}");
-
+            // Route through account/login so Keycloak mode can apply post-logout prompt handling.
+            NavigationManager.NavigateTo($"account/login?returnUrl={returnUrl}");
             return;
         }
         

--- a/src/web/Fig.Web/Services/AccountService.cs
+++ b/src/web/Fig.Web/Services/AccountService.cs
@@ -1,225 +1,57 @@
-using Fig.Common.Events;
-using Fig.Client.Abstractions.Data;
 using Fig.Contracts.Authentication;
-using Fig.Web.Converters;
-using Fig.Web.Events;
 using Fig.Web.Models.Authentication;
-using Fig.Web.Notifications;
-using Microsoft.AspNetCore.Components;
-using Newtonsoft.Json;
-using System.Text;
-using Radzen;
+using Fig.Web.Services.Authentication;
 
 namespace Fig.Web.Services;
 
 public class AccountService : IAccountService
 {
-    private readonly IHttpService _httpService;
-    private readonly ILocalStorageService _localStorageService;
-    private readonly NavigationManager _navigationManager;
-    private readonly IUserConverter _userConverter;
-    private readonly IEventDistributor _eventDistributor;
-    private readonly INotificationHistoryService _notificationHistoryService;
-    private readonly NotificationService _notificationService;
-    private readonly string _userKey = "user";
+    private readonly IWebAuthenticationModeService _webAuthenticationModeService;
 
     public AccountService(
-        IHttpService httpService,
-        NavigationManager navigationManager,
-        ILocalStorageService localStorageService,
-        IUserConverter userConverter,
-        IEventDistributor eventDistributor,
-        INotificationHistoryService notificationHistoryService,
-        NotificationService notificationService)
+        IWebAuthenticationModeService webAuthenticationModeService)
     {
-        _httpService = httpService;
-        _navigationManager = navigationManager;
-        _localStorageService = localStorageService;
-        _userConverter = userConverter;
-        _eventDistributor = eventDistributor;
-        _notificationHistoryService = notificationHistoryService;
-        _notificationService = notificationService;
+        _webAuthenticationModeService = webAuthenticationModeService;
     }
 
-    public AuthenticatedUserModel? AuthenticatedUser { get; private set; }
-    
-    public bool IsInitialized { get; private set; }
+    public WebAuthMode AuthenticationMode => _webAuthenticationModeService.Mode;
+
+    public AuthenticatedUserModel? AuthenticatedUser => _webAuthenticationModeService.AuthenticatedUser;
+
+    public bool IsInitialized => _webAuthenticationModeService.IsInitialized;
 
     public async Task Initialize()
     {
-        try
-        {
-            AuthenticatedUser = await _localStorageService.GetItem<AuthenticatedUserModel>(_userKey);
-            
-            // Required as this could be null when the property was introduced. Can be removed in a later version.
-            if (AuthenticatedUser is not null && AuthenticatedUser.AllowedClassifications is null)
-            {
-                AuthenticatedUser.AllowedClassifications =
-                    Enum.GetValues(typeof(Classification)).Cast<Classification>().ToList();
-            }
-            
-            // Validate the token if we have a user
-            if (AuthenticatedUser != null)
-            {
-                var isValid = await ValidateCurrentToken();
-                if (!isValid)
-                {
-                    await LogoutSilently();
-                }
-            }
-        }
-        finally
-        {
-            IsInitialized = true;
-        }
-    }
-
-    private async Task<bool> ValidateCurrentToken()
-    {
-        if (AuthenticatedUser?.Token == null)
-            return false;
-
-        if (AuthenticatedUser.PasswordChangeRequired)
-            return !IsJwtExpired(AuthenticatedUser.Token);
-
-        try
-        {
-            // Make a simple authenticated request to validate the token
-            // Use a lightweight endpoint that doesn't require specific permissions
-            var result = await _httpService.Get<object>("/users", false); // Don't show notifications for this validation
-            return result != null;
-        }
-        catch (HttpRequestException)
-        {
-            // Network/connection issue - don't invalidate token, just return true to avoid logout
-            Console.WriteLine("Network issue during token validation, assuming token is valid");
-            return true;
-        }
-        catch (Exception ex)
-        {
-            // Other errors (like unauthorized) should invalidate the token
-            Console.WriteLine($"Token validation failed: {ex.Message}");
-            return false;
-        }
+        await _webAuthenticationModeService.Initialize();
     }
 
     public async Task Login(LoginModel model)
     {
-        var dataContract = new AuthenticateRequestDataContract(model.Username!, model.Password!);
-        var user = await _httpService.Post<AuthenticateResponseDataContract>("/users/authenticate", dataContract);
-
-        if (user == null)
-            throw new Exception("Invalid user");
-
-        ClearNotifications();
-        AuthenticatedUser = _userConverter.Convert(user);
-        await _localStorageService.SetItem(_userKey, AuthenticatedUser);
+        await _webAuthenticationModeService.Login(model);
     }
 
     public async Task Logout()
     {
-        ClearNotifications();
-        AuthenticatedUser = null;
-        await _localStorageService.RemoveItem(_userKey);
-        await _eventDistributor.PublishAsync(EventConstants.LogoutEvent);
-        
-        // Only avoid navigation if we're already on the login page specifically
-        var currentUri = new Uri(_navigationManager.Uri);
-        if (!currentUri.AbsolutePath.Contains("/account/login", StringComparison.OrdinalIgnoreCase))
-        {
-            _navigationManager.NavigateTo("/account/login");
-        }
+        await _webAuthenticationModeService.Logout();
     }
 
-    private async Task LogoutSilently()
+    public async Task<Guid> Register(RegisterUserRequestDataContract model)
     {
-        ClearNotifications();
-        AuthenticatedUser = null;
-        await _localStorageService.RemoveItem(_userKey);
-        await _eventDistributor.PublishAsync(EventConstants.LogoutEvent);
-        // Don't navigate during silent logout (used during initialization)
-    }
-
-    private static bool IsJwtExpired(string? token)
-    {
-        if (string.IsNullOrWhiteSpace(token))
-            return true;
-
-        try
-        {
-            var parts = token.Split('.');
-            if (parts.Length < 2)
-                return true;
-
-            var payload = parts[1]
-                .Replace('-', '+')
-                .Replace('_', '/');
-
-            payload = payload.PadRight(payload.Length + ((4 - payload.Length % 4) % 4), '=');
-
-            var json = Encoding.UTF8.GetString(Convert.FromBase64String(payload));
-            var data = JsonConvert.DeserializeObject<Dictionary<string, object>>(json);
-            if (data == null || !data.TryGetValue("exp", out var expiryValue))
-                return true;
-
-            var expiry = Convert.ToInt64(expiryValue);
-            return DateTimeOffset.UtcNow >= DateTimeOffset.FromUnixTimeSeconds(expiry);
-        }
-        catch
-        {
-            return true;
-        }
-    }
-
-    public async Task<Guid> Register(RegisterUserRequestDataContract userRegistration)
-    {
-        return await _httpService.Post<Guid>("/users/register", userRegistration);
+        return await _webAuthenticationModeService.Register(model);
     }
 
     public async Task<IList<UserDataContract>> GetAll()
     {
-        return await _httpService.Get<IList<UserDataContract>>("/users") ?? new List<UserDataContract>();
+        return await _webAuthenticationModeService.GetAll();
     }
 
-    public async Task Update(Guid id, UpdateUserRequestDataContract update)
+    public async Task Update(Guid id, UpdateUserRequestDataContract model)
     {
-        var passwordChanged = !string.IsNullOrEmpty(update.Password);
-        var shouldLogoutAfterForcedPasswordChange = id == AuthenticatedUser?.Id &&
-                                                   AuthenticatedUser?.PasswordChangeRequired == true &&
-                                                   passwordChanged;
-
-        await _httpService.Put($"/users/{id}", update);
-
-        // update stored user if the logged in user updated their own record
-        if (id == AuthenticatedUser?.Id)
-        {
-            // update local storage
-            AuthenticatedUser.FirstName = update.FirstName;
-            AuthenticatedUser.LastName = update.LastName;
-            AuthenticatedUser.Username = update.Username;
-            if (passwordChanged)
-                AuthenticatedUser.PasswordChangeRequired = false;
-            await _localStorageService.SetItem(_userKey, AuthenticatedUser);
-        }
-
-        if (shouldLogoutAfterForcedPasswordChange)
-        {
-            await Logout();
-        }
+        await _webAuthenticationModeService.Update(id, model);
     }
 
     public async Task Delete(Guid id)
     {
-        await _httpService.Delete($"/users/{id}");
-
-        // auto logout if the logged in user deleted their own record
-        if (id == AuthenticatedUser?.Id)
-            await Logout();
-    }
-
-    private void ClearNotifications()
-    {
-        _notificationHistoryService.Clear();
-        _notificationService.Messages.Clear();
+        await _webAuthenticationModeService.Delete(id);
     }
 }

--- a/src/web/Fig.Web/Services/Assistant/AssistantChatClient.cs
+++ b/src/web/Fig.Web/Services/Assistant/AssistantChatClient.cs
@@ -5,7 +5,7 @@ using Fig.Common.NetStandard.Constants;
 using Fig.Common.NetStandard.Json;
 using Fig.Contracts.Assistant;
 using Fig.Web.Events;
-using Fig.Web.Models.Authentication;
+using Fig.Web.Services.Authentication;
 using Microsoft.AspNetCore.Components.WebAssembly.Http;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -17,7 +17,7 @@ public sealed class AssistantChatClient : IAssistantChatClient, IDisposable
     private const int MaxStoredMessages = 40;
 
     private readonly HttpClient _httpClient;
-    private readonly ILocalStorageService _localStorageService;
+    private readonly IFigApiAccessTokenProvider _accessTokenProvider;
     private readonly IAssistantContextService _contextService;
     private readonly IAssistantActionApplier _actionApplier;
     private readonly IEventDistributor _eventDistributor;
@@ -25,13 +25,13 @@ public sealed class AssistantChatClient : IAssistantChatClient, IDisposable
 
     public AssistantChatClient(
         IHttpClientFactory httpClientFactory,
-        ILocalStorageService localStorageService,
+        IFigApiAccessTokenProvider accessTokenProvider,
         IAssistantContextService contextService,
         IAssistantActionApplier actionApplier,
         IEventDistributor eventDistributor)
     {
         _httpClient = httpClientFactory.CreateClient(HttpClientNames.FigApi);
-        _localStorageService = localStorageService;
+        _accessTokenProvider = accessTokenProvider;
         _contextService = contextService;
         _actionApplier = actionApplier;
         _eventDistributor = eventDistributor;
@@ -186,9 +186,9 @@ public sealed class AssistantChatClient : IAssistantChatClient, IDisposable
 
     private async Task AddJwtHeader(HttpRequestMessage request)
     {
-        var user = await _localStorageService.GetItem<AuthenticatedUserModel>("user");
-        if (user?.Token is not null)
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", user.Token);
+        var token = await _accessTokenProvider.GetAccessTokenAsync();
+        if (!string.IsNullOrWhiteSpace(token))
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
     }
 
     public void Clear()

--- a/src/web/Fig.Web/Services/Authentication/FigApiAccessTokenProvider.cs
+++ b/src/web/Fig.Web/Services/Authentication/FigApiAccessTokenProvider.cs
@@ -1,0 +1,40 @@
+using Fig.Web.Models.Authentication;
+using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Fig.Web.Services.Authentication;
+
+public sealed class FigApiAccessTokenProvider : IFigApiAccessTokenProvider
+{
+    private readonly WebAuthMode _authenticationMode;
+    private readonly ILocalStorageService _localStorageService;
+    private readonly IServiceProvider _serviceProvider;
+
+    public FigApiAccessTokenProvider(
+        IOptions<WebSettings> webSettings,
+        ILocalStorageService localStorageService,
+        IServiceProvider serviceProvider)
+    {
+        _authenticationMode = webSettings.Value.Authentication.Mode;
+        _localStorageService = localStorageService;
+        _serviceProvider = serviceProvider;
+    }
+
+    public async Task<string?> GetAccessTokenAsync()
+    {
+        if (_authenticationMode == WebAuthMode.Keycloak)
+        {
+            var accessTokenProvider = _serviceProvider.GetService<IAccessTokenProvider>();
+            if (accessTokenProvider is null)
+                return null;
+
+            var tokenResult = await accessTokenProvider.RequestAccessToken();
+            return tokenResult.TryGetToken(out var token) ? token.Value : null;
+        }
+
+        var user = await _localStorageService.GetItem<AuthenticatedUserModel>(
+            WebAuthenticationConstants.AuthenticatedUserStorageKey);
+        return string.IsNullOrWhiteSpace(user?.Token) ? null : user.Token;
+    }
+}

--- a/src/web/Fig.Web/Services/Authentication/FigManagedAuthenticationStateProvider.cs
+++ b/src/web/Fig.Web/Services/Authentication/FigManagedAuthenticationStateProvider.cs
@@ -1,0 +1,16 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Components.Authorization;
+
+namespace Fig.Web.Services.Authentication;
+
+/// <summary>
+/// No-op provider so <see cref="CascadingAuthenticationState"/> can resolve in FigManaged mode.
+/// Session state lives in <see cref="FigManagedWebAuthenticationModeService"/> / <see cref="IAccountService"/>.
+/// </summary>
+public class FigManagedAuthenticationStateProvider : AuthenticationStateProvider
+{
+    private static readonly Task<AuthenticationState> AnonymousState =
+        Task.FromResult(new AuthenticationState(new ClaimsPrincipal(new ClaimsIdentity())));
+
+    public override Task<AuthenticationState> GetAuthenticationStateAsync() => AnonymousState;
+}

--- a/src/web/Fig.Web/Services/Authentication/FigManagedWebAuthenticationModeService.cs
+++ b/src/web/Fig.Web/Services/Authentication/FigManagedWebAuthenticationModeService.cs
@@ -1,0 +1,210 @@
+using Fig.Client.Abstractions.Data;
+using Fig.Common.Events;
+using Fig.Contracts.Authentication;
+using Fig.Web.Converters;
+using Fig.Web.Events;
+using Fig.Web.Models.Authentication;
+using Fig.Web.Notifications;
+using Microsoft.AspNetCore.Components;
+using Newtonsoft.Json;
+using Radzen;
+using System.Text;
+
+namespace Fig.Web.Services.Authentication;
+
+public class FigManagedWebAuthenticationModeService : IWebAuthenticationModeService
+{
+    private readonly IHttpService _httpService;
+    private readonly ILocalStorageService _localStorageService;
+    private readonly NavigationManager _navigationManager;
+    private readonly IUserConverter _userConverter;
+    private readonly IEventDistributor _eventDistributor;
+    private readonly INotificationHistoryService _notificationHistoryService;
+    private readonly NotificationService _notificationService;
+
+    public FigManagedWebAuthenticationModeService(
+        IHttpService httpService,
+        NavigationManager navigationManager,
+        ILocalStorageService localStorageService,
+        IUserConverter userConverter,
+        IEventDistributor eventDistributor,
+        INotificationHistoryService notificationHistoryService,
+        NotificationService notificationService)
+    {
+        _httpService = httpService;
+        _navigationManager = navigationManager;
+        _localStorageService = localStorageService;
+        _userConverter = userConverter;
+        _eventDistributor = eventDistributor;
+        _notificationHistoryService = notificationHistoryService;
+        _notificationService = notificationService;
+    }
+
+    public WebAuthMode Mode => WebAuthMode.FigManaged;
+
+    public AuthenticatedUserModel? AuthenticatedUser { get; private set; }
+
+    public bool IsInitialized { get; private set; }
+
+    public async Task Initialize()
+    {
+        try
+        {
+            AuthenticatedUser = await _localStorageService.GetItem<AuthenticatedUserModel>(WebAuthenticationConstants.AuthenticatedUserStorageKey);
+
+            if (AuthenticatedUser is not null && AuthenticatedUser.AllowedClassifications is null)
+            {
+                AuthenticatedUser.AllowedClassifications =
+                    Enum.GetValues(typeof(Classification)).Cast<Classification>().ToList();
+            }
+
+            if (AuthenticatedUser != null)
+            {
+                var isValid = await ValidateCurrentToken();
+                if (!isValid)
+                    await LogoutSilently();
+            }
+        }
+        finally
+        {
+            IsInitialized = true;
+        }
+    }
+
+    public async Task Login(LoginModel model)
+    {
+        var dataContract = new AuthenticateRequestDataContract(model.Username!, model.Password!);
+        var user = await _httpService.Post<AuthenticateResponseDataContract>("/users/authenticate", dataContract);
+
+        if (user == null)
+            throw new Exception("Invalid user");
+
+        ClearNotifications();
+        AuthenticatedUser = _userConverter.Convert(user);
+        await _localStorageService.SetItem(WebAuthenticationConstants.AuthenticatedUserStorageKey, AuthenticatedUser);
+    }
+
+    public async Task Logout()
+    {
+        ClearNotifications();
+        AuthenticatedUser = null;
+        await _localStorageService.RemoveItem(WebAuthenticationConstants.AuthenticatedUserStorageKey);
+        await _eventDistributor.PublishAsync(EventConstants.LogoutEvent);
+
+        var currentUri = new Uri(_navigationManager.Uri);
+        if (!currentUri.AbsolutePath.Contains("/account/login", StringComparison.OrdinalIgnoreCase))
+            _navigationManager.NavigateTo("/account/login");
+    }
+
+    public async Task<Guid> Register(RegisterUserRequestDataContract model)
+    {
+        return await _httpService.Post<Guid>("/users/register", model);
+    }
+
+    public async Task<IList<UserDataContract>> GetAll()
+    {
+        return await _httpService.Get<IList<UserDataContract>>("/users") ?? new List<UserDataContract>();
+    }
+
+    public async Task Update(Guid id, UpdateUserRequestDataContract model)
+    {
+        var passwordChanged = !string.IsNullOrEmpty(model.Password);
+        var shouldLogoutAfterForcedPasswordChange = id == AuthenticatedUser?.Id &&
+                                                    AuthenticatedUser?.PasswordChangeRequired == true &&
+                                                    passwordChanged;
+
+        await _httpService.Put($"/users/{id}", model);
+
+        if (id == AuthenticatedUser?.Id)
+        {
+            AuthenticatedUser.FirstName = model.FirstName;
+            AuthenticatedUser.LastName = model.LastName;
+            AuthenticatedUser.Username = model.Username;
+            if (passwordChanged)
+                AuthenticatedUser.PasswordChangeRequired = false;
+
+            await _localStorageService.SetItem(WebAuthenticationConstants.AuthenticatedUserStorageKey, AuthenticatedUser);
+        }
+
+        if (shouldLogoutAfterForcedPasswordChange)
+            await Logout();
+    }
+
+    public async Task Delete(Guid id)
+    {
+        await _httpService.Delete($"/users/{id}");
+
+        if (id == AuthenticatedUser?.Id)
+            await Logout();
+    }
+
+    private async Task<bool> ValidateCurrentToken()
+    {
+        if (AuthenticatedUser?.Token == null)
+            return false;
+
+        if (AuthenticatedUser.PasswordChangeRequired)
+            return !IsJwtExpired(AuthenticatedUser.Token);
+
+        try
+        {
+            var result = await _httpService.Get<object>("/users", false);
+            return result != null;
+        }
+        catch (HttpRequestException)
+        {
+            Console.WriteLine("Network issue during token validation, assuming token is valid");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Token validation failed: {ex.Message}");
+            return false;
+        }
+    }
+
+    private async Task LogoutSilently()
+    {
+        ClearNotifications();
+        AuthenticatedUser = null;
+        await _localStorageService.RemoveItem(WebAuthenticationConstants.AuthenticatedUserStorageKey);
+        await _eventDistributor.PublishAsync(EventConstants.LogoutEvent);
+    }
+
+    private static bool IsJwtExpired(string? token)
+    {
+        if (string.IsNullOrWhiteSpace(token))
+            return true;
+
+        try
+        {
+            var parts = token.Split('.');
+            if (parts.Length < 2)
+                return true;
+
+            var payload = parts[1]
+                .Replace('-', '+')
+                .Replace('_', '/');
+
+            payload = payload.PadRight(payload.Length + ((4 - payload.Length % 4) % 4), '=');
+
+            var json = Encoding.UTF8.GetString(Convert.FromBase64String(payload));
+            var data = JsonConvert.DeserializeObject<Dictionary<string, object>>(json);
+            if (data == null || !data.TryGetValue("exp", out var expiryValue))
+                return true;
+
+            var expiry = Convert.ToInt64(expiryValue);
+            return DateTimeOffset.UtcNow >= DateTimeOffset.FromUnixTimeSeconds(expiry);
+        }
+        catch
+        {
+            return true;
+        }
+    }
+
+    private void ClearNotifications()
+    {
+        _notificationHistoryService.Clear();
+        _notificationService.Messages.Clear();
+    }
+}

--- a/src/web/Fig.Web/Services/Authentication/IFigApiAccessTokenProvider.cs
+++ b/src/web/Fig.Web/Services/Authentication/IFigApiAccessTokenProvider.cs
@@ -1,0 +1,6 @@
+namespace Fig.Web.Services.Authentication;
+
+public interface IFigApiAccessTokenProvider
+{
+    Task<string?> GetAccessTokenAsync();
+}

--- a/src/web/Fig.Web/Services/Authentication/IWebAuthenticationModeService.cs
+++ b/src/web/Fig.Web/Services/Authentication/IWebAuthenticationModeService.cs
@@ -1,14 +1,14 @@
 using Fig.Contracts.Authentication;
 using Fig.Web.Models.Authentication;
 
-namespace Fig.Web.Services;
+namespace Fig.Web.Services.Authentication;
 
-public interface IAccountService
+public interface IWebAuthenticationModeService
 {
-    WebAuthMode AuthenticationMode { get; }
+    WebAuthMode Mode { get; }
 
     AuthenticatedUserModel? AuthenticatedUser { get; }
-    
+
     bool IsInitialized { get; }
 
     Task Initialize();

--- a/src/web/Fig.Web/Services/Authentication/KeycloakWebAuthenticationModeService.cs
+++ b/src/web/Fig.Web/Services/Authentication/KeycloakWebAuthenticationModeService.cs
@@ -1,0 +1,461 @@
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+using Fig.Client.Abstractions.Data;
+using Fig.Common.Events;
+using Fig.Contracts.Authentication;
+using Fig.Web.Events;
+using Fig.Web.Models.Authentication;
+using Fig.Web.Notifications;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Radzen;
+
+namespace Fig.Web.Services.Authentication;
+
+public class KeycloakWebAuthenticationModeService : IWebAuthenticationModeService, IDisposable
+{
+    private readonly IAccessTokenProvider _accessTokenProvider;
+    private readonly AuthenticationStateProvider _authenticationStateProvider;
+    private readonly IEventDistributor _eventDistributor;
+    private readonly WebKeycloakAuthenticationSettings _keycloakSettings;
+    private readonly ILocalStorageService _localStorageService;
+    private readonly NavigationManager _navigationManager;
+    private readonly INotificationHistoryService _notificationHistoryService;
+    private readonly NotificationService _notificationService;
+
+    public KeycloakWebAuthenticationModeService(
+        NavigationManager navigationManager,
+        ILocalStorageService localStorageService,
+        IEventDistributor eventDistributor,
+        IAccessTokenProvider accessTokenProvider,
+        AuthenticationStateProvider authenticationStateProvider,
+        INotificationHistoryService notificationHistoryService,
+        NotificationService notificationService,
+        IOptions<WebSettings> webSettings)
+    {
+        _navigationManager = navigationManager;
+        _localStorageService = localStorageService;
+        _eventDistributor = eventDistributor;
+        _accessTokenProvider = accessTokenProvider;
+        _authenticationStateProvider = authenticationStateProvider;
+        _notificationHistoryService = notificationHistoryService;
+        _notificationService = notificationService;
+        _keycloakSettings = webSettings.Value.Authentication.Keycloak;
+
+        _authenticationStateProvider.AuthenticationStateChanged += OnAuthenticationStateChanged;
+    }
+
+    public WebAuthMode Mode => WebAuthMode.Keycloak;
+
+    public AuthenticatedUserModel? AuthenticatedUser { get; private set; }
+
+    public bool IsInitialized { get; private set; }
+
+    public async Task Initialize()
+    {
+        try
+        {
+            await RefreshAuthenticatedUser();
+        }
+        finally
+        {
+            IsInitialized = true;
+        }
+    }
+
+    public Task Login(LoginModel model)
+    {
+        var returnUrl = GetReturnUrl();
+        _navigationManager.NavigateTo($"authentication/login?returnUrl={Uri.EscapeDataString(returnUrl)}", true);
+        return Task.CompletedTask;
+    }
+
+    public async Task Logout()
+    {
+        ClearNotifications();
+        AuthenticatedUser = null;
+        await _localStorageService.RemoveItem(WebAuthenticationConstants.AuthenticatedUserStorageKey);
+        await _eventDistributor.PublishAsync(EventConstants.LogoutEvent);
+
+        _navigationManager.NavigateToLogout("authentication/logout");
+    }
+
+    public Task<Guid> Register(RegisterUserRequestDataContract model)
+    {
+        throw new NotSupportedException("User registration is not supported when Authentication.Mode is Keycloak");
+    }
+
+    public Task<IList<UserDataContract>> GetAll()
+    {
+        throw new NotSupportedException("User management is not supported when Authentication.Mode is Keycloak");
+    }
+
+    public Task Update(Guid id, UpdateUserRequestDataContract model)
+    {
+        throw new NotSupportedException("User updates are not supported when Authentication.Mode is Keycloak");
+    }
+
+    public Task Delete(Guid id)
+    {
+        throw new NotSupportedException("User deletion is not supported when Authentication.Mode is Keycloak");
+    }
+
+    private async Task RefreshAuthenticatedUser()
+    {
+        var authenticationState = await _authenticationStateProvider.GetAuthenticationStateAsync();
+        await RefreshAuthenticatedUser(authenticationState.User);
+    }
+
+    private async Task RefreshAuthenticatedUser(ClaimsPrincipal principal)
+    {
+        if (principal.Identity?.IsAuthenticated != true)
+        {
+            AuthenticatedUser = null;
+            await _localStorageService.RemoveItem(WebAuthenticationConstants.AuthenticatedUserStorageKey);
+            return;
+        }
+
+        var accessTokenResult = await _accessTokenProvider.RequestAccessToken();
+        if (!accessTokenResult.TryGetToken(out var token))
+        {
+            AuthenticatedUser = null;
+            await _localStorageService.RemoveItem(WebAuthenticationConstants.AuthenticatedUserStorageKey);
+            return;
+        }
+
+        var role = ResolveRole(principal, _keycloakSettings);
+        if (role == null)
+        {
+            AuthenticatedUser = null;
+            await _localStorageService.RemoveItem(WebAuthenticationConstants.AuthenticatedUserStorageKey);
+            return;
+        }
+
+        var allowedClassifications = ResolveAllowedClassifications(principal, role.Value, _keycloakSettings);
+        if (allowedClassifications == null)
+        {
+            AuthenticatedUser = null;
+            await _localStorageService.RemoveItem(WebAuthenticationConstants.AuthenticatedUserStorageKey);
+            return;
+        }
+
+        var username = ClaimValue(principal, _keycloakSettings.UsernameClaim)
+                       ?? ClaimValue(principal, ClaimTypes.Name)
+                       ?? ClaimValue(principal, "sub")
+                       ?? "unknown";
+        var subject = ClaimValue(principal, "sub") ?? username;
+
+        AuthenticatedUser = new AuthenticatedUserModel
+        {
+            Id = CreateDeterministicGuid(subject),
+            Username = username,
+            FirstName = ClaimValue(principal, _keycloakSettings.FirstNameClaim)
+                       ?? ClaimValue(principal, _keycloakSettings.NameClaim)
+                       ?? username,
+            LastName = ClaimValue(principal, _keycloakSettings.LastNameClaim),
+            Role = role.Value,
+            AllowedClassifications = allowedClassifications,
+            Token = token.Value,
+            PasswordChangeRequired = false
+        };
+
+        await _localStorageService.SetItem(WebAuthenticationConstants.AuthenticatedUserStorageKey, AuthenticatedUser);
+    }
+
+    private void OnAuthenticationStateChanged(Task<AuthenticationState> authenticationStateTask)
+    {
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                var authenticationState = await authenticationStateTask;
+                await RefreshAuthenticatedUser(authenticationState.User);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error refreshing authentication state: {ex.Message}");
+                AuthenticatedUser = null;
+                await _localStorageService.RemoveItem(WebAuthenticationConstants.AuthenticatedUserStorageKey);
+            }
+        });
+    }
+
+    public void Dispose()
+    {
+        _authenticationStateProvider.AuthenticationStateChanged -= OnAuthenticationStateChanged;
+    }
+
+    private static Role? ResolveRole(ClaimsPrincipal principal, WebKeycloakAuthenticationSettings settings)
+    {
+        var roleClaims = principal.Claims
+            .SelectMany(ExtractRoleValues)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var claimPath in settings.RoleClaimPaths.Where(a => !string.IsNullOrWhiteSpace(a)))
+        {
+            foreach (var role in GetValuesAtPath(principal, claimPath))
+                roleClaims.Add(role);
+        }
+
+        if (ContainsMappedRole(roleClaims, Role.Administrator, settings, settings.AdminRoleName))
+            return Role.Administrator;
+
+        if (ContainsMappedRole(roleClaims, Role.ReadOnly, settings))
+            return Role.ReadOnly;
+
+        if (ContainsMappedRole(roleClaims, Role.LookupService, settings))
+            return Role.LookupService;
+
+        if (ContainsMappedRole(roleClaims, Role.User, settings))
+            return Role.User;
+
+        return null;
+    }
+
+    private static IEnumerable<string> ExtractRoleValues(Claim claim)
+    {
+        if (claim.Type == ClaimTypes.Role || claim.Type == "role")
+            return [claim.Value];
+
+        if (claim.Type == "roles")
+        {
+            var parsed = ParseStringArrayClaim(claim.Value);
+            return parsed.Count > 0 ? parsed : [claim.Value];
+        }
+
+        if (claim.Type == "groups")
+        {
+            var parsed = ParseStringArrayClaim(claim.Value);
+            return parsed.Count > 0 ? parsed : [claim.Value];
+        }
+
+        if (claim.Type == "realm_access")
+            return ParseKeycloakRoleContainer(claim.Value, "roles");
+
+        if (claim.Type == "resource_access")
+            return ParseKeycloakResourceAccessRoles(claim.Value);
+
+        return [];
+    }
+
+    private static List<string> ParseStringArrayClaim(string claimValue)
+    {
+        if (string.IsNullOrWhiteSpace(claimValue) || !claimValue.TrimStart().StartsWith("["))
+            return [];
+
+        try
+        {
+            var token = JToken.Parse(claimValue);
+            return token is JArray array
+                ? array.Values<string?>().Where(a => !string.IsNullOrWhiteSpace(a)).Select(a => a!).ToList()
+                : [];
+        }
+        catch (JsonException)
+        {
+            return [];
+        }
+    }
+
+    private static List<string> ParseKeycloakRoleContainer(string claimValue, string propertyName)
+    {
+        if (string.IsNullOrWhiteSpace(claimValue))
+            return [];
+
+        try
+        {
+            var token = JToken.Parse(claimValue);
+            var roles = token[propertyName] as JArray;
+            return roles?.Values<string?>().Where(a => !string.IsNullOrWhiteSpace(a)).Select(a => a!).ToList() ?? [];
+        }
+        catch (JsonException)
+        {
+            return [];
+        }
+    }
+
+    private static List<string> ParseKeycloakResourceAccessRoles(string claimValue)
+    {
+        if (string.IsNullOrWhiteSpace(claimValue))
+            return [];
+
+        try
+        {
+            var token = JToken.Parse(claimValue) as JObject;
+            if (token == null)
+                return [];
+
+            return token.Properties()
+                .SelectMany(property => (property.Value["roles"] as JArray)?.Values<string?>() ?? [])
+                .Where(role => !string.IsNullOrWhiteSpace(role))
+                .Select(role => role!)
+                .ToList();
+        }
+        catch (JsonException)
+        {
+            return [];
+        }
+    }
+
+    private static List<Classification>? ResolveAllowedClassifications(
+        ClaimsPrincipal principal,
+        Role role,
+        WebKeycloakAuthenticationSettings settings)
+    {
+        var claimValue = ClaimValue(principal, settings.AllowedClassificationsClaim);
+
+        if (string.IsNullOrWhiteSpace(claimValue))
+        {
+            return role == Role.Administrator
+                ? Enum.GetValues(typeof(Classification)).Cast<Classification>().ToList()
+                : null;
+        }
+
+        IEnumerable<string?> values;
+        try
+        {
+            values = claimValue.Trim().StartsWith("[")
+                ? JArray.Parse(claimValue).Values<string>()
+                : claimValue.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+
+        var classifications = values
+            .Where(a => Enum.TryParse<Classification>(a, true, out _))
+            .Select(a => Enum.Parse<Classification>(a, true))
+            .ToList();
+
+        return classifications.Count == 0 ? null : classifications;
+    }
+
+    private static string? ClaimValue(ClaimsPrincipal principal, string claimType)
+    {
+        return principal.Claims.FirstOrDefault(a => a.Type == claimType)?.Value;
+    }
+
+    private static IEnumerable<string> GetValuesAtPath(ClaimsPrincipal principal, string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return [];
+
+        var splitIndex = path.IndexOf('.');
+        var claimType = splitIndex > 0 ? path[..splitIndex] : path;
+        var claimValue = ClaimValue(principal, claimType);
+        if (string.IsNullOrWhiteSpace(claimValue))
+            return [];
+
+        if (splitIndex < 0)
+        {
+            var parsed = ParseStringArrayClaim(claimValue);
+            return parsed.Count > 0 ? parsed : [claimValue];
+        }
+
+        try
+        {
+            var jToken = JToken.Parse(claimValue).SelectToken(path[(splitIndex + 1)..]);
+            if (jToken == null)
+                return [];
+
+            return jToken.Type == JTokenType.Array
+                ? jToken.Values<string>().Where(a => !string.IsNullOrWhiteSpace(a))
+                : [jToken.ToString()];
+        }
+        catch (JsonException)
+        {
+            return [];
+        }
+    }
+
+    private static bool ContainsMappedRole(
+        HashSet<string> tokenValues,
+        Role role,
+        WebKeycloakAuthenticationSettings settings,
+        params string[] additionalMappedValues)
+    {
+        var mappedValues = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (settings.RoleMappings.TryGetValue(role.ToString(), out var configuredValues))
+        {
+            foreach (var configuredValue in configuredValues.Where(a => !string.IsNullOrWhiteSpace(a)))
+                mappedValues.Add(configuredValue);
+        }
+
+        foreach (var additionalMappedValue in additionalMappedValues.Where(a => !string.IsNullOrWhiteSpace(a)))
+            mappedValues.Add(additionalMappedValue);
+
+        mappedValues.Add(role.ToString());
+
+        return tokenValues.Any(tokenValue => MatchesAnyMappedRoleValue(tokenValue, mappedValues));
+    }
+
+    private static bool MatchesAnyMappedRoleValue(string tokenValue, HashSet<string> mappedValues)
+    {
+        if (mappedValues.Contains(tokenValue))
+            return true;
+
+        var groupLeaf = tokenValue.Split('/', StringSplitOptions.RemoveEmptyEntries).LastOrDefault();
+        return !string.IsNullOrWhiteSpace(groupLeaf) &&
+               mappedValues.Any(mappedValue =>
+                   !mappedValue.Contains('/', StringComparison.Ordinal) &&
+                   string.Equals(groupLeaf, mappedValue, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static Guid CreateDeterministicGuid(string source)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(source));
+        Span<byte> guidBytes = stackalloc byte[16];
+        bytes[..16].CopyTo(guidBytes);
+        return new Guid(guidBytes);
+    }
+
+    private string GetReturnUrl()
+    {
+        var uri = new Uri(_navigationManager.Uri);
+        var query = uri.Query.TrimStart('?');
+        var pairs = query.Split('&', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        foreach (var pair in pairs)
+        {
+            var splitIndex = pair.IndexOf('=');
+            if (splitIndex <= 0)
+                continue;
+
+            var key = Uri.UnescapeDataString(pair[..splitIndex]);
+            if (!string.Equals(key, "returnUrl", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var value = Uri.UnescapeDataString(pair[(splitIndex + 1)..]);
+            if (!string.IsNullOrWhiteSpace(value) && IsRelativeUrl(value))
+                return value;
+        }
+
+        return uri.PathAndQuery;
+    }
+
+    private void ClearNotifications()
+    {
+        _notificationHistoryService.Clear();
+        _notificationService.Messages.Clear();
+    }
+
+    private static bool IsRelativeUrl(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+            return false;
+
+        // Must start with / and not with // (which browsers treat as protocol-relative)
+        if (!url.StartsWith('/') || url.StartsWith("//"))
+            return false;
+
+        // Reject URLs with scheme indicators
+        if (url.Contains("://"))
+            return false;
+
+        return true;
+    }
+}

--- a/src/web/Fig.Web/Services/Authentication/KeycloakWebAuthenticationModeService.cs
+++ b/src/web/Fig.Web/Services/Authentication/KeycloakWebAuthenticationModeService.cs
@@ -71,8 +71,7 @@ public class KeycloakWebAuthenticationModeService : IWebAuthenticationModeServic
     public Task Login(LoginModel model)
     {
         var returnUrl = GetReturnUrl();
-        _navigationManager.NavigateTo($"authentication/login?returnUrl={Uri.EscapeDataString(returnUrl)}", true);
-        return Task.CompletedTask;
+        return BeginLoginAsync(returnUrl);
     }
 
     public async Task Logout()
@@ -82,7 +81,33 @@ public class KeycloakWebAuthenticationModeService : IWebAuthenticationModeServic
         await _localStorageService.RemoveItem(WebAuthenticationConstants.AuthenticatedUserStorageKey);
         await _eventDistributor.PublishAsync(EventConstants.LogoutEvent);
 
+        await _localStorageService.SetItem(WebAuthenticationConstants.PostLogoutLoginStorageKey, true);
         _navigationManager.NavigateToLogout("authentication/logout");
+    }
+
+    private async Task BeginLoginAsync(string returnUrl)
+    {
+        var postLogoutLogin = await _localStorageService.GetItem<bool?>(WebAuthenticationConstants.PostLogoutLoginStorageKey) == true;
+        if (postLogoutLogin)
+            await _localStorageService.RemoveItem(WebAuthenticationConstants.PostLogoutLoginStorageKey);
+
+        if (postLogoutLogin && !string.IsNullOrWhiteSpace(_keycloakSettings.PostLogoutLoginPrompt))
+        {
+            var absoluteReturnUrl = _navigationManager.ToAbsoluteUri(returnUrl).AbsoluteUri;
+            var requestOptions = new InteractiveRequestOptions
+            {
+                Interaction = InteractionType.SignIn,
+                ReturnUrl = absoluteReturnUrl
+            };
+            requestOptions.TryAddAdditionalParameter(
+                OidcProviderOptionsConfigurator.PromptParameterName,
+                _keycloakSettings.PostLogoutLoginPrompt.Trim());
+
+            _navigationManager.NavigateToLogin("authentication/login", requestOptions);
+            return;
+        }
+
+        _navigationManager.NavigateTo($"authentication/login?returnUrl={Uri.EscapeDataString(returnUrl)}", true);
     }
 
     public Task<Guid> Register(RegisterUserRequestDataContract model)

--- a/src/web/Fig.Web/Services/Authentication/KeycloakWebAuthenticationModeService.cs
+++ b/src/web/Fig.Web/Services/Authentication/KeycloakWebAuthenticationModeService.cs
@@ -215,11 +215,12 @@ public class KeycloakWebAuthenticationModeService : IWebAuthenticationModeServic
         _authenticationStateProvider.AuthenticationStateChanged -= OnAuthenticationStateChanged;
     }
 
-    private static Role? ResolveRole(ClaimsPrincipal principal, WebKeycloakAuthenticationSettings settings)
+    /// <summary>
+    /// Resolves the Fig role exclusively from configured claim paths so RoleClaimPaths remain an authorization boundary.
+    /// </summary>
+    internal static Role? ResolveRole(ClaimsPrincipal principal, WebKeycloakAuthenticationSettings settings)
     {
-        var roleClaims = principal.Claims
-            .SelectMany(ExtractRoleValues)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var roleClaims = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
         foreach (var claimPath in settings.RoleClaimPaths.Where(a => !string.IsNullOrWhiteSpace(a)))
         {
@@ -242,32 +243,6 @@ public class KeycloakWebAuthenticationModeService : IWebAuthenticationModeServic
         return null;
     }
 
-    private static IEnumerable<string> ExtractRoleValues(Claim claim)
-    {
-        if (claim.Type == ClaimTypes.Role || claim.Type == "role")
-            return [claim.Value];
-
-        if (claim.Type == "roles")
-        {
-            var parsed = ParseStringArrayClaim(claim.Value);
-            return parsed.Count > 0 ? parsed : [claim.Value];
-        }
-
-        if (claim.Type == "groups")
-        {
-            var parsed = ParseStringArrayClaim(claim.Value);
-            return parsed.Count > 0 ? parsed : [claim.Value];
-        }
-
-        if (claim.Type == "realm_access")
-            return ParseKeycloakRoleContainer(claim.Value, "roles");
-
-        if (claim.Type == "resource_access")
-            return ParseKeycloakResourceAccessRoles(claim.Value);
-
-        return [];
-    }
-
     private static List<string> ParseStringArrayClaim(string claimValue)
     {
         if (string.IsNullOrWhiteSpace(claimValue) || !claimValue.TrimStart().StartsWith("["))
@@ -279,46 +254,6 @@ public class KeycloakWebAuthenticationModeService : IWebAuthenticationModeServic
             return token is JArray array
                 ? array.Values<string?>().Where(a => !string.IsNullOrWhiteSpace(a)).Select(a => a!).ToList()
                 : [];
-        }
-        catch (JsonException)
-        {
-            return [];
-        }
-    }
-
-    private static List<string> ParseKeycloakRoleContainer(string claimValue, string propertyName)
-    {
-        if (string.IsNullOrWhiteSpace(claimValue))
-            return [];
-
-        try
-        {
-            var token = JToken.Parse(claimValue);
-            var roles = token[propertyName] as JArray;
-            return roles?.Values<string?>().Where(a => !string.IsNullOrWhiteSpace(a)).Select(a => a!).ToList() ?? [];
-        }
-        catch (JsonException)
-        {
-            return [];
-        }
-    }
-
-    private static List<string> ParseKeycloakResourceAccessRoles(string claimValue)
-    {
-        if (string.IsNullOrWhiteSpace(claimValue))
-            return [];
-
-        try
-        {
-            var token = JToken.Parse(claimValue) as JObject;
-            if (token == null)
-                return [];
-
-            return token.Properties()
-                .SelectMany(property => (property.Value["roles"] as JArray)?.Values<string?>() ?? [])
-                .Where(role => !string.IsNullOrWhiteSpace(role))
-                .Select(role => role!)
-                .ToList();
         }
         catch (JsonException)
         {

--- a/src/web/Fig.Web/Services/Authentication/OidcProviderOptionsConfigurator.cs
+++ b/src/web/Fig.Web/Services/Authentication/OidcProviderOptionsConfigurator.cs
@@ -1,0 +1,27 @@
+using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
+
+namespace Fig.Web.Services.Authentication;
+
+public static class OidcProviderOptionsConfigurator
+{
+    public const string IdentityProviderHintParameterName = "kc_idp_hint";
+    public const string PromptParameterName = "prompt";
+
+    public static void Apply(OidcProviderOptions providerOptions, WebKeycloakAuthenticationSettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(providerOptions);
+        ArgumentNullException.ThrowIfNull(settings);
+
+        if (settings.EnableIdentityProviderHint &&
+            !string.IsNullOrWhiteSpace(settings.IdentityProviderHint))
+        {
+            providerOptions.AdditionalProviderParameters[IdentityProviderHintParameterName] =
+                settings.IdentityProviderHint.Trim();
+        }
+
+        if (!string.IsNullOrWhiteSpace(settings.LoginPrompt))
+        {
+            providerOptions.AdditionalProviderParameters[PromptParameterName] = settings.LoginPrompt.Trim();
+        }
+    }
+}

--- a/src/web/Fig.Web/Services/Authentication/WebAuthenticationConstants.cs
+++ b/src/web/Fig.Web/Services/Authentication/WebAuthenticationConstants.cs
@@ -1,0 +1,6 @@
+namespace Fig.Web.Services.Authentication;
+
+public static class WebAuthenticationConstants
+{
+    public const string AuthenticatedUserStorageKey = "user";
+}

--- a/src/web/Fig.Web/Services/Authentication/WebAuthenticationConstants.cs
+++ b/src/web/Fig.Web/Services/Authentication/WebAuthenticationConstants.cs
@@ -3,4 +3,6 @@ namespace Fig.Web.Services.Authentication;
 public static class WebAuthenticationConstants
 {
     public const string AuthenticatedUserStorageKey = "user";
+
+    public const string PostLogoutLoginStorageKey = "fig.postLogoutLogin";
 }

--- a/src/web/Fig.Web/Services/Authentication/WebAuthenticationModeService.cs
+++ b/src/web/Fig.Web/Services/Authentication/WebAuthenticationModeService.cs
@@ -1,0 +1,54 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Fig.Web.Services.Authentication;
+
+public class WebAuthenticationModeService : IWebAuthenticationModeService
+{
+    private readonly AuthenticationModeSelector _authenticationModeSelector;
+
+    public WebAuthenticationModeService(IServiceProvider serviceProvider, IOptions<WebSettings> webSettings)
+    {
+        _authenticationModeSelector = new AuthenticationModeSelector(serviceProvider, webSettings.Value);
+    }
+
+    public WebAuthMode Mode => _authenticationModeSelector.Mode;
+
+    public Fig.Web.Models.Authentication.AuthenticatedUserModel? AuthenticatedUser => _authenticationModeSelector.Current.AuthenticatedUser;
+
+    public bool IsInitialized => _authenticationModeSelector.Current.IsInitialized;
+
+    public Task Initialize() => _authenticationModeSelector.Current.Initialize();
+
+    public Task Login(Fig.Web.Models.Authentication.LoginModel model) => _authenticationModeSelector.Current.Login(model);
+
+    public Task Logout() => _authenticationModeSelector.Current.Logout();
+
+    public Task<Guid> Register(Fig.Contracts.Authentication.RegisterUserRequestDataContract model) => _authenticationModeSelector.Current.Register(model);
+
+    public Task<IList<Fig.Contracts.Authentication.UserDataContract>> GetAll() => _authenticationModeSelector.Current.GetAll();
+
+    public Task Update(Guid id, Fig.Contracts.Authentication.UpdateUserRequestDataContract model) => _authenticationModeSelector.Current.Update(id, model);
+
+    public Task Delete(Guid id) => _authenticationModeSelector.Current.Delete(id);
+
+    private class AuthenticationModeSelector
+    {
+        private readonly IServiceProvider _serviceProvider;
+        private readonly WebSettings _settings;
+
+        public AuthenticationModeSelector(IServiceProvider serviceProvider, WebSettings settings)
+        {
+            _serviceProvider = serviceProvider;
+            _settings = settings;
+        }
+
+        public WebAuthMode Mode => _settings.Authentication.Mode;
+
+        public IWebAuthenticationModeService Current => Mode switch
+        {
+            WebAuthMode.Keycloak => _serviceProvider.GetRequiredService<KeycloakWebAuthenticationModeService>(),
+            _ => _serviceProvider.GetRequiredService<FigManagedWebAuthenticationModeService>()
+        };
+    }
+}

--- a/src/web/Fig.Web/Services/Authentication/WebAuthenticationSettingsValidator.cs
+++ b/src/web/Fig.Web/Services/Authentication/WebAuthenticationSettingsValidator.cs
@@ -1,0 +1,40 @@
+using Fig.Contracts.Authentication;
+
+namespace Fig.Web.Services.Authentication;
+
+public static class WebAuthenticationSettingsValidator
+{
+    public static void Validate(WebSettings settings)
+    {
+        if (settings.Authentication.Mode != WebAuthMode.Keycloak)
+            return;
+
+        if (string.IsNullOrWhiteSpace(settings.Authentication.Keycloak.Authority))
+            throw new ApplicationException("WebSettings:Authentication:Keycloak:Authority must be configured when Mode=Keycloak");
+
+        if (string.IsNullOrWhiteSpace(settings.Authentication.Keycloak.ClientId))
+            throw new ApplicationException("WebSettings:Authentication:Keycloak:ClientId must be configured when Mode=Keycloak");
+
+        if (settings.Authentication.Keycloak.RoleClaimPaths == null ||
+            settings.Authentication.Keycloak.RoleClaimPaths.All(string.IsNullOrWhiteSpace))
+            throw new ApplicationException("WebSettings:Authentication:Keycloak:RoleClaimPaths must be configured when Mode=Keycloak");
+
+        if (string.IsNullOrWhiteSpace(settings.Authentication.Keycloak.AllowedClassificationsClaim))
+            throw new ApplicationException("WebSettings:Authentication:Keycloak:AllowedClassificationsClaim must be configured when Mode=Keycloak");
+
+        if (string.IsNullOrWhiteSpace(settings.Authentication.Keycloak.AdminRoleName))
+            throw new ApplicationException("WebSettings:Authentication:Keycloak:AdminRoleName must be configured when Mode=Keycloak");
+
+        if (settings.Authentication.Keycloak.RoleMappings == null)
+            throw new ApplicationException("WebSettings:Authentication:Keycloak:RoleMappings must be configured when Mode=Keycloak");
+
+        foreach (var roleName in Enum.GetNames<Role>())
+        {
+            if (!settings.Authentication.Keycloak.RoleMappings.TryGetValue(roleName, out var mappedValues) ||
+                mappedValues == null ||
+                mappedValues.All(string.IsNullOrWhiteSpace))
+                throw new ApplicationException(
+                    $"WebSettings:Authentication:Keycloak:RoleMappings:{roleName} must be configured when Mode=Keycloak");
+        }
+    }
+}

--- a/src/web/Fig.Web/Services/HttpService.cs
+++ b/src/web/Fig.Web/Services/HttpService.cs
@@ -11,7 +11,11 @@ using Fig.Contracts.Json;
 using Fig.Contracts.SettingDefinitions;
 using Fig.Web.Models.Authentication;
 using Fig.Web.Notifications;
+using Fig.Web.Services.Authentication;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using Radzen;
 
@@ -24,13 +28,17 @@ public class HttpService : IHttpService
     private readonly NotificationService _notificationService;
     private readonly INotificationFactory _notificationFactory;
     private readonly NavigationManager _navigationManager;
+    private readonly WebAuthMode _authenticationMode;
+    private readonly IServiceProvider _serviceProvider;
 
     public HttpService(
         IHttpClientFactory httpClientFactory,
         NavigationManager navigationManager,
         ILocalStorageService localStorageService,
         NotificationService notificationService,
-        INotificationFactory notificationFactory)
+        INotificationFactory notificationFactory,
+        IOptions<WebSettings> webSettings,
+        IServiceProvider serviceProvider)
     {
         _httpClient = httpClientFactory.CreateClient(HttpClientNames.FigApi);
         _httpClient.Timeout = TimeSpan.FromHours(1);
@@ -38,6 +46,8 @@ public class HttpService : IHttpService
         _localStorageService = localStorageService;
         _notificationService = notificationService;
         _notificationFactory = notificationFactory;
+        _authenticationMode = webSettings.Value.Authentication.Mode;
+        _serviceProvider = serviceProvider;
         Console.WriteLine($"Initializing httpservice with API address {_httpClient.BaseAddress}");
     }
 
@@ -154,7 +164,7 @@ public class HttpService : IHttpService
     {
         var request = new HttpRequestMessage(method, uri);
 
-        // Add Accept-Encoding header for compression support (GZip only)
+        // Add Accept-Encoding header for Brotli compression support
         request.Headers.AcceptEncoding.Add(new StringWithQualityHeaderValue("br"));
 
         if (value != null)
@@ -406,10 +416,28 @@ public class HttpService : IHttpService
         if (!addJwtHeader)
             return;
 
-        // add jwt auth header if user is logged in and request is to the api url
-        var user = await _localStorageService.GetItem<AuthenticatedUserModel>("user");
         var isApiUrl = !request.RequestUri?.IsAbsoluteUri == true;
-        if (user != null && isApiUrl)
+        if (!isApiUrl)
+            return;
+
+        if (_authenticationMode == WebAuthMode.Keycloak)
+        {
+            var accessTokenProvider = _serviceProvider.GetService<IAccessTokenProvider>();
+            if (accessTokenProvider != null)
+            {
+                var tokenResult = await accessTokenProvider.RequestAccessToken();
+                if (tokenResult.TryGetToken(out var token))
+                {
+                    request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token.Value);
+                }
+            }
+
+            return;
+        }
+
+        var user = await _localStorageService.GetItem<AuthenticatedUserModel>(
+            WebAuthenticationConstants.AuthenticatedUserStorageKey);
+        if (user != null && !string.IsNullOrWhiteSpace(user.Token))
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", user.Token);
     }
 

--- a/src/web/Fig.Web/Services/HttpService.cs
+++ b/src/web/Fig.Web/Services/HttpService.cs
@@ -9,13 +9,9 @@ using Fig.Contracts.Constants;
 using Fig.Contracts.Diagnostics;
 using Fig.Contracts.Json;
 using Fig.Contracts.SettingDefinitions;
-using Fig.Web.Models.Authentication;
 using Fig.Web.Notifications;
 using Fig.Web.Services.Authentication;
 using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using Radzen;
 
@@ -24,30 +20,24 @@ namespace Fig.Web.Services;
 public class HttpService : IHttpService
 {
     private readonly HttpClient _httpClient;
-    private readonly ILocalStorageService _localStorageService;
+    private readonly IFigApiAccessTokenProvider _accessTokenProvider;
     private readonly NotificationService _notificationService;
     private readonly INotificationFactory _notificationFactory;
     private readonly NavigationManager _navigationManager;
-    private readonly WebAuthMode _authenticationMode;
-    private readonly IServiceProvider _serviceProvider;
 
     public HttpService(
         IHttpClientFactory httpClientFactory,
         NavigationManager navigationManager,
-        ILocalStorageService localStorageService,
+        IFigApiAccessTokenProvider accessTokenProvider,
         NotificationService notificationService,
-        INotificationFactory notificationFactory,
-        IOptions<WebSettings> webSettings,
-        IServiceProvider serviceProvider)
+        INotificationFactory notificationFactory)
     {
         _httpClient = httpClientFactory.CreateClient(HttpClientNames.FigApi);
         _httpClient.Timeout = TimeSpan.FromHours(1);
         _navigationManager = navigationManager;
-        _localStorageService = localStorageService;
+        _accessTokenProvider = accessTokenProvider;
         _notificationService = notificationService;
         _notificationFactory = notificationFactory;
-        _authenticationMode = webSettings.Value.Authentication.Mode;
-        _serviceProvider = serviceProvider;
         Console.WriteLine($"Initializing httpservice with API address {_httpClient.BaseAddress}");
     }
 
@@ -420,25 +410,9 @@ public class HttpService : IHttpService
         if (!isApiUrl)
             return;
 
-        if (_authenticationMode == WebAuthMode.Keycloak)
-        {
-            var accessTokenProvider = _serviceProvider.GetService<IAccessTokenProvider>();
-            if (accessTokenProvider != null)
-            {
-                var tokenResult = await accessTokenProvider.RequestAccessToken();
-                if (tokenResult.TryGetToken(out var token))
-                {
-                    request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token.Value);
-                }
-            }
-
-            return;
-        }
-
-        var user = await _localStorageService.GetItem<AuthenticatedUserModel>(
-            WebAuthenticationConstants.AuthenticatedUserStorageKey);
-        if (user != null && !string.IsNullOrWhiteSpace(user.Token))
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", user.Token);
+        var token = await _accessTokenProvider.GetAccessTokenAsync();
+        if (!string.IsNullOrWhiteSpace(token))
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
     }
 
     private void HandleUnauthorizedResponse(HttpRequestMessage request)

--- a/src/web/Fig.Web/Shared/MainLayout.razor
+++ b/src/web/Fig.Web/Shared/MainLayout.razor
@@ -37,7 +37,10 @@
                 @if (AccountService?.AuthenticatedUser?.Role == Role.Administrator)
                 {
                     <NavLink href="groups" class="nav-item nav-link">Groups</NavLink>
-                    <NavLink href="users" class="nav-item nav-link">Users</NavLink>
+                    @if (AccountService.AuthenticationMode != WebAuthMode.Keycloak)
+                    {
+                        <NavLink href="users" class="nav-item nav-link">Users</NavLink>
+                    }
                     <NavLink href="clients" class="nav-item nav-link" style="display: flex; align-items: center; gap: 0.5rem;">
                         Connected Clients
                         @if (ClientStatusFacade.ConnectedClientsCount > 0)
@@ -123,8 +126,8 @@
 
                         <p class="text-center fs-3" style="margin: 0">@AccountService?.AuthenticatedUser?.Username</p>
                         <p class="text-center fst-italic">@AccountService?.AuthenticatedUser?.Role</p>
-                        <RadzenProfileMenuItem class="match-navbar-background" Text="Account" Path="account/manage" Icon="account_circle"/>
-                        <RadzenProfileMenuItem class="match-navbar-background" Text="Logout" Path="account/logout" Icon="logout"/>
+                        <RadzenProfileMenuItem class="match-navbar-background" Text="Account" Path="/account/manage" Icon="account_circle"/>
+                        <RadzenProfileMenuItem class="match-navbar-background" Text="Logout" Path="/account/logout" Icon="logout"/>
                     </ChildContent>
                 </RadzenProfileMenu>
             </div>

--- a/src/web/Fig.Web/WebSettings.cs
+++ b/src/web/Fig.Web/WebSettings.cs
@@ -1,10 +1,68 @@
 namespace Fig.Web;
 
+using Fig.Contracts.Authentication;
+
 public class WebSettings
 {
     public string ApiUri { get; set; } = "https://localhost:7281";
     
     public string? Environment { get; set; }
+
+    public WebAuthenticationSettings Authentication { get; set; } = new();
     
     public bool DefaultDisplayCollapsed { get; set; } = true;
+}
+
+public class WebAuthenticationSettings
+{
+    public WebAuthMode Mode { get; set; } = WebAuthMode.FigManaged;
+
+    public WebKeycloakAuthenticationSettings Keycloak { get; set; } = new();
+}
+
+public enum WebAuthMode
+{
+    FigManaged,
+    Keycloak
+}
+
+public class WebKeycloakAuthenticationSettings
+{
+    private static readonly Dictionary<string, string[]> DefaultRoleMappings = new(StringComparer.OrdinalIgnoreCase)
+    {
+        [Role.Administrator.ToString()] = ["Administrator", "/fig/Administrator"],
+        [Role.User.ToString()] = ["User", "/fig/User"],
+        [Role.ReadOnly.ToString()] = ["ReadOnly", "/fig/ReadOnly"],
+        [Role.LookupService.ToString()] = ["LookupService", "/fig/LookupService"]
+    };
+
+    public string? Authority { get; set; }
+
+    public string? ClientId { get; set; }
+
+    public string Scopes { get; set; } = "openid profile email";
+
+    public string ApiScope { get; set; } = string.Empty;
+
+    public string ResponseType { get; set; } = "code";
+
+    public string? PostLogoutRedirectUri { get; set; }
+
+    public string? AccountManagementUrl { get; set; }
+
+    public string UsernameClaim { get; set; } = "preferred_username";
+
+    public string FirstNameClaim { get; set; } = "given_name";
+
+    public string LastNameClaim { get; set; } = "family_name";
+
+    public string NameClaim { get; set; } = "name";
+
+    public List<string> RoleClaimPaths { get; set; } = ["groups", "realm_access.roles", "resource_access.fig.roles"];
+
+    public string AllowedClassificationsClaim { get; set; } = "fig_allowed_classifications";
+
+    public string AdminRoleName { get; set; } = "Administrator";
+
+    public Dictionary<string, string[]> RoleMappings { get; set; } = new(DefaultRoleMappings, StringComparer.OrdinalIgnoreCase);
 }

--- a/src/web/Fig.Web/WebSettings.cs
+++ b/src/web/Fig.Web/WebSettings.cs
@@ -50,6 +50,27 @@ public class WebKeycloakAuthenticationSettings
 
     public string? AccountManagementUrl { get; set; }
 
+    /// <summary>
+    /// Keycloak identity provider alias sent as OIDC <c>kc_idp_hint</c> (e.g. <c>entra-id</c>).
+    /// When set and <see cref="EnableIdentityProviderHint"/> is true, Keycloak skips its login page and brokers to that IdP.
+    /// </summary>
+    public string? IdentityProviderHint { get; set; }
+
+    /// <summary>
+    /// When false, <see cref="IdentityProviderHint"/> is not sent even if configured.
+    /// </summary>
+    public bool EnableIdentityProviderHint { get; set; } = true;
+
+    /// <summary>
+    /// Optional OIDC <c>prompt</c> for normal logins (usually empty for seamless IdP SSO).
+    /// </summary>
+    public string? LoginPrompt { get; set; }
+
+    /// <summary>
+    /// OIDC <c>prompt</c> applied on the first login after logout so the user can pick another account.
+    /// </summary>
+    public string? PostLogoutLoginPrompt { get; set; } = "select_account";
+
     public string UsernameClaim { get; set; } = "preferred_username";
 
     public string FirstNameClaim { get; set; } = "given_name";

--- a/src/web/Fig.Web/wwwroot/appsettings.Keycloak.json
+++ b/src/web/Fig.Web/wwwroot/appsettings.Keycloak.json
@@ -1,0 +1,16 @@
+{
+  "WebSettings": {
+    "Authentication": {
+      "Mode": "Keycloak",
+      "Keycloak": {
+        "Authority": "http://localhost:8085/realms/fig",
+        "ClientId": "fig-web",
+        "Scopes": "openid profile email roles",
+        "ApiScope": "",
+        "ResponseType": "code",
+        "PostLogoutRedirectUri": "https://localhost:7148/",
+        "AccountManagementUrl": "http://localhost:8085/realms/fig/account/"
+      }
+    }
+  }
+}

--- a/src/web/Fig.Web/wwwroot/appsettings.json
+++ b/src/web/Fig.Web/wwwroot/appsettings.json
@@ -2,6 +2,47 @@
   "WebSettings": {
     "ApiUri": "https://localhost:7281",
     "Environment": "Development",
+    "Authentication": {
+      "Mode": "FigManaged",
+      "Keycloak": {
+        "Authority": "",
+        "ClientId": "",
+        "Scopes": "openid profile email",
+        "ApiScope": "",
+        "ResponseType": "code",
+        "PostLogoutRedirectUri": "",
+        "AccountManagementUrl": "",
+        "UsernameClaim": "preferred_username",
+        "FirstNameClaim": "given_name",
+        "LastNameClaim": "family_name",
+        "NameClaim": "name",
+        "RoleClaimPaths": [
+          "groups",
+          "realm_access.roles",
+          "resource_access.fig.roles"
+        ],
+        "RoleMappings": {
+          "Administrator": [
+            "Administrator",
+            "/fig/Administrator"
+          ],
+          "User": [
+            "User",
+            "/fig/User"
+          ],
+          "ReadOnly": [
+            "ReadOnly",
+            "/fig/ReadOnly"
+          ],
+          "LookupService": [
+            "LookupService",
+            "/fig/LookupService"
+          ]
+        },
+        "AllowedClassificationsClaim": "fig_allowed_classifications",
+        "AdminRoleName": "Administrator"
+      }
+    },
     "DefaultDisplayCollapsed": true
   }
 }

--- a/src/web/Fig.Web/wwwroot/index.html
+++ b/src/web/Fig.Web/wwwroot/index.html
@@ -58,6 +58,7 @@
     <a class="reload" href="">Reload</a>
     <a class="dismiss">🗙</a>
 </div>
+<script src="_content/Microsoft.AspNetCore.Components.WebAssembly.Authentication/AuthenticationService.js"></script>
 <script src="_framework/blazor.webassembly.js"></script>
 <script src="_content/Radzen.Blazor/Radzen.Blazor.js"></script>
 <script src="js/checkbox-handler.js"></script>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dual authentication modes (Fig-managed default and optional Keycloak) with role/classification claim mapping.
  * In Keycloak mode, user-management endpoints/UI actions are disabled (e.g., `/users/authenticate` returns 404) while client/machine-client flows continue.
  * Updated web login/account experiences and platform/report summaries to reflect Keycloak-managed users (e.g., “External (Keycloak)” and Keycloak-specific Access & Privilege behavior).
* **Bug Fixes**
  * Improved value-only import/export error detection for decryption-key-required cases.
* **Documentation**
  * Added README and security/user-management docs for Keycloak setup, endpoint differences, rollback, and troubleshooting.
* **Tests**
  * Added Keycloak-mode integration and regression coverage for authentication/authorization and machine-client registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->