### PR TITLE
Improve performance of release highlights request by not calling GitH…

### DIFF
--- a/doc/fig-documentation/docs/api-configuration.md
+++ b/doc/fig-documentation/docs/api-configuration.md
@@ -42,10 +42,17 @@ There are the following settings:
 
     // Optional. Absolute path for file-based imports. Empty or invalid disables file import.
     "ImportFolderPath": "",
+
+    // When true (default), the API periodically checks GitHub for newer Fig releases
+    // to surface a "new release available" highlight. Set to false on hosts without
+    // outbound internet access (or via ApiSettings__EnableGitHubReleaseDiscovery=false).
+    "EnableGitHubReleaseDiscovery": true,
   },
 ```
 
 File-based imports are only enabled when `ImportFolderPath` is set to a valid, writable absolute path. When the value is empty or invalid, the import background service is not registered and file imports are disabled.
+
+GitHub release discovery is enabled by default. When disabled, the API does not make outbound calls to GitHub; the "new release available" highlight will not appear. Static release highlights shipped with Fig.Web are unaffected.
 
 :::warning Security Considerations
 The configured import folder path requires write access and any JSON files placed in this directory will be automatically processed and deleted by the Fig API. When configuring this path:

--- a/doc/fig-documentation/versioned_docs/version-3.x/api-configuration.md
+++ b/doc/fig-documentation/versioned_docs/version-3.x/api-configuration.md
@@ -42,10 +42,17 @@ There are the following settings:
 
     // Optional. Absolute path for file-based imports. Empty or invalid disables file import.
     "ImportFolderPath": "",
+
+    // When true (default), the API periodically checks GitHub for newer Fig releases
+    // to surface a "new release available" highlight. Set to false on hosts without
+    // outbound internet access (or via ApiSettings__EnableGitHubReleaseDiscovery=false).
+    "EnableGitHubReleaseDiscovery": true,
   },
 ```
 
 File-based imports are only enabled when `ImportFolderPath` is set to a valid, writable absolute path. When the value is empty or invalid, the import background service is not registered and file imports are disabled.
+
+GitHub release discovery is enabled by default. When disabled, the API does not make outbound calls to GitHub; the "new release available" highlight will not appear. Static release highlights shipped with Fig.Web are unaffected.
 
 :::warning Security Considerations
 The configured import folder path requires write access and any JSON files placed in this directory will be automatically processed and deleted by the Fig API. When configuring this path:

--- a/src/api/Fig.Api/ApiSettings.cs
+++ b/src/api/Fig.Api/ApiSettings.cs
@@ -40,6 +40,13 @@ public class ApiSettings
     /// and then to the host's default proxy behavior.
     /// </summary>
     public string? OutboundHttpProxyAddress { get; set; }
+
+    /// <summary>
+    /// When true (default), Fig.Api periodically checks GitHub for newer Fig releases
+    /// to surface a "new release available" highlight. Set to false on hosts without
+    /// outbound internet access.
+    /// </summary>
+    public bool EnableGitHubReleaseDiscovery { get; set; } = true;
     
     /// <summary>
     /// Cache expiry time in minutes for hash validation results.

--- a/src/api/Fig.Api/Program.cs
+++ b/src/api/Fig.Api/Program.cs
@@ -224,6 +224,7 @@ builder.Services.AddHostedService<TimeMachineWorker>();
 builder.Services.AddHostedService<WebHookProcessorWorker>();
 builder.Services.AddHostedService<SessionCleanupWorker>();
 builder.Services.AddHostedService<DataCleanupWorker>();
+builder.Services.AddHostedService<ReleaseDiscoveryWorker>();
 
 builder.Services.AddScoped<IAuthenticatedService>(a => a.GetService<IConfigurationService>()!);
 builder.Services.AddScoped<IAuthenticatedService>(a => a.GetService<IEventsService>()!);

--- a/src/api/Fig.Api/Services/GitHubReleaseDiscoveryService.cs
+++ b/src/api/Fig.Api/Services/GitHubReleaseDiscoveryService.cs
@@ -62,6 +62,12 @@ public partial class GitHubReleaseDiscoveryService : IFigReleaseDiscoveryService
 
     public async Task RefreshAsync()
     {
+        if (!_apiSettings.CurrentValue.EnableGitHubReleaseDiscovery)
+        {
+            _logger.LogDebug("Skipping GitHub release discovery because EnableGitHubReleaseDiscovery is false");
+            return;
+        }
+
         var (completed, result) = await TryFetchNewestAvailableReleaseHighlight();
         if (!completed)
         {

--- a/src/api/Fig.Api/Services/GitHubReleaseDiscoveryService.cs
+++ b/src/api/Fig.Api/Services/GitHubReleaseDiscoveryService.cs
@@ -6,16 +6,22 @@ using Fig.Contracts.ReleaseHighlights;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
 
 namespace Fig.Api.Services;
 
 public partial class GitHubReleaseDiscoveryService : IFigReleaseDiscoveryService
 {
     private const string ReleaseFeatureKey = "new-release-available";
-    private const string ReleasesUrl = "https://github.com/mzbrau/fig/releases";
+    private const string LatestReleaseUrl = "https://api.github.com/repos/mzbrau/fig/releases/latest";
     private const string PlaceholderImagePath = "images/release-highlights/shared/new-release.png";
     private const string CacheKey = "fig_github_newest_release";
     private static readonly TimeSpan CacheDuration = TimeSpan.FromHours(1);
+    private static readonly JsonSerializerSettings GitHubJsonSettings = new()
+    {
+        TypeNameHandling = TypeNameHandling.None
+    };
+
     private readonly IOptionsMonitor<ApiSettings> _apiSettings;
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly IMemoryCache _memoryCache;
@@ -36,14 +42,18 @@ public partial class GitHubReleaseDiscoveryService : IFigReleaseDiscoveryService
         _logger = logger;
     }
 
-    public async Task<ReleaseHighlightCatalogItemDataContract?> GetNewestAvailableReleaseHighlight()
+    public Task<ReleaseHighlightCatalogItemDataContract?> GetNewestAvailableReleaseHighlight()
     {
         if (_memoryCache.TryGetValue(CacheKey, out ReleaseHighlightCatalogItemDataContract? cached))
-            return cached;
+            return Task.FromResult(cached);
 
+        return Task.FromResult<ReleaseHighlightCatalogItemDataContract?>(null);
+    }
+
+    public async Task RefreshAsync()
+    {
         var result = await FetchNewestAvailableReleaseHighlight();
         _memoryCache.Set(CacheKey, result, CacheDuration);
-        return result;
     }
 
     private async Task<ReleaseHighlightCatalogItemDataContract?> FetchNewestAvailableReleaseHighlight()
@@ -59,9 +69,9 @@ public partial class GitHubReleaseDiscoveryService : IFigReleaseDiscoveryService
             var clientLease = CreateClient();
             try
             {
-                using var request = new HttpRequestMessage(HttpMethod.Get, ReleasesUrl);
+                using var request = new HttpRequestMessage(HttpMethod.Get, LatestReleaseUrl);
                 request.Headers.UserAgent.Add(new ProductInfoHeaderValue("Fig.Api", "1.0"));
-                request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/html"));
+                request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
 
                 using var response = await clientLease.Client.SendAsync(request);
                 if (!response.IsSuccessStatusCode)
@@ -70,19 +80,29 @@ public partial class GitHubReleaseDiscoveryService : IFigReleaseDiscoveryService
                     return null;
                 }
 
-                var html = await response.Content.ReadAsStringAsync();
-                var release = FindNewestRelease(html, currentVersion);
-                if (release == null)
+                var json = await response.Content.ReadAsStringAsync();
+                var release = JsonConvert.DeserializeObject<GitHubReleaseResponse>(json, GitHubJsonSettings);
+                if (release == null || string.IsNullOrWhiteSpace(release.TagName))
                     return null;
 
+                if (!TryParseNormalizedVersion(release.TagName, out var releaseVersion, out var releaseVersionText))
+                    return null;
+
+                if (releaseVersion <= currentVersion)
+                    return null;
+
+                var releaseUrl = string.IsNullOrWhiteSpace(release.HtmlUrl)
+                    ? $"https://github.com/mzbrau/fig/releases/tag/{release.TagName.Trim()}"
+                    : release.HtmlUrl;
+
                 return new ReleaseHighlightCatalogItemDataContract(
-                    release.ReleaseVersion,
+                    releaseVersionText,
                     ReleaseFeatureKey,
-                    $"Fig v{release.ReleaseVersion} is available",
-                    $"A newer Fig release is available. You're currently running Fig v{currentVersionText}. Review the release notes for v{release.ReleaseVersion}.",
+                    $"Fig v{releaseVersionText} is available",
+                    $"A newer Fig release is available. You're currently running Fig v{currentVersionText}. Review the release notes for v{releaseVersionText}.",
                     PlaceholderImagePath,
                     int.MaxValue,
-                    release.ReleaseUrl,
+                    releaseUrl,
                     markViewedOnDisplay: false);
             }
             finally
@@ -142,34 +162,6 @@ public partial class GitHubReleaseDiscoveryService : IFigReleaseDiscoveryService
         return client;
     }
 
-    private static ReleaseCandidate? FindNewestRelease(string html, Version currentVersion)
-    {
-        var releases = ReleaseLinkRegex()
-            .Matches(html)
-            .Select(match => CreateCandidate(
-                WebUtility.HtmlDecode(match.Groups["tag"].Value),
-                WebUtility.HtmlDecode(match.Groups["path"].Value)))
-            .Where(candidate => candidate != null)
-            .Cast<ReleaseCandidate>()
-            .GroupBy(candidate => candidate.ReleaseVersion, StringComparer.OrdinalIgnoreCase)
-            .Select(group => group.First())
-            .OrderByDescending(candidate => candidate.NormalizedVersion)
-            .ToList();
-
-        return releases.FirstOrDefault(candidate => candidate.NormalizedVersion > currentVersion);
-    }
-
-    private static ReleaseCandidate? CreateCandidate(string rawTag, string relativePath)
-    {
-        if (!TryParseNormalizedVersion(rawTag, out var normalizedVersion, out var releaseVersion))
-            return null;
-
-        return new ReleaseCandidate(
-            normalizedVersion,
-            releaseVersion,
-            new Uri(new Uri(ReleasesUrl), relativePath).ToString());
-    }
-
     private static bool TryParseNormalizedVersion(string versionText, out Version normalizedVersion, out string releaseVersion)
     {
         var match = SemanticVersionRegex().Match(versionText);
@@ -192,10 +184,14 @@ public partial class GitHubReleaseDiscoveryService : IFigReleaseDiscoveryService
 
     private sealed record HttpClientLease(HttpClient Client, bool DisposeClient);
 
-    private sealed record ReleaseCandidate(Version NormalizedVersion, string ReleaseVersion, string ReleaseUrl);
+    private sealed class GitHubReleaseResponse
+    {
+        [JsonProperty("tag_name")]
+        public string? TagName { get; set; }
 
-    [GeneratedRegex("href=\"(?<path>/mzbrau/fig/releases/tag/(?<tag>[^\"]+))\"", RegexOptions.IgnoreCase)]
-    private static partial Regex ReleaseLinkRegex();
+        [JsonProperty("html_url")]
+        public string? HtmlUrl { get; set; }
+    }
 
     [GeneratedRegex("\\d+\\.\\d+(?:\\.\\d+){0,2}")]
     private static partial Regex SemanticVersionRegex();

--- a/src/api/Fig.Api/Services/GitHubReleaseDiscoveryService.cs
+++ b/src/api/Fig.Api/Services/GitHubReleaseDiscoveryService.cs
@@ -16,30 +16,40 @@ public partial class GitHubReleaseDiscoveryService : IFigReleaseDiscoveryService
     private const string LatestReleaseUrl = "https://api.github.com/repos/mzbrau/fig/releases/latest";
     private const string PlaceholderImagePath = "images/release-highlights/shared/new-release.png";
     private const string CacheKey = "fig_github_newest_release";
-    private static readonly TimeSpan CacheDuration = TimeSpan.FromHours(1);
+    private static readonly TimeSpan CacheDuration = TimeSpan.FromHours(24);
     private static readonly JsonSerializerSettings GitHubJsonSettings = new()
     {
         TypeNameHandling = TypeNameHandling.None
     };
 
     private readonly IOptionsMonitor<ApiSettings> _apiSettings;
-    private readonly IHttpClientFactory _httpClientFactory;
     private readonly IMemoryCache _memoryCache;
     private readonly IVersionHelper _versionHelper;
     private readonly ILogger<GitHubReleaseDiscoveryService> _logger;
+    private readonly HttpMessageHandler? _httpMessageHandler;
 
     public GitHubReleaseDiscoveryService(
         IOptionsMonitor<ApiSettings> apiSettings,
-        IHttpClientFactory httpClientFactory,
         IMemoryCache memoryCache,
         IVersionHelper versionHelper,
         ILogger<GitHubReleaseDiscoveryService> logger)
+        : this(apiSettings, memoryCache, versionHelper, logger, httpMessageHandler: null)
+    {
+    }
+
+    // Used by unit tests to inject a mock handler without sharing IHttpClientFactory clients.
+    internal GitHubReleaseDiscoveryService(
+        IOptionsMonitor<ApiSettings> apiSettings,
+        IMemoryCache memoryCache,
+        IVersionHelper versionHelper,
+        ILogger<GitHubReleaseDiscoveryService> logger,
+        HttpMessageHandler? httpMessageHandler)
     {
         _apiSettings = apiSettings;
-        _httpClientFactory = httpClientFactory;
         _memoryCache = memoryCache;
         _versionHelper = versionHelper;
         _logger = logger;
+        _httpMessageHandler = httpMessageHandler;
     }
 
     public Task<ReleaseHighlightCatalogItemDataContract?> GetNewestAvailableReleaseHighlight()
@@ -52,114 +62,117 @@ public partial class GitHubReleaseDiscoveryService : IFigReleaseDiscoveryService
 
     public async Task RefreshAsync()
     {
-        var result = await FetchNewestAvailableReleaseHighlight();
+        var (completed, result) = await TryFetchNewestAvailableReleaseHighlight();
+        if (!completed)
+        {
+            // Transient failure: keep any existing highlight and extend its TTL.
+            if (_memoryCache.TryGetValue(CacheKey, out ReleaseHighlightCatalogItemDataContract? existing) && existing != null)
+                _memoryCache.Set(CacheKey, existing, CacheDuration);
+            return;
+        }
+
         _memoryCache.Set(CacheKey, result, CacheDuration);
     }
 
-    private async Task<ReleaseHighlightCatalogItemDataContract?> FetchNewestAvailableReleaseHighlight()
+    private async Task<(bool Completed, ReleaseHighlightCatalogItemDataContract? Highlight)> TryFetchNewestAvailableReleaseHighlight()
     {
         if (!TryParseNormalizedVersion(_versionHelper.GetVersion(), out var currentVersion, out var currentVersionText))
         {
             _logger.LogWarning("Skipping GitHub release discovery because the current API version could not be parsed");
-            return null;
+            return (true, null);
         }
 
         try
         {
-            var clientLease = CreateClient();
-            try
+            using var client = CreateClient();
+            using var request = new HttpRequestMessage(HttpMethod.Get, LatestReleaseUrl);
+            request.Headers.UserAgent.Add(new ProductInfoHeaderValue("Fig.Api", "1.0"));
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
+
+            using var response = await client.SendAsync(request);
+            if (!response.IsSuccessStatusCode)
             {
-                using var request = new HttpRequestMessage(HttpMethod.Get, LatestReleaseUrl);
-                request.Headers.UserAgent.Add(new ProductInfoHeaderValue("Fig.Api", "1.0"));
-                request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
-
-                using var response = await clientLease.Client.SendAsync(request);
-                if (!response.IsSuccessStatusCode)
-                {
-                    _logger.LogWarning("GitHub release discovery returned status code {StatusCode}", response.StatusCode);
-                    return null;
-                }
-
-                var json = await response.Content.ReadAsStringAsync();
-                var release = JsonConvert.DeserializeObject<GitHubReleaseResponse>(json, GitHubJsonSettings);
-                if (release == null || string.IsNullOrWhiteSpace(release.TagName))
-                    return null;
-
-                if (!TryParseNormalizedVersion(release.TagName, out var releaseVersion, out var releaseVersionText))
-                    return null;
-
-                if (releaseVersion <= currentVersion)
-                    return null;
-
-                var releaseUrl = string.IsNullOrWhiteSpace(release.HtmlUrl)
-                    ? $"https://github.com/mzbrau/fig/releases/tag/{release.TagName.Trim()}"
-                    : release.HtmlUrl;
-
-                return new ReleaseHighlightCatalogItemDataContract(
-                    releaseVersionText,
-                    ReleaseFeatureKey,
-                    $"Fig v{releaseVersionText} is available",
-                    $"A newer Fig release is available. You're currently running Fig v{currentVersionText}. Review the release notes for v{releaseVersionText}.",
-                    PlaceholderImagePath,
-                    int.MaxValue,
-                    releaseUrl,
-                    markViewedOnDisplay: false);
+                _logger.LogWarning("GitHub release discovery returned status code {StatusCode}", response.StatusCode);
+                return (false, null);
             }
-            finally
-            {
-                if (clientLease.DisposeClient)
-                    clientLease.Client.Dispose();
-            }
+
+            var json = await response.Content.ReadAsStringAsync();
+            var release = JsonConvert.DeserializeObject<GitHubReleaseResponse>(json, GitHubJsonSettings);
+            if (release == null || string.IsNullOrWhiteSpace(release.TagName))
+                return (true, null);
+
+            if (!TryParseNormalizedVersion(release.TagName, out var releaseVersion, out var releaseVersionText))
+                return (true, null);
+
+            if (releaseVersion <= currentVersion)
+                return (true, null);
+
+            var releaseUrl = string.IsNullOrWhiteSpace(release.HtmlUrl)
+                ? $"https://github.com/mzbrau/fig/releases/tag/{release.TagName.Trim()}"
+                : release.HtmlUrl;
+
+            return (true, new ReleaseHighlightCatalogItemDataContract(
+                releaseVersionText,
+                ReleaseFeatureKey,
+                $"Fig v{releaseVersionText} is available",
+                $"A newer Fig release is available. You're currently running Fig v{currentVersionText}. Review the release notes for v{releaseVersionText}.",
+                PlaceholderImagePath,
+                int.MaxValue,
+                releaseUrl,
+                markViewedOnDisplay: false));
         }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to discover newer Fig releases from GitHub");
-            return null;
+            return (false, null);
         }
     }
 
-    private HttpClientLease CreateClient()
+    private HttpClient CreateClient()
     {
         var proxyAddress = _apiSettings.CurrentValue.GetOutboundHttpProxyAddress();
-        if (string.IsNullOrWhiteSpace(proxyAddress))
+        if (!string.IsNullOrWhiteSpace(proxyAddress) &&
+            Uri.TryCreate(proxyAddress, UriKind.Absolute, out var proxyUri))
         {
-            _logger.LogDebug("Using host default proxy resolution for GitHub release discovery.");
-            return new HttpClientLease(CreateDefaultClient(), DisposeClient: false);
+            _logger.LogInformation("Using outbound proxy {ProxyAddress} for GitHub release discovery.", proxyUri);
+
+            var proxy = new WebProxy(proxyUri)
+            {
+                Credentials = CredentialCache.DefaultCredentials
+            };
+
+            var handler = new HttpClientHandler
+            {
+                UseProxy = true,
+                Proxy = proxy,
+                DefaultProxyCredentials = CredentialCache.DefaultCredentials
+            };
+
+            return new HttpClient(handler, disposeHandler: true)
+            {
+                Timeout = TimeSpan.FromSeconds(5)
+            };
         }
 
-        if (!Uri.TryCreate(proxyAddress, UriKind.Absolute, out var proxyUri))
-        {
+        if (!string.IsNullOrWhiteSpace(proxyAddress))
             _logger.LogWarning("Ignoring invalid outbound proxy address '{ProxyAddress}' for GitHub release discovery.", proxyAddress);
-            return new HttpClientLease(CreateDefaultClient(), DisposeClient: false);
+        else
+            _logger.LogDebug("Using host default proxy resolution for GitHub release discovery.");
+
+        // Always use a dedicated client so discovery never mutates shared IHttpClientFactory instances
+        // (integration tests replace the factory with a single shared WebHookClient).
+        if (_httpMessageHandler != null)
+        {
+            return new HttpClient(_httpMessageHandler, disposeHandler: false)
+            {
+                Timeout = TimeSpan.FromSeconds(5)
+            };
         }
 
-        _logger.LogInformation("Using outbound proxy {ProxyAddress} for GitHub release discovery.", proxyUri);
-
-        var proxy = new WebProxy(proxyUri)
-        {
-            Credentials = CredentialCache.DefaultCredentials
-        };
-
-        var handler = new HttpClientHandler
-        {
-            UseProxy = true,
-            Proxy = proxy,
-            DefaultProxyCredentials = CredentialCache.DefaultCredentials
-        };
-
-        return new HttpClientLease(new HttpClient(handler, disposeHandler: true)
+        return new HttpClient
         {
             Timeout = TimeSpan.FromSeconds(5)
-        }, DisposeClient: true);
-    }
-
-    private HttpClient CreateDefaultClient()
-    {
-        var client = _httpClientFactory.CreateClient();
-        if (client.Timeout > TimeSpan.FromSeconds(5))
-            client.Timeout = TimeSpan.FromSeconds(5);
-
-        return client;
+        };
     }
 
     private static bool TryParseNormalizedVersion(string versionText, out Version normalizedVersion, out string releaseVersion)
@@ -181,8 +194,6 @@ public partial class GitHubReleaseDiscoveryService : IFigReleaseDiscoveryService
     {
         return new Version(version.Major, version.Minor, Math.Max(version.Build, 0), Math.Max(version.Revision, 0));
     }
-
-    private sealed record HttpClientLease(HttpClient Client, bool DisposeClient);
 
     private sealed class GitHubReleaseResponse
     {

--- a/src/api/Fig.Api/Services/IFigReleaseDiscoveryService.cs
+++ b/src/api/Fig.Api/Services/IFigReleaseDiscoveryService.cs
@@ -4,5 +4,14 @@ namespace Fig.Api.Services;
 
 public interface IFigReleaseDiscoveryService
 {
+    /// <summary>
+    /// Returns the cached newest available release highlight, or null if the cache is cold or no newer release exists.
+    /// Does not perform network I/O.
+    /// </summary>
     Task<ReleaseHighlightCatalogItemDataContract?> GetNewestAvailableReleaseHighlight();
+
+    /// <summary>
+    /// Fetches the newest Fig release from GitHub and updates the in-memory cache.
+    /// </summary>
+    Task RefreshAsync();
 }

--- a/src/api/Fig.Api/Services/ReleaseHighlightsService.cs
+++ b/src/api/Fig.Api/Services/ReleaseHighlightsService.cs
@@ -30,7 +30,7 @@ public class ReleaseHighlightsService : AuthenticatedService, IReleaseHighlights
         var views = await _releaseHighlightViewRepository.GetViews(userId);
         var availableHighlights = new List<ReleaseHighlightCatalogItemDataContract>();
         var newestAvailableRelease = await _figReleaseDiscoveryService.GetNewestAvailableReleaseHighlight();
-        if (newestAvailableRelease != null)
+        if (newestAvailableRelease != null && !HasViewed(views, newestAvailableRelease))
             availableHighlights.Add(newestAvailableRelease);
 
         return new ReleaseHighlightProgressDataContract(views.Select(Convert).ToList(), availableHighlights);
@@ -87,6 +87,15 @@ public class ReleaseHighlightsService : AuthenticatedService, IReleaseHighlights
             throw new UnauthorizedAccessException("Only administrators can access release highlights.");
 
         return AuthenticatedUser.Id;
+    }
+
+    private static bool HasViewed(
+        IEnumerable<ReleaseHighlightViewBusinessEntity> views,
+        ReleaseHighlightCatalogItemDataContract highlight)
+    {
+        return views.Any(view =>
+            string.Equals(view.ReleaseVersion, highlight.ReleaseVersion, StringComparison.OrdinalIgnoreCase) &&
+            string.Equals(view.FeatureKey, highlight.FeatureKey, StringComparison.OrdinalIgnoreCase));
     }
 
     private static ReleaseHighlightViewDataContract Convert(ReleaseHighlightViewBusinessEntity entity)

--- a/src/api/Fig.Api/Workers/ReleaseDiscoveryWorker.cs
+++ b/src/api/Fig.Api/Workers/ReleaseDiscoveryWorker.cs
@@ -1,5 +1,6 @@
 using Fig.Api.Services;
 using Fig.Common.Timer;
+using Microsoft.Extensions.Options;
 
 namespace Fig.Api.Workers;
 
@@ -11,21 +12,30 @@ public class ReleaseDiscoveryWorker : BackgroundService
     private static readonly TimeSpan RefreshInterval = TimeSpan.FromHours(24);
 
     private readonly ILogger<ReleaseDiscoveryWorker> _logger;
+    private readonly IOptionsMonitor<ApiSettings> _settings;
     private readonly IServiceScopeFactory _serviceScopeFactory;
     private readonly IPeriodicTimer _timer;
 
     public ReleaseDiscoveryWorker(
         ILogger<ReleaseDiscoveryWorker> logger,
+        IOptionsMonitor<ApiSettings> settings,
         ITimerFactory timerFactory,
         IServiceScopeFactory serviceScopeFactory)
     {
         _logger = logger;
+        _settings = settings;
         _serviceScopeFactory = serviceScopeFactory;
         _timer = timerFactory.Create(RefreshInterval);
     }
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
+        if (!_settings.CurrentValue.EnableGitHubReleaseDiscovery)
+        {
+            _logger.LogInformation("Release discovery worker is disabled because EnableGitHubReleaseDiscovery is false");
+            return;
+        }
+
         _logger.LogInformation("Release discovery worker starting");
 
         await RefreshDiscovery();

--- a/src/api/Fig.Api/Workers/ReleaseDiscoveryWorker.cs
+++ b/src/api/Fig.Api/Workers/ReleaseDiscoveryWorker.cs
@@ -1,0 +1,54 @@
+using Fig.Api.Services;
+using Fig.Common.Timer;
+
+namespace Fig.Api.Workers;
+
+/// <summary>
+/// Keeps the newest Fig release highlight cache warm so GET /releasehighlights never blocks on GitHub.
+/// </summary>
+public class ReleaseDiscoveryWorker : BackgroundService
+{
+    private static readonly TimeSpan RefreshInterval = TimeSpan.FromHours(1);
+
+    private readonly ILogger<ReleaseDiscoveryWorker> _logger;
+    private readonly IServiceScopeFactory _serviceScopeFactory;
+    private readonly IPeriodicTimer _timer;
+
+    public ReleaseDiscoveryWorker(
+        ILogger<ReleaseDiscoveryWorker> logger,
+        ITimerFactory timerFactory,
+        IServiceScopeFactory serviceScopeFactory)
+    {
+        _logger = logger;
+        _serviceScopeFactory = serviceScopeFactory;
+        _timer = timerFactory.Create(RefreshInterval);
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("Release discovery worker starting");
+
+        await RefreshDiscovery();
+
+        while (await _timer.WaitForNextTickAsync(stoppingToken) && !stoppingToken.IsCancellationRequested)
+        {
+            await RefreshDiscovery();
+        }
+    }
+
+    private async Task RefreshDiscovery()
+    {
+        using var scope = _serviceScopeFactory.CreateScope();
+
+        try
+        {
+            var discoveryService = scope.ServiceProvider.GetRequiredService<IFigReleaseDiscoveryService>();
+            await discoveryService.RefreshAsync();
+            _logger.LogDebug("Release discovery cache refreshed");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error refreshing GitHub release discovery cache");
+        }
+    }
+}

--- a/src/api/Fig.Api/Workers/ReleaseDiscoveryWorker.cs
+++ b/src/api/Fig.Api/Workers/ReleaseDiscoveryWorker.cs
@@ -8,7 +8,7 @@ namespace Fig.Api.Workers;
 /// </summary>
 public class ReleaseDiscoveryWorker : BackgroundService
 {
-    private static readonly TimeSpan RefreshInterval = TimeSpan.FromHours(1);
+    private static readonly TimeSpan RefreshInterval = TimeSpan.FromHours(24);
 
     private readonly ILogger<ReleaseDiscoveryWorker> _logger;
     private readonly IServiceScopeFactory _serviceScopeFactory;
@@ -34,6 +34,12 @@ public class ReleaseDiscoveryWorker : BackgroundService
         {
             await RefreshDiscovery();
         }
+    }
+
+    public override void Dispose()
+    {
+        _timer.Dispose();
+        base.Dispose();
     }
 
     private async Task RefreshDiscovery()

--- a/src/api/Fig.Api/appsettings.json
+++ b/src/api/Fig.Api/appsettings.json
@@ -16,6 +16,7 @@
     "TimeMachineCheckIntervalMs": 3600000,
     "ImportFolderPath": "",
     "OutboundHttpProxyAddress": "",
+    "EnableGitHubReleaseDiscovery": true,
     "HashCacheExpiryMinutes": 60,
     "TrustForwardedHeaders": false,
     "KnownProxies": [

--- a/src/tests/Fig.Integration.Test/Api/WebHookIntegrationTests.cs
+++ b/src/tests/Fig.Integration.Test/Api/WebHookIntegrationTests.cs
@@ -92,6 +92,7 @@ public class WebHookIntegrationTests : IntegrationTestBase
     }
     
     [Test]
+    [Retry(3)]
     public async Task ShallSendClientStatusChangedWebHookWhenDisconnected()
     {
         var testStart = DateTime.UtcNow;
@@ -105,6 +106,9 @@ public class WebHookIntegrationTests : IntegrationTestBase
 
         var clientStatus = CreateStatusRequest(FiveHundredMillisecondsAgo(), DateTime.UtcNow, 10, true);
         await GetStatus("ThreeSettings", secret, clientStatus);
+
+        // Wait for Connected webhook delivery so webhook DB work finishes before session cleanup.
+        await WaitForCondition(async () => (await GetWebHookMessages(testStart)).Count() == 1, TimeSpan.FromSeconds(1));
 
         // Wait for session to expire (pollInterval=10ms, grace period=2*10+50=70ms)
         await Task.Delay(100);
@@ -302,10 +306,13 @@ public class WebHookIntegrationTests : IntegrationTestBase
         var secret = GetNewSecret();
         await RegisterSettings<ClientA>(secret);
 
+        await WaitForCondition(async () => (await GetWebHookMessages(testStart)).Count() == 1, TimeSpan.FromSeconds(1));
+
         // Second, unchanged registration
         await RegisterSettings<ClientA>(secret);
 
-        await Task.Delay(50);
+        // Allow time for a second webhook to arrive if one were incorrectly queued.
+        await Task.Delay(500);
 
         var webHookMessages = (await GetWebHookMessages(testStart)).ToList();
         

--- a/src/tests/Fig.Test.Common/IntegrationTestBase.cs
+++ b/src/tests/Fig.Test.Common/IntegrationTestBase.cs
@@ -83,6 +83,7 @@ public abstract class IntegrationTestBase
         Settings.TokenLifeMinutes = 60;
         Settings.SchedulingCheckIntervalMs = 547;
         Settings.TimeMachineCheckIntervalMs = 1002;
+        Settings.EnableGitHubReleaseDiscovery = false;
         Settings.ImportFolderPath = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
             "Fig",
@@ -120,6 +121,7 @@ public abstract class IntegrationTestBase
                 {
                     opts.SchedulingCheckIntervalMs = Settings.SchedulingCheckIntervalMs;
                     opts.TimeMachineCheckIntervalMs = Settings.TimeMachineCheckIntervalMs;
+                    opts.EnableGitHubReleaseDiscovery = Settings.EnableGitHubReleaseDiscovery;
                 });
             });
         });

--- a/src/tests/Fig.Unit.Test/Api/GitHubReleaseDiscoveryServiceTests.cs
+++ b/src/tests/Fig.Unit.Test/Api/GitHubReleaseDiscoveryServiceTests.cs
@@ -17,38 +17,37 @@ namespace Fig.Unit.Test.Api;
 [TestFixture]
 public class GitHubReleaseDiscoveryServiceTests
 {
-    private Mock<IHttpClientFactory> _httpClientFactory = null!;
     private Mock<IOptionsMonitor<ApiSettings>> _apiSettings = null!;
     private Mock<IVersionHelper> _versionHelper = null!;
     private Mock<ILogger<GitHubReleaseDiscoveryService>> _logger = null!;
     private Mock<HttpMessageHandler> _httpMessageHandler = null!;
-    private HttpClient _httpClient = null!;
     private IMemoryCache _memoryCache = null!;
     private GitHubReleaseDiscoveryService _sut = null!;
 
     [SetUp]
     public void SetUp()
     {
-        _httpClientFactory = new Mock<IHttpClientFactory>();
         _apiSettings = new Mock<IOptionsMonitor<ApiSettings>>();
         _versionHelper = new Mock<IVersionHelper>();
         _logger = new Mock<ILogger<GitHubReleaseDiscoveryService>>();
         _httpMessageHandler = new Mock<HttpMessageHandler>();
-        _httpClient = new HttpClient(_httpMessageHandler.Object);
         _memoryCache = new MemoryCache(new MemoryCacheOptions());
 
         _apiSettings.SetupGet(x => x.CurrentValue).Returns(new ApiSettings
         {
             DbConnectionString = "Data Source=fig.db;Version=3;New=True"
         });
-        _httpClientFactory.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(_httpClient);
-        _sut = new GitHubReleaseDiscoveryService(_apiSettings.Object, _httpClientFactory.Object, _memoryCache, _versionHelper.Object, _logger.Object);
+        _sut = new GitHubReleaseDiscoveryService(
+            _apiSettings.Object,
+            _memoryCache,
+            _versionHelper.Object,
+            _logger.Object,
+            _httpMessageHandler.Object);
     }
 
     [TearDown]
     public void TearDown()
     {
-        _httpClient.Dispose();
         _memoryCache.Dispose();
     }
 
@@ -154,6 +153,36 @@ public class GitHubReleaseDiscoveryServiceTests
                 Times.Once(),
                 ItExpr.IsAny<HttpRequestMessage>(),
                 ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Test]
+    public async Task ShallKeepExistingCachedHighlightWhenRefreshFails()
+    {
+        _versionHelper.Setup(x => x.GetVersion()).Returns("3.5.0.0");
+        SetupResponse("""
+            {
+              "tag_name": "v3.5.1",
+              "html_url": "https://github.com/mzbrau/fig/releases/tag/v3.5.1"
+            }
+            """);
+
+        await _sut.RefreshAsync();
+        var cached = await _sut.GetNewestAvailableReleaseHighlight();
+        Assert.That(cached, Is.Not.Null);
+
+        _httpMessageHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
+
+        await _sut.RefreshAsync();
+        var result = await _sut.GetNewestAvailableReleaseHighlight();
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.ReleaseVersion, Is.EqualTo("3.5.1"));
+        Assert.That(result.FeatureKey, Is.EqualTo("new-release-available"));
     }
 
     private void SetupResponse(string json)

--- a/src/tests/Fig.Unit.Test/Api/GitHubReleaseDiscoveryServiceTests.cs
+++ b/src/tests/Fig.Unit.Test/Api/GitHubReleaseDiscoveryServiceTests.cs
@@ -53,19 +53,33 @@ public class GitHubReleaseDiscoveryServiceTests
     }
 
     [Test]
-    public async Task ShallReturnNewestAvailableReleaseWhenGitHubContainsNewerVersion()
+    public async Task ShallReturnNullFromCacheWhenCacheIsCold()
+    {
+        _versionHelper.Setup(x => x.GetVersion()).Returns("3.5.0.0");
+
+        var result = await _sut.GetNewestAvailableReleaseHighlight();
+
+        Assert.That(result, Is.Null);
+        _httpMessageHandler.Protected()
+            .Verify<Task<HttpResponseMessage>>(
+                "SendAsync",
+                Times.Never(),
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Test]
+    public async Task ShallReturnNewestAvailableReleaseAfterRefreshWhenGitHubContainsNewerVersion()
     {
         _versionHelper.Setup(x => x.GetVersion()).Returns("3.5.0.0");
         SetupResponse("""
-            <html>
-              <body>
-                <a href="/mzbrau/fig/releases/tag/v3.5.1">v3.5.1</a>
-                <a href="/mzbrau/fig/releases/tag/v3.4.3">v3.4.3</a>
-                <a href="/mzbrau/fig/releases/tag/v3.5.0">v3.5.0</a>
-              </body>
-            </html>
+            {
+              "tag_name": "v3.5.1",
+              "html_url": "https://github.com/mzbrau/fig/releases/tag/v3.5.1"
+            }
             """);
 
+        await _sut.RefreshAsync();
         var result = await _sut.GetNewestAvailableReleaseHighlight();
 
         Assert.That(result, Is.Not.Null);
@@ -79,25 +93,24 @@ public class GitHubReleaseDiscoveryServiceTests
     }
 
     [Test]
-    public async Task ShallReturnNullWhenCurrentVersionAlreadyMatchesNewestRelease()
+    public async Task ShallReturnNullAfterRefreshWhenCurrentVersionAlreadyMatchesNewestRelease()
     {
         _versionHelper.Setup(x => x.GetVersion()).Returns("3.5.1.0");
         SetupResponse("""
-            <html>
-              <body>
-                <a href="/mzbrau/fig/releases/tag/v3.5.1">v3.5.1</a>
-                <a href="/mzbrau/fig/releases/tag/v3.5.0">v3.5.0</a>
-              </body>
-            </html>
+            {
+              "tag_name": "v3.5.1",
+              "html_url": "https://github.com/mzbrau/fig/releases/tag/v3.5.1"
+            }
             """);
 
+        await _sut.RefreshAsync();
         var result = await _sut.GetNewestAvailableReleaseHighlight();
 
         Assert.That(result, Is.Null);
     }
 
     [Test]
-    public async Task ShallReturnNullWhenGitHubRequestFails()
+    public async Task ShallReturnNullAfterRefreshWhenGitHubRequestFails()
     {
         _versionHelper.Setup(x => x.GetVersion()).Returns("3.5.0.0");
         _httpMessageHandler.Protected()
@@ -107,12 +120,43 @@ public class GitHubReleaseDiscoveryServiceTests
                 ItExpr.IsAny<CancellationToken>())
             .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.ServiceUnavailable));
 
+        await _sut.RefreshAsync();
         var result = await _sut.GetNewestAvailableReleaseHighlight();
 
         Assert.That(result, Is.Null);
     }
 
-    private void SetupResponse(string html)
+    [Test]
+    public async Task ShallNotCallGitHubOnGetAfterCacheIsWarm()
+    {
+        _versionHelper.Setup(x => x.GetVersion()).Returns("3.5.0.0");
+        SetupResponse("""
+            {
+              "tag_name": "v3.5.1",
+              "html_url": "https://github.com/mzbrau/fig/releases/tag/v3.5.1"
+            }
+            """);
+
+        await _sut.RefreshAsync();
+        _httpMessageHandler.Protected()
+            .Verify<Task<HttpResponseMessage>>(
+                "SendAsync",
+                Times.Once(),
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>());
+
+        var result = await _sut.GetNewestAvailableReleaseHighlight();
+
+        Assert.That(result, Is.Not.Null);
+        _httpMessageHandler.Protected()
+            .Verify<Task<HttpResponseMessage>>(
+                "SendAsync",
+                Times.Once(),
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>());
+    }
+
+    private void SetupResponse(string json)
     {
         _httpMessageHandler.Protected()
             .Setup<Task<HttpResponseMessage>>(
@@ -121,7 +165,7 @@ public class GitHubReleaseDiscoveryServiceTests
                 ItExpr.IsAny<CancellationToken>())
             .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
             {
-                Content = new StringContent(html)
+                Content = new StringContent(json)
             });
     }
 }

--- a/src/tests/Fig.Unit.Test/Api/GitHubReleaseDiscoveryServiceTests.cs
+++ b/src/tests/Fig.Unit.Test/Api/GitHubReleaseDiscoveryServiceTests.cs
@@ -35,7 +35,8 @@ public class GitHubReleaseDiscoveryServiceTests
 
         _apiSettings.SetupGet(x => x.CurrentValue).Returns(new ApiSettings
         {
-            DbConnectionString = "Data Source=fig.db;Version=3;New=True"
+            DbConnectionString = "Data Source=fig.db;Version=3;New=True",
+            EnableGitHubReleaseDiscovery = true
         });
         _sut = new GitHubReleaseDiscoveryService(
             _apiSettings.Object,
@@ -183,6 +184,34 @@ public class GitHubReleaseDiscoveryServiceTests
         Assert.That(result, Is.Not.Null);
         Assert.That(result!.ReleaseVersion, Is.EqualTo("3.5.1"));
         Assert.That(result.FeatureKey, Is.EqualTo("new-release-available"));
+    }
+
+    [Test]
+    public async Task ShallNotCallGitHubWhenReleaseDiscoveryIsDisabled()
+    {
+        _apiSettings.SetupGet(x => x.CurrentValue).Returns(new ApiSettings
+        {
+            DbConnectionString = "Data Source=fig.db;Version=3;New=True",
+            EnableGitHubReleaseDiscovery = false
+        });
+        _versionHelper.Setup(x => x.GetVersion()).Returns("3.5.0.0");
+        SetupResponse("""
+            {
+              "tag_name": "v3.5.1",
+              "html_url": "https://github.com/mzbrau/fig/releases/tag/v3.5.1"
+            }
+            """);
+
+        await _sut.RefreshAsync();
+        var result = await _sut.GetNewestAvailableReleaseHighlight();
+
+        Assert.That(result, Is.Null);
+        _httpMessageHandler.Protected()
+            .Verify<Task<HttpResponseMessage>>(
+                "SendAsync",
+                Times.Never(),
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>());
     }
 
     private void SetupResponse(string json)

--- a/src/tests/Fig.Unit.Test/Api/ReleaseHighlightsServiceTests.cs
+++ b/src/tests/Fig.Unit.Test/Api/ReleaseHighlightsServiceTests.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Fig.Api.Datalayer.Repositories;
+using Fig.Api.Services;
+using Fig.Client.Abstractions.Data;
+using Fig.Contracts.Authentication;
+using Fig.Contracts.ReleaseHighlights;
+using Fig.Datalayer.BusinessEntities;
+using Moq;
+using NUnit.Framework;
+using ISession = NHibernate.ISession;
+
+namespace Fig.Unit.Test.Api;
+
+[TestFixture]
+public class ReleaseHighlightsServiceTests
+{
+    private Mock<IFigReleaseDiscoveryService> _discoveryService = null!;
+    private Mock<IReleaseHighlightViewRepository> _viewRepository = null!;
+    private Mock<ISession> _session = null!;
+    private ReleaseHighlightsService _sut = null!;
+    private Guid _userId;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _discoveryService = new Mock<IFigReleaseDiscoveryService>();
+        _viewRepository = new Mock<IReleaseHighlightViewRepository>();
+        _session = new Mock<ISession>();
+        _userId = Guid.NewGuid();
+
+        _sut = new ReleaseHighlightsService(_discoveryService.Object, _viewRepository.Object, _session.Object);
+        _sut.SetAuthenticatedUser(new UserDataContract(
+            _userId,
+            "admin",
+            "Admin",
+            "User",
+            Role.Administrator,
+            "*",
+            new List<Classification>()));
+    }
+
+    [Test]
+    public async Task ShallIncludeAvailableHighlightWhenNotYetViewed()
+    {
+        _viewRepository.Setup(x => x.GetViews(_userId))
+            .ReturnsAsync(new List<ReleaseHighlightViewBusinessEntity>());
+        _discoveryService.Setup(x => x.GetNewestAvailableReleaseHighlight())
+            .ReturnsAsync(CreateAvailableHighlight("3.7.0"));
+
+        var progress = await _sut.GetProgress();
+
+        Assert.That(progress.AvailableHighlights.Count, Is.EqualTo(1));
+        Assert.That(progress.AvailableHighlights[0].ReleaseVersion, Is.EqualTo("3.7.0"));
+        Assert.That(progress.AvailableHighlights[0].FeatureKey, Is.EqualTo("new-release-available"));
+    }
+
+    [Test]
+    public async Task ShallOmitAvailableHighlightWhenAlreadyViewed()
+    {
+        _viewRepository.Setup(x => x.GetViews(_userId))
+            .ReturnsAsync(new List<ReleaseHighlightViewBusinessEntity>
+            {
+                new()
+                {
+                    UserId = _userId,
+                    ReleaseVersion = "3.7.0",
+                    FeatureKey = "new-release-available",
+                    ViewedAtUtc = DateTime.UtcNow
+                }
+            });
+        _discoveryService.Setup(x => x.GetNewestAvailableReleaseHighlight())
+            .ReturnsAsync(CreateAvailableHighlight("3.7.0"));
+
+        var progress = await _sut.GetProgress();
+
+        Assert.That(progress.AvailableHighlights, Is.Empty);
+        Assert.That(progress.ViewedHighlights.Count, Is.EqualTo(1));
+    }
+
+    [Test]
+    public async Task ShallReturnEmptyAvailableHighlightsWhenCacheIsCold()
+    {
+        _viewRepository.Setup(x => x.GetViews(_userId))
+            .ReturnsAsync(new List<ReleaseHighlightViewBusinessEntity>());
+        _discoveryService.Setup(x => x.GetNewestAvailableReleaseHighlight())
+            .ReturnsAsync((ReleaseHighlightCatalogItemDataContract?)null);
+
+        var progress = await _sut.GetProgress();
+
+        Assert.That(progress.AvailableHighlights, Is.Empty);
+        Assert.That(progress.ViewedHighlights, Is.Empty);
+    }
+
+    private static ReleaseHighlightCatalogItemDataContract CreateAvailableHighlight(string releaseVersion)
+    {
+        return new ReleaseHighlightCatalogItemDataContract(
+            releaseVersion,
+            "new-release-available",
+            $"Fig v{releaseVersion} is available",
+            "A newer Fig release is available.",
+            "images/release-highlights/shared/new-release.png",
+            int.MaxValue,
+            $"https://github.com/mzbrau/fig/releases/tag/v{releaseVersion}",
+            markViewedOnDisplay: false);
+    }
+}


### PR DESCRIPTION
…ub on every request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic discovery of new releases from GitHub, refreshed periodically in the background.
  * Added a configuration option to disable GitHub release discovery and outbound GitHub requests.
  * Release highlight checks now use cached results to avoid delaying requests.

* **Bug Fixes**
  * Prevented previously viewed release highlights from appearing again.
  * Improved handling of temporary discovery failures while preserving cached results.

* **Documentation**
  * Documented the new release discovery setting and its default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->