### PR TITLE
Add warning if the heading will be on an advanced setting

### DIFF
--- a/src/client/Fig.Client/ConfigurationProvider/FigConfigurationProvider.cs
+++ b/src/client/Fig.Client/ConfigurationProvider/FigConfigurationProvider.cs
@@ -174,6 +174,20 @@ public class FigConfigurationProvider : Microsoft.Extensions.Configuration.Confi
     private SettingsClientDefinitionDataContract BuildSettingsDefinition()
     {
         var settingsDataContract = _settings.CreateDataContract(_source.ClientName, _source.AutomaticallyGenerateHeadings);
+
+        foreach (var warning in SettingDefinitionWarnings.GetHiddenCategoryHeadingWarnings(settingsDataContract.Settings))
+        {
+            _logger.LogWarning(
+                "Category '{CategoryName}' for client {ClientName}: the category heading is on advanced setting '{FirstSettingName}', " +
+                "but non-advanced settings follow in the same category ({NonAdvancedSettingNames}). " +
+                "Move the non-advanced setting(s) above '{FirstSettingName}' in your settings class so the category heading remains visible when advanced settings are hidden.",
+                warning.CategoryName,
+                _source.ClientName,
+                warning.FirstSettingName,
+                string.Join(", ", warning.NonAdvancedSettingNames),
+                warning.FirstSettingName);
+        }
+
         _secretSettings = settingsDataContract.Settings
             .Where(a => a.IsSecret)
             .Select(a => a.Name)

--- a/src/client/Fig.Client/SettingDefinitionWarnings.cs
+++ b/src/client/Fig.Client/SettingDefinitionWarnings.cs
@@ -1,0 +1,69 @@
+using System.Collections.Generic;
+using System.Linq;
+using Fig.Contracts.SettingDefinitions;
+
+namespace Fig.Client;
+
+internal static class SettingDefinitionWarnings
+{
+    internal sealed class HiddenCategoryHeadingWarning
+    {
+        public required string CategoryName { get; init; }
+        public required string FirstSettingName { get; init; }
+        public required IReadOnlyList<string> NonAdvancedSettingNames { get; init; }
+    }
+
+    internal static IEnumerable<HiddenCategoryHeadingWarning> GetHiddenCategoryHeadingWarnings(
+        IReadOnlyList<SettingDefinitionDataContract> settings)
+    {
+        var orderedSettings = settings
+            .OrderBy(s => s.DisplayOrder ?? int.MaxValue)
+            .ToList();
+
+        var categoryLeaders = new Dictionary<string, SettingDefinitionDataContract>();
+
+        foreach (var setting in orderedSettings)
+        {
+            if (string.IsNullOrEmpty(setting.CategoryName))
+            {
+                continue;
+            }
+
+            if (!categoryLeaders.ContainsKey(setting.CategoryName))
+            {
+                categoryLeaders[setting.CategoryName] = setting;
+            }
+        }
+
+        foreach (var categoryLeader in categoryLeaders)
+        {
+            var categoryName = categoryLeader.Key;
+            var leader = categoryLeader.Value;
+
+            if (leader.Heading?.Advanced != true)
+            {
+                continue;
+            }
+
+            var leaderDisplayOrder = leader.DisplayOrder ?? int.MaxValue;
+            var nonAdvancedFollowers = orderedSettings
+                .Where(s => s.CategoryName == categoryName
+                            && (s.DisplayOrder ?? int.MaxValue) > leaderDisplayOrder
+                            && !s.Advanced)
+                .Select(s => s.Name)
+                .ToList();
+
+            if (nonAdvancedFollowers.Count == 0)
+            {
+                continue;
+            }
+
+            yield return new HiddenCategoryHeadingWarning
+            {
+                CategoryName = categoryName,
+                FirstSettingName = leader.Name,
+                NonAdvancedSettingNames = nonAdvancedFollowers
+            };
+        }
+    }
+}

--- a/src/tests/Fig.Unit.Test/Client/CategoryAdvancedOrderingWarningTests.cs
+++ b/src/tests/Fig.Unit.Test/Client/CategoryAdvancedOrderingWarningTests.cs
@@ -1,0 +1,192 @@
+using System.Collections.Generic;
+using System.Linq;
+using Fig.Client;
+using Fig.Client.Abstractions.Attributes;
+using NUnit.Framework;
+
+namespace Fig.Unit.Test.Client;
+
+[TestFixture]
+public class CategoryAdvancedOrderingWarningTests
+{
+    [Test]
+    public void GetHiddenCategoryHeadingWarnings_WhenAdvancedFirstAndNonAdvancedSecondInSameCategory_ReturnsWarning()
+    {
+        var settings = new TestSettingsWithAdvancedFirstInCategory();
+        var dataContract = settings.CreateDataContract("TestClient");
+
+        var warnings = SettingDefinitionWarnings.GetHiddenCategoryHeadingWarnings(dataContract.Settings).ToList();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(warnings, Has.Count.EqualTo(1));
+            Assert.That(warnings[0].CategoryName, Is.EqualTo("Database"));
+            Assert.That(warnings[0].FirstSettingName, Is.EqualTo("AdvancedFirstSetting"));
+            Assert.That(warnings[0].NonAdvancedSettingNames, Is.EquivalentTo(new[] { "NonAdvancedSecondSetting" }));
+        });
+    }
+
+    [Test]
+    public void GetHiddenCategoryHeadingWarnings_WhenAllSettingsInCategoryAreAdvanced_ReturnsNoWarnings()
+    {
+        var settings = new TestSettingsWithAllAdvancedInCategory();
+        var dataContract = settings.CreateDataContract("TestClient");
+
+        var warnings = SettingDefinitionWarnings.GetHiddenCategoryHeadingWarnings(dataContract.Settings).ToList();
+
+        Assert.That(warnings, Is.Empty);
+    }
+
+    [Test]
+    public void GetHiddenCategoryHeadingWarnings_WhenNonAdvancedFirstInCategory_ReturnsNoWarnings()
+    {
+        var settings = new TestSettingsWithNonAdvancedFirstInCategory();
+        var dataContract = settings.CreateDataContract("TestClient");
+
+        var warnings = SettingDefinitionWarnings.GetHiddenCategoryHeadingWarnings(dataContract.Settings).ToList();
+
+        Assert.That(warnings, Is.Empty);
+    }
+
+    [Test]
+    public void GetHiddenCategoryHeadingWarnings_WhenCategoriesAreInterleaved_ReturnsWarningForAffectedCategory()
+    {
+        var settings = new TestSettingsWithInterleavedAdvancedCategory();
+        var dataContract = settings.CreateDataContract("TestClient");
+
+        var warnings = SettingDefinitionWarnings.GetHiddenCategoryHeadingWarnings(dataContract.Settings).ToList();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(warnings, Has.Count.EqualTo(1));
+            Assert.That(warnings[0].CategoryName, Is.EqualTo("Database"));
+            Assert.That(warnings[0].FirstSettingName, Is.EqualTo("Database1"));
+            Assert.That(warnings[0].NonAdvancedSettingNames, Is.EquivalentTo(new[] { "Database2" }));
+        });
+    }
+
+    [Test]
+    public void GetHiddenCategoryHeadingWarnings_WhenNoCategoryOnSettings_ReturnsNoWarnings()
+    {
+        var settings = new TestSettingsWithoutCategoryForWarnings();
+        var dataContract = settings.CreateDataContract("TestClient");
+
+        var warnings = SettingDefinitionWarnings.GetHiddenCategoryHeadingWarnings(dataContract.Settings).ToList();
+
+        Assert.That(warnings, Is.Empty);
+    }
+
+    [Test]
+    public void GetHiddenCategoryHeadingWarnings_WhenMultipleNonAdvancedFollowers_ListsAllFollowers()
+    {
+        var settings = new TestSettingsWithMultipleNonAdvancedFollowers();
+        var dataContract = settings.CreateDataContract("TestClient");
+
+        var warnings = SettingDefinitionWarnings.GetHiddenCategoryHeadingWarnings(dataContract.Settings).ToList();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(warnings, Has.Count.EqualTo(1));
+            Assert.That(warnings[0].NonAdvancedSettingNames, Is.EquivalentTo(new[] { "SecondSetting", "ThirdSetting" }));
+        });
+    }
+
+    private class TestSettingsWithAdvancedFirstInCategory : SettingsBase
+    {
+        public override string ClientDescription => "Test settings";
+
+        [Setting("Advanced first setting")]
+        [Fig.Client.Abstractions.Attributes.Category("Database", "#0066CC")]
+        [Advanced]
+        public string AdvancedFirstSetting { get; set; } = "default";
+
+        [Setting("Non-advanced second setting")]
+        [Fig.Client.Abstractions.Attributes.Category("Database", "#0066CC")]
+        public string NonAdvancedSecondSetting { get; set; } = "default";
+
+        public override IEnumerable<string> GetValidationErrors() => [];
+    }
+
+    private class TestSettingsWithAllAdvancedInCategory : SettingsBase
+    {
+        public override string ClientDescription => "Test settings";
+
+        [Setting("Advanced first setting")]
+        [Fig.Client.Abstractions.Attributes.Category("Database", "#0066CC")]
+        [Advanced]
+        public string AdvancedFirstSetting { get; set; } = "default";
+
+        [Setting("Advanced second setting")]
+        [Fig.Client.Abstractions.Attributes.Category("Database", "#0066CC")]
+        [Advanced]
+        public string AdvancedSecondSetting { get; set; } = "default";
+
+        public override IEnumerable<string> GetValidationErrors() => [];
+    }
+
+    private class TestSettingsWithNonAdvancedFirstInCategory : SettingsBase
+    {
+        public override string ClientDescription => "Test settings";
+
+        [Setting("Non-advanced first setting")]
+        [Fig.Client.Abstractions.Attributes.Category("Database", "#0066CC")]
+        public string NonAdvancedFirstSetting { get; set; } = "default";
+
+        [Setting("Advanced second setting")]
+        [Fig.Client.Abstractions.Attributes.Category("Database", "#0066CC")]
+        [Advanced]
+        public string AdvancedSecondSetting { get; set; } = "default";
+
+        public override IEnumerable<string> GetValidationErrors() => [];
+    }
+
+    private class TestSettingsWithInterleavedAdvancedCategory : SettingsBase
+    {
+        public override string ClientDescription => "Test settings";
+
+        [Setting("First database setting")]
+        [Fig.Client.Abstractions.Attributes.Category("Database", "#0066CC")]
+        [Advanced]
+        public string Database1 { get; set; } = "default";
+
+        [Setting("Logging setting")]
+        [Fig.Client.Abstractions.Attributes.Category("Logging", "#FF6600")]
+        public string Logging1 { get; set; } = "default";
+
+        [Setting("Second database setting")]
+        [Fig.Client.Abstractions.Attributes.Category("Database", "#0066CC")]
+        public string Database2 { get; set; } = "default";
+
+        public override IEnumerable<string> GetValidationErrors() => [];
+    }
+
+    private class TestSettingsWithoutCategoryForWarnings : SettingsBase
+    {
+        public override string ClientDescription => "Test settings";
+
+        [Setting("Setting without category")]
+        public string SettingWithoutCategory { get; set; } = "default";
+
+        public override IEnumerable<string> GetValidationErrors() => [];
+    }
+
+    private class TestSettingsWithMultipleNonAdvancedFollowers : SettingsBase
+    {
+        public override string ClientDescription => "Test settings";
+
+        [Setting("Advanced first setting")]
+        [Fig.Client.Abstractions.Attributes.Category("Database", "#0066CC")]
+        [Advanced]
+        public string FirstSetting { get; set; } = "default";
+
+        [Setting("Non-advanced second setting")]
+        [Fig.Client.Abstractions.Attributes.Category("Database", "#0066CC")]
+        public string SecondSetting { get; set; } = "default";
+
+        [Setting("Non-advanced third setting")]
+        [Fig.Client.Abstractions.Attributes.Category("Database", "#0066CC")]
+        public string ThirdSetting { get; set; } = "default";
+
+        public override IEnumerable<string> GetValidationErrors() => [];
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added warnings when advanced settings appear before non-advanced settings in the same category, helping identify potentially hidden category headings.
  * Warning details now include the affected category and setting names.

* **Tests**
  * Added coverage for advanced-setting ordering, interleaved categories, multiple affected settings, and categories without applicable settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->